### PR TITLE
index: allow sync-owners to be run by hand

### DIFF
--- a/.github/workflows/sync-owners.yml
+++ b/.github/workflows/sync-owners.yml
@@ -10,6 +10,10 @@ on:
   push:
     branches: [main]
     paths: ['domains/**']
+  # The rebuild is idempotent, so a manual run is a safe way to prove the
+  # workflow works without waiting for a claim to land, and to repair the index
+  # by hand if a run is ever missed.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` so the owners rebuild can be triggered manually — needed to verify the workflow actually runs, since nothing has touched `domains/**` since it merged. The rebuild is idempotent, so a manual run is safe and also gives a way to repair the index if a run is ever missed.