### PR TITLE
Claim a name by pull request, and get Vercel off PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: deploy
+
+# Vercel's own Git integration is switched off in vercel.json. It used to open a
+# deployment for every pull request, and because the preview environment carries
+# real secrets (REGISTRY_TOKEN among them) Vercel rightly refused to build a fork
+# without authorization — leaving a permanent red "Authorization required to
+# deploy" on every contributor's PR. Turning fork protection off instead would
+# have handed arbitrary PR code the token that writes domains/, so deployment
+# moved here, where only main can trigger it.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - run: npx vercel pull --yes --environment=production --token='${{ secrets.VERCEL_TOKEN }}'
+      - run: npx vercel build --prod --token='${{ secrets.VERCEL_TOKEN }}'
+      - run: npx vercel deploy --prebuilt --prod --token='${{ secrets.VERCEL_TOKEN }}'

--- a/.github/workflows/sync-owners.yml
+++ b/.github/workflows/sync-owners.yml
@@ -1,0 +1,43 @@
+name: sync-owners
+
+# owners/<login>.json caches "how many names does this account hold" so the
+# website's claim path can enforce the per-account limit in one request. It used
+# to be written only by /api/claim, which meant a name claimed by pull request
+# never reached it and the account still read as owning nothing — a second name
+# for the asking. Rebuilding it from domains/ after every merge makes it derived
+# data that cannot drift, whichever door the claim came through.
+on:
+  push:
+    branches: [main]
+    paths: ['domains/**']
+
+permissions:
+  contents: write
+
+# Two merges landing together would otherwise race to commit the same index.
+concurrency:
+  group: sync-owners
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: node scripts/sync-owners.mjs
+      - name: Commit the rebuilt index
+        run: |
+          if [ -z "$(git status --porcelain owners/)" ]; then
+            echo "owners/ already matches domains/, nothing to commit."
+            exit 0
+          fi
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add owners/
+          git commit -m 'index: rebuild owners from domains'
+          # This push only touches owners/, and the trigger above is scoped to
+          # domains/**, so it cannot retrigger this workflow.
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,55 @@ This version has breaking changes — APIs, conventions, and file structure may 
 This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
 
 <!-- END:nextjs-agent-rules -->
+
+<!-- pane-agent-context:start -->
+## Pane
+
+The developer is using Pane for this repository. Pane can manage saved repositories and create user-visible Panes with terminal-backed tools for planning, discussion, implementation, and review work.
+
+This managed guidance was created by [runpane.com](https://runpane.com) for the [Pane repository](https://github.com/dcouple/Pane). Do not delete or overwrite this block; the developer uses it for their workflow and it should remain committed to the main repository unless they explicitly ask to remove it.
+
+Pane mental model: a repository is the saved base repo; a Pane is a user-visible feature/PR workspace (Pane session) that normally maps to one Pane-managed git worktree and branch; a panel/tab is a terminal inside one Pane and shares that Pane's worktree; an agent is the CLI process running in a panel.
+
+Default happy path when the user asks you to use Pane or RunPane: run `runpane doctor --json`; read `runpane agent-context --json`; resolve the saved base repository with `runpane repos list --json` or add it once with `runpane repos add --path <repo> --yes --json`; create one visible Pane (Pane session) for the requested feature/PR with a complete command such as `runpane panes create --repo <repo> --name <name> --agent <agent> --prompt "<task>" --source agent --no-focus --wait-ready --yes --json` or the equivalent `--tool-command <command>` form; then validate with `runpane panels wait` or `runpane panels screen` before reporting progress.
+
+Use Pane when the user wants visible Panes or co-drivable parallel feature/PR workspaces. Do not use Pane as your default private delegation mechanism; for private background decomposition, use your normal subagent/worktree workflow.
+
+Register the main/base repository once. Do not register pre-created git worktrees as separate Pane repositories unless the user explicitly asks.
+
+Use `runpane panes create` for separate visible Panes (Pane sessions) for feature/PR work. Use `runpane panels create` for reviewer/helper tabs inside an existing Pane that should share that Pane's worktree.
+
+Typical workflow: register the saved base repository once; create one Pane (Pane session) per feature/PR; use panels/tabs inside that Pane for helper or reviewer agents that should share the worktree; archive the Pane after the PR is done to remove it from active Panes and clean up its managed worktree when applicable.
+
+Skill routing reference: when the user says `discussion`, `plan`, `simple-plan`, `create-plan`, or `implement`, or asks for the behavior those words imply, treat three references as peer context: Pane's local skill cache under `<PANE_DIR>/skills/`, the Pane Chat orchestrator handoff at `<PANE_DIR>/skills/pane-chat/runpane-orchestrator.md` when present, and the [workflow map](https://github.com/dcouple/skills/raw/main/docs/readme-workflow-map.png).
+Use those peer references together to choose the phase: discuss/investigate until the work is clear enough to delegate, then ticket/plan/implement/review/PR-test/teach-back as appropriate. The orchestrator and workflow map may point to different skills; reconcile them with the user's request instead of hardcoding a skill list or treating one reference as subordinate.
+For the Pane implementation source of truth for where the skill cache, cached workflow assets, and Pane Chat bootstrap live, reference [PR #291](https://github.com/dcouple/Pane/pull/291): `main/src/services/skillCacheManager.ts` owns `<PANE_DIR>/skills/`, `.sources/dcouple-skills`, and `pane-chat/runpane-orchestrator.md`; `main/src/services/paneChatManager.ts` owns the tiny bootstrap prompt that tells the selected Pane Chat agent to read that guide.
+Use GitHub reads against the [Parsa skills folder](https://github.com/dcouple/skills/tree/main/parsa) only to inspect or refresh referenced skill files; do not clone/install the repo unless the user asks.
+Do not hardcode a specific assistant brand in workflow guidance. Use the Pane agent or custom tool command the user selected, and use `runpane agents doctor --agent <agent> --repo <selector> --json` only when checking a built-in agent template.
+
+Start with `runpane doctor --json` before taking Pane actions. Use it to understand wrapper/runtime details, daemon reachability, and the next safe commands.
+
+In a Pane repository checkout, if `runpane` is not on PATH, use the built local wrapper with Node 22: `PATH=/opt/homebrew/opt/node@22/bin:$PATH node packages/runpane/dist/cli.js doctor --json`.
+
+Use `runpane agent-context --json` for full Pane CLI context. Use `runpane agent-context --command "panels wait" --json` or another command name for detailed schema only when needed.
+
+Default to context-safe validation: after creating Panes or sending terminal input, run `runpane panels wait` or `runpane panels screen` before reporting success. Prefer `runpane panels submit` for normal text plus Enter; use `runpane panels input` only for exact bytes such as Ctrl-C or escape sequences.
+
+Pane terminals draw inline images: sixel, iTerm2 inline images, and the kitty graphics protocol. Tools that need kitty graphics, such as [terminal-browser](https://github.com/zenbu-labs/terminal-browser) and [terminal-doom](https://github.com/dcouple/terminal-doom), run inside a Pane panel. `runpane doctor --json` reports the protocol list under `terminal.graphicsProtocols`.
+
+Common commands:
+- `runpane doctor --json`
+- `runpane agent-context --json`
+- `runpane repos list --json`
+- `runpane repos add --path <repo> --yes --json`
+- `runpane agents doctor --agent <agent> --repo active --json`
+- `runpane panes create --repo active --name <name> --agent <agent> --prompt "<task>" --source agent --no-focus --wait-ready --yes --json`
+- `runpane panels create --pane <pane-id> --agent <agent> --source agent --no-focus --wait-ready --yes --json`
+- `runpane panels list --pane <pane-id> --json`
+- `runpane panels screen --panel <panel-id> --limit 80 --json`
+- `runpane panels wait --panel <panel-id> --for ready --timeout-ms 30000 --json`
+- `runpane panels submit --panel <panel-id> --text "<answer>" --yes --json`
+- `runpane panels input --panel <panel-id> --input-file <path|-> --yes --json`
+
+WSL note: if `runpane doctor --json` cannot find `/tmp/pane-daemon.../daemon.sock` or `runpane` resolves to a broken Windows shim, Pane may be running on Windows. Try `powershell.exe -NoProfile -Command 'Set-Location $env:TEMP; runpane doctor --json'`, then create Panes through the same PowerShell form using the saved WSL repo name or id. Use `runpane agents doctor --agent <agent> --repo <selector> --json` to diagnose the repo environment Pane will actually use.
+<!-- pane-agent-context:end -->

--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ PR yourself before opening it:
 - Renaming a record is refused outright. Claim a new name instead.
 - `owner` and `claimedAt` are immutable once set; only the recorded owner
   may edit or remove a record.
-- New names are claimed on the site, never by pull request; that's the
-  only path that checks account age, public-repo count, and the
-  one-name-per-account limit.
+- New names may be claimed either on the site or by pull request. Both
+  paths apply the same gates: the record must name its own author as
+  owner, the name must not be reserved, the account must be at least 30
+  days old with one public repository, and it must not already hold a
+  name.
 - An owner may delete their own record by pull request; a maintainer can
   do the same under [POLICY.md](./POLICY.md).
 

--- a/docs/claiming.md
+++ b/docs/claiming.md
@@ -27,6 +27,36 @@ wildcard DNS record, so there's nothing to provision. You get a profile
 card built from your GitHub account until you point the name at your own
 hosting (see the main [README](../README.md#point-it-at-your-own-hosting)).
 
+## Claiming by pull request
+
+The site is the quick path; a pull request does the same thing by hand.
+Add `domains/<name>.json` naming yourself as owner and open a PR:
+
+```json
+{
+  "name": "yourname",
+  "owner": { "github": "your-github-login" },
+  "claimedAt": "2026-01-01T00:00:00.000Z",
+  "records": {}
+}
+```
+
+You can set `records` in the same PR rather than claiming empty and
+pointing the name in a second one.
+
+`validateChangeset` (`lib/pr.js`) holds this to the same gates
+`evaluateClaim` applies on the site, in the same order: the record must
+name its own author as owner, the name must not be reserved, `claimedAt`
+may not be in the future, the account must be 30 days old with a public
+repository, and it must not already hold a name. Eligibility is read from
+`GET /users/<login>` and the owned-name count from `domains/` at the base
+commit; if either lookup fails, the check fails with it rather than
+guessing.
+
+The one thing the site gives you that a PR cannot is the atomic create.
+Two PRs claiming the same name will both pass CI, and the second to merge
+produces a conflict rather than a clean `409 taken`.
+
 ## Eligibility
 
 Claiming requires, checked by `lib/eligibility.js`:
@@ -59,6 +89,13 @@ per-account index file, `owners/<login>.json`, read with `getOwnerIndex`
 and written with `putOwnerIndex` (both in `lib/owners.js`). A successful
 claim appends the new name to that account's index right after the record
 itself is written.
+
+That index is a cache, not the registry — `domains/` is. A name claimed by
+pull request never runs `putOwnerIndex`, so the index would undercount and
+hand the account a second name; `scripts/sync-owners.mjs` therefore
+rebuilds `owners/` from `domains/` after every merge that touches a record
+(`.github/workflows/sync-owners.yml`), and CI counts owned names by
+scanning `domains/` directly rather than trusting the index.
 
 This closes the same land-grab door the eligibility rules open partway:
 even a 30-day-old account with a real repo could otherwise sweep a long

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -74,11 +74,22 @@ Three workflows, all under `.github/workflows/`:
 - **Editing a record** is allowed only for its recorded owner, and
   `owner`/`claimedAt` can never change by pull request, even for the
   owner, only set once at claim time.
-- **Creating a record** is refused unconditionally: `validateChangeset`
-  has no branch that approves a brand-new file. New names go through
-  `POST /api/claim` instead, which is the only path that checks account
-  age, public-repo count, and the per-account claim limit, so a pull
-  request can never bypass eligibility to originate a name.
+- **Creating a record** is allowed, and is held to exactly the gates
+  `POST /api/claim` applies through `evaluateClaim`, in the same order:
+  the record must name its own author as `owner.github` (compared
+  case-insensitively, since GitHub logins are unique that way), the name
+  must not be reserved, `claimedAt` may not be in the future, the account
+  must pass `lib/eligibility.js` (30 days old, one public repository), and
+  it must not already own a name. A pull request is a second front door
+  onto the same registry, so any gate it checked less strictly would
+  simply become the way around that gate.
+- **Both claim lookups fail closed.** Eligibility comes from
+  `GET /users/<login>` and the owned-name count from scanning `domains/`
+  at the base commit; if either cannot be read, `validateChangeset`
+  reports "could not check" and the PR fails. A rate-limited check must
+  never read as "eligible" or "owns nothing", because load is exactly when
+  a land grab happens — the same reasoning `POST /api/claim` uses when it
+  answers busy rather than letting an uncounted claim through.
 - The record itself must still pass `lib/schema.js`'s `validateRecord` and
   `lib/name.js`'s `validateName`.
 

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -1,9 +1,98 @@
 import { validateName } from './name.js';
 import { validateRecord } from './schema.js';
+import { isReserved } from './blocklist.js';
+import { checkEligibility } from './eligibility.js';
+import { MAX_NAMES_PER_ACCOUNT } from './claim.js';
 
 const DOMAIN_FILE = /^domains\/([a-z0-9-]+)\.json$/;
 
-export async function validateChangeset({ files, prAuthor, readFile, readBase }) {
+// GitHub logins are unique case-insensitively, so `Zyaxxy` and `zyaxxy` are the
+// same account. Comparing them raw would let a record written with one casing
+// lock its own owner out of editing it.
+function sameLogin(a, b) {
+  return typeof a === 'string' && typeof b === 'string'
+    && a.toLowerCase() === b.toLowerCase();
+}
+
+// The five gates /api/claim applies through evaluateClaim, re-applied here.
+// A pull request is now a first-class way to claim a name, which means this
+// branch is a second front door onto the same registry — if it checks any
+// fewer of them, the way to bypass a gate is simply to open a PR instead of
+// using the site. Kept in the same order as evaluateClaim so the two read
+// side by side.
+async function validateNewClaim({ head, name, prAuthor, getUser, countOwnedNames, now }) {
+  const errors = [];
+
+  // A record is owned by whoever the file says owns it, so a PR may only
+  // introduce one naming its own author. Without this, anyone could open a
+  // PR claiming a name on behalf of another account and burn that account's
+  // one-name allowance.
+  if (!sameLogin(head.owner?.github, prAuthor)) {
+    errors.push(`a claim must name its own author as owner (@${prAuthor})`);
+    // Every remaining gate is scoped to the author, so checking them against
+    // a record that claims to be someone else's would report nonsense.
+    return errors;
+  }
+
+  const reserved = isReserved(name);
+  if (reserved.reserved) {
+    errors.push(`${name} is reserved (${reserved.list})`);
+  }
+
+  // claimedAt is the moment the name was taken. A future timestamp is either
+  // a mistake or an attempt to win a tie-break against a later claim.
+  const claimedAt = Date.parse(head.claimedAt);
+  if (!Number.isNaN(claimedAt) && claimedAt > now.getTime() + 60_000) {
+    errors.push('claimedAt cannot be in the future');
+  }
+
+  // Both lookups fail closed. An unavailable GitHub API or a rate limit must
+  // never read as "eligible" or "owns nothing" — load is exactly when a land
+  // grab happens, which is the same reasoning /api/claim uses when it answers
+  // busy rather than letting an uncounted claim through.
+  let user;
+  try {
+    user = await getUser(prAuthor);
+  } catch {
+    return [...errors, 'could not check account eligibility, try re-running this check'];
+  }
+  if (!user) {
+    return [...errors, 'could not check account eligibility, try re-running this check'];
+  }
+
+  const eligible = checkEligibility(user, now);
+  if (!eligible.ok) {
+    errors.push(eligible.reason === 'age'
+      ? 'account must be at least 30 days old to claim a name'
+      : 'account must have at least one public repository to claim a name');
+  }
+
+  let owned;
+  try {
+    owned = await countOwnedNames(prAuthor);
+  } catch {
+    return [...errors, 'could not check how many names you already own, try re-running this check'];
+  }
+  if (!Number.isInteger(owned)) {
+    return [...errors, 'could not check how many names you already own, try re-running this check'];
+  }
+
+  if (owned >= MAX_NAMES_PER_ACCOUNT) {
+    errors.push(`one name per account: @${prAuthor} already owns ${owned}`);
+  }
+
+  return errors;
+}
+
+export async function validateChangeset({
+  files,
+  prAuthor,
+  readFile,
+  readBase,
+  getUser,
+  countOwnedNames,
+  now = new Date(),
+}) {
   const errors = [];
 
   if (!Array.isArray(files) || files.length !== 1) {
@@ -33,7 +122,7 @@ export async function validateChangeset({ files, prAuthor, readFile, readBase })
   // head file no longer exists once removed, so this must branch before readFile.
   if (file.status === 'removed') {
     if (!base) return { ok: false, errors: ['could not read the record being removed'] };
-    if (base.owner?.github !== prAuthor) {
+    if (!sameLogin(base.owner?.github, prAuthor)) {
       errors.push(`only the owner (@${base.owner?.github}) may remove this record`);
     }
     return { ok: errors.length === 0, errors };
@@ -49,20 +138,24 @@ export async function validateChangeset({ files, prAuthor, readFile, readBase })
   if (head.name !== nameFromPath) errors.push('filename must match the record name');
 
   if (base) {
-    if (base.owner?.github !== prAuthor) {
+    if (!sameLogin(base.owner?.github, prAuthor)) {
       errors.push(`only the owner (@${base.owner?.github}) may change this record`);
     }
-    if (head.owner?.github !== base.owner?.github) {
+    if (!sameLogin(head.owner?.github, base.owner?.github)) {
       errors.push('owner cannot be changed by pull request');
     }
     if (head.claimedAt !== base.claimedAt) {
       errors.push('claimedAt cannot be changed');
     }
   } else {
-    // New names go through /api/claim, which enforces account-age and public-repo
-    // eligibility. This branch has no such check, so a day-old account could
-    // otherwise claim a name here with a green CI check a maintainer would trust.
-    errors.push('new names are claimed at runs-on.dev, not by pull request');
+    errors.push(...await validateNewClaim({
+      head,
+      name: nameFromPath,
+      prAuthor,
+      getUser,
+      countOwnedNames,
+      now,
+    }));
   }
 
   return { ok: errors.length === 0, errors };

--- a/scripts/sync-owners.mjs
+++ b/scripts/sync-owners.mjs
@@ -1,0 +1,78 @@
+import { readdir, readFile, writeFile, unlink, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+// owners/<login>.json is derived data: the answer to "how many names does this
+// account hold", cached so the website's claim path can check the per-account
+// limit in one request instead of scanning the whole registry. domains/ is the
+// registry itself, so this rebuilds the index from it rather than trying to keep
+// the two in step incrementally — a claim that lands by pull request never goes
+// through /api/claim and so never runs putOwnerIndex, and an index that silently
+// undercounts hands the account a second name it should not get.
+const ROOT = path.resolve(import.meta.dirname, '..');
+const DOMAINS = path.join(ROOT, 'domains');
+const OWNERS = path.join(ROOT, 'owners');
+
+const LOGIN_SHAPE = /^[a-z0-9-]{1,39}$/;
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+
+const domainFiles = (await readdir(DOMAINS)).filter((f) => f.endsWith('.json'));
+
+// login (lowercased, as the index filenames are) -> names held
+const byOwner = new Map();
+
+for (const file of domainFiles) {
+  const record = await readJson(path.join(DOMAINS, file));
+  const login = record?.owner?.github;
+  if (typeof login !== 'string' || !login) {
+    console.warn(`skipping domains/${file}: no owner.github`);
+    continue;
+  }
+  const key = login.toLowerCase();
+  if (!LOGIN_SHAPE.test(key)) {
+    console.warn(`skipping domains/${file}: owner.github is not a valid login (${login})`);
+    continue;
+  }
+  if (!byOwner.has(key)) byOwner.set(key, []);
+  byOwner.get(key).push(record.name ?? path.basename(file, '.json'));
+}
+
+await mkdir(OWNERS, { recursive: true });
+const existing = new Set((await readdir(OWNERS)).filter((f) => f.endsWith('.json')));
+
+let written = 0;
+let removed = 0;
+
+for (const [login, names] of byOwner) {
+  names.sort();
+  const body = `${JSON.stringify({ github: login, names }, null, 2)}\n`;
+  const file = path.join(OWNERS, `${login}.json`);
+
+  // Only write when the content actually differs, so a run that changes nothing
+  // leaves the tree clean and the workflow skips its commit entirely.
+  let current = null;
+  try {
+    current = await readFile(file, 'utf8');
+  } catch {
+    // absent, so it needs writing
+  }
+  if (current !== body) {
+    await writeFile(file, body);
+    written += 1;
+    console.log(`owners/${login}.json -> ${names.length} name${names.length === 1 ? '' : 's'}`);
+  }
+  existing.delete(`${login}.json`);
+}
+
+// Whatever is left held no names in domains/ — the record was removed or
+// released, so the index entry goes too rather than lingering as a phantom
+// count that blocks the account from ever claiming again.
+for (const stale of existing) {
+  await unlink(path.join(OWNERS, stale));
+  removed += 1;
+  console.log(`owners/${stale} -> removed (owns nothing)`);
+}
+
+console.log(`sync-owners: ${byOwner.size} owner(s), ${written} written, ${removed} removed.`);

--- a/scripts/validate-pr.mjs
+++ b/scripts/validate-pr.mjs
@@ -32,6 +32,49 @@ async function readAt(path, ref) {
   return JSON.parse(Buffer.from(body.content, 'base64').toString('utf8'));
 }
 
+// Eligibility is read from the PR author's public GitHub profile, the same two
+// fields the session carries into evaluateClaim on the website. Throwing rather
+// than returning null on a transport failure matters: validateChangeset treats a
+// throw as "could not check" and fails the PR closed.
+async function getUser(login) {
+  const res = await api(`/users/${encodeURIComponent(login)}`);
+  if (!res.ok) throw new Error(`GET /users/${login} -> ${res.status}`);
+  const u = await res.json();
+  return { created_at: u.created_at, public_repos: u.public_repos };
+}
+
+// Counted from domains/ itself rather than the owners/ index, because domains/
+// is the registry — the index is derived data rebuilt after merge by
+// sync-owners, and a stale or missing index must never read as "owns nothing"
+// and hand out a second name.
+async function countOwnedNames(login) {
+  const res = await api(`/repos/${REPO}/contents/domains?ref=${BASE_SHA}`);
+  if (!res.ok) throw new Error(`GET domains/ -> ${res.status}`);
+  const entries = await res.json();
+  const records = entries.filter((e) => e.type === 'file' && e.name.endsWith('.json'));
+
+  const target = login.toLowerCase();
+  let owned = 0;
+
+  // Modest concurrency: enough to keep a few hundred records quick, low enough
+  // not to trip secondary rate limits on a shared Actions IP.
+  const BATCH = 10;
+  for (let i = 0; i < records.length; i += BATCH) {
+    const slice = records.slice(i, i + BATCH);
+    const parsed = await Promise.all(slice.map(async (entry) => {
+      const r = await api(`/repos/${REPO}/contents/domains/${entry.name}?ref=${BASE_SHA}`);
+      if (!r.ok) throw new Error(`GET domains/${entry.name} -> ${r.status}`);
+      const body = await r.json();
+      return JSON.parse(Buffer.from(body.content, 'base64').toString('utf8'));
+    }));
+    for (const rec of parsed) {
+      if (String(rec?.owner?.github ?? '').toLowerCase() === target) owned += 1;
+    }
+  }
+
+  return owned;
+}
+
 const prRes = await api(`/repos/${REPO}/pulls/${PR}`);
 if (!prRes.ok) {
   console.error(`validate-pr: failed to fetch PR #${PR} from ${REPO}: ${prRes.status} ${prRes.statusText}`);
@@ -55,6 +98,8 @@ const result = await validateChangeset({
   prAuthor: user.login,
   readFile: (p) => readAt(p, HEAD_SHA),
   readBase: (p) => readAt(p, BASE_SHA),
+  getUser,
+  countOwnedNames,
 });
 
 if (!result.ok) {

--- a/test/validate-pr.test.mjs
+++ b/test/validate-pr.test.mjs
@@ -94,8 +94,11 @@ test('rejects a new file claiming a reserved name', async () => {
     prAuthor: 'zordhalo',
     readFile: async () => reserved,
     readBase: async () => null,
+    getUser: async () => ({ created_at: '2020-01-01T00:00:00Z', public_repos: 3 }),
+    countOwnedNames: async () => 0,
   });
   assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('reserved')));
 });
 
 test('rejects a renamed file', async () => {
@@ -109,15 +112,129 @@ test('rejects a renamed file', async () => {
   assert.ok(out.errors.some((e) => e.includes('renam')));
 });
 
-test('rejects a new name claimed by pull request', async () => {
-  const out = await validateChangeset({
-    files: [{ filename: 'domains/newname.json', status: 'added' }],
-    prAuthor: 'zordhalo',
-    readFile: async () => ({ ...owned, name: 'newname' }),
-    readBase: async () => null,
-  });
+// --- claiming a new name by pull request -------------------------------------
+//
+// This path is a second front door onto the same registry as /api/claim, so
+// each test below pins one of the gates evaluateClaim applies. If any of them
+// starts passing, opening a pull request has become the way around that gate.
+
+const ELIGIBLE = { created_at: '2020-01-01T00:00:00Z', public_repos: 3 };
+const NOW = new Date('2026-09-01T12:00:00Z');
+
+const claim = (over = {}) => ({
+  files: [{ filename: 'domains/newname.json', status: 'added' }],
+  prAuthor: 'zordhalo',
+  readFile: async () => ({
+    name: 'newname',
+    owner: { github: 'zordhalo' },
+    claimedAt: '2026-09-01T11:00:00Z',
+    records: {},
+  }),
+  readBase: async () => null,
+  getUser: async () => ELIGIBLE,
+  countOwnedNames: async () => 0,
+  now: NOW,
+  ...over,
+});
+
+test('accepts a new name claimed by pull request', async () => {
+  const out = await validateChangeset(claim());
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('accepts a claim that sets records up front', async () => {
+  const out = await validateChangeset(claim({
+    readFile: async () => ({
+      name: 'newname',
+      owner: { github: 'zordhalo' },
+      claimedAt: '2026-09-01T11:00:00Z',
+      records: { CNAME: 'cname.vercel-dns.com' },
+    }),
+  }));
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('rejects a claim naming someone else as owner', async () => {
+  const out = await validateChangeset(claim({
+    readFile: async () => ({
+      name: 'newname',
+      owner: { github: 'someone-else' },
+      claimedAt: '2026-09-01T11:00:00Z',
+      records: {},
+    }),
+  }));
   assert.equal(out.ok, false);
-  assert.ok(out.errors.some((e) => e.includes('not by pull request')));
+  assert.ok(out.errors.some((e) => e.includes('its own author')));
+});
+
+test('matches the owner case-insensitively', async () => {
+  const out = await validateChangeset(claim({
+    prAuthor: 'ZordHalo',
+    readFile: async () => ({
+      name: 'newname',
+      owner: { github: 'zordhalo' },
+      claimedAt: '2026-09-01T11:00:00Z',
+      records: {},
+    }),
+  }));
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('rejects a claim on an account younger than 30 days', async () => {
+  const out = await validateChangeset(claim({
+    getUser: async () => ({ created_at: '2026-08-25T00:00:00Z', public_repos: 3 }),
+  }));
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('30 days')));
+});
+
+test('rejects a claim from an account with no public repositories', async () => {
+  const out = await validateChangeset(claim({
+    getUser: async () => ({ created_at: '2020-01-01T00:00:00Z', public_repos: 0 }),
+  }));
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('public repositor')));
+});
+
+test('rejects a second name for an account that already owns one', async () => {
+  const out = await validateChangeset(claim({ countOwnedNames: async () => 1 }));
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('one name per account')));
+});
+
+test('rejects a claim with a future claimedAt', async () => {
+  const out = await validateChangeset(claim({
+    readFile: async () => ({
+      name: 'newname',
+      owner: { github: 'zordhalo' },
+      claimedAt: '2027-01-01T00:00:00Z',
+      records: {},
+    }),
+  }));
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('future')));
+});
+
+test('fails closed when eligibility cannot be checked', async () => {
+  const out = await validateChangeset(claim({
+    getUser: async () => { throw new Error('rate limited'); },
+  }));
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('could not check account eligibility')));
+});
+
+test('fails closed when the owned-name count cannot be checked', async () => {
+  const out = await validateChangeset(claim({
+    countOwnedNames: async () => { throw new Error('rate limited'); },
+  }));
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('how many names')));
+});
+
+test('fails closed when the owned-name count is not a number', async () => {
+  const out = await validateChangeset(claim({ countOwnedNames: async () => undefined }));
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('how many names')));
 });
 
 test('allows an owner to remove their own record', async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
Three changes, one per commit.

## `claim:` allow claiming a name by pull request

`validateChangeset` refused every new file, because `/api/claim` was the only path that checked account age, public-repo count and the per-account limit. This enforces those same gates in `lib/pr.js` instead, in the same order `evaluateClaim` applies them:

| Gate | Site (`evaluateClaim`) | PR (`validateChangeset`) |
|---|---|---|
| Name grammar | ✅ | ✅ (already) |
| Reserved blocklist | ✅ | ✅ new |
| Owner is the claimant | session login | ✅ new — must equal PR author |
| Account ≥ 30 days, ≥ 1 public repo | ✅ | ✅ new |
| One name per account | ✅ | ✅ new |

A PR is a second front door onto the same registry, so any gate checked less strictly here would simply become *the* way around that gate.

Two details worth review:

- **Both lookups fail closed.** Eligibility is `GET /users/<login>`; the owned-name count scans `domains/` at the base commit. If either can't be read the PR fails rather than guessing — a rate-limited check must never read as "eligible" or "owns nothing", since load is exactly when a land grab happens. Same reasoning `/api/claim` uses when it answers busy.
- **The count scans `domains/`, not `owners/`.** `domains/` is the registry; the index is derived. A stale index must never hand out a second name.

Also compares owner logins case-insensitively — GitHub logins are unique that way, so a record written `Zyaxxy` would otherwise lock out `zyaxxy`.

The one thing the site still gives you that a PR can't is the atomic create: two PRs claiming the same name both pass CI, and the second to merge conflicts instead of getting a clean `409 taken`. Documented rather than solved.

14 new tests, one per gate plus the three fail-closed paths. 129 pass.

## `index:` rebuild owners from domains after every merge

`owners/<login>.json` was written only by `putOwnerIndex` on the website path — complete while that was the only way to claim. A PR claim never runs it, and an index that undercounts hands the account a second name. `scripts/sync-owners.mjs` rebuilds it from `domains/` on every push touching a record.

Idempotent, commits only when content differs, writes `owners/` only while the trigger is scoped to `domains/**` so it can't retrigger itself. Verified it reproduces all 17 current index files byte-identically.

## `deploy:` ship production from Actions

Vercel opened a deployment per PR, and the preview environment carries `REGISTRY_TOKEN`, `GITHUB_CLIENT_SECRET` and `SESSION_SECRET` — so it refused to build forks without authorization, leaving a permanent red ❌ on every contributor's PR.

Turning fork protection off would have removed the ❌ by handing arbitrary PR code the token that writes `domains/`. So the git integration goes off in `vercel.json` and deploys move to a workflow only `main` can trigger. Repo variables `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are set; it reuses the existing `VERCEL_TOKEN` secret.

**Needs a live check after merge:** the first `deploy` run, since it can't be exercised from a PR.

---

Also changed outside this branch: fork-PR approval was `first_time_contributors`, which is why `validate` never ran on any of #1–#4. Now `first_time_contributors_new_to_github`, which lines up with the registry's own 30-day rule.