### PR TITLE
Let an owner point their name from the site

### DIFF
--- a/app/api/claim/route.js
+++ b/app/api/claim/route.js
@@ -1,4 +1,4 @@
-import { readSession } from '../../../lib/session.js';
+import { sessionFromRequest } from '../../../lib/session.js';
 import { evaluateClaim } from '../../../lib/claim.js';
 import { putRecord } from '../../../lib/registry.js';
 import { getOwnerIndex, putOwnerIndex } from '../../../lib/owners.js';
@@ -12,9 +12,7 @@ export async function POST(request) {
   const body = await request.json().catch(() => ({}));
   const name = typeof body.name === 'string' ? body.name.trim().toLowerCase() : '';
 
-  const cookie = request.headers.get('cookie') ?? '';
-  const raw = cookie.match(/(?:^|;\s*)session=([^;]+)/)?.[1];
-  const session = raw ? readSession(raw, process.env.SESSION_SECRET) : null;
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
 
   let ownerIndex = null;
   if (session?.login) {

--- a/app/api/records/route.js
+++ b/app/api/records/route.js
@@ -1,0 +1,80 @@
+import { sessionFromRequest } from '../../../lib/session.js';
+import { validateEdit } from '../../../lib/edit.js';
+import { getContentsMeta, putRecordUpdate } from '../../../lib/registry.js';
+import { validateName } from '../../../lib/name.js';
+
+const TOKEN = () => process.env.REGISTRY_TOKEN;
+
+const BUSY_RESPONSE = () =>
+  Response.json({ error: 'busy', retryInMs: 4000 }, { status: 503, headers: { 'Retry-After': '4' } });
+
+// The second write path onto domains/<name>.json, alongside /api/claim and a
+// merged pull request. It commits straight to main for the same reason
+// claiming does: the record file is the registry, and making an owner fork a
+// repo to point their own name is the friction that leaves most claimed names
+// pointing nowhere. The commit is still a public diff in the log, and the
+// rules it must satisfy are the same ones CI applies to a pull request,
+// because both call validateEdit.
+export async function POST(request) {
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
+  if (!session?.login) {
+    return Response.json({ error: 'signin_required' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const name = typeof body.name === 'string' ? body.name.trim().toLowerCase() : '';
+  if (!validateName(name).ok) {
+    return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+
+  let meta;
+  try {
+    meta = await getContentsMeta(`domains/${name}.json`, { token: TOKEN() });
+  } catch {
+    // Fail closed, as /api/claim does: a read that could not run must not be
+    // treated as "no such record" or as permission to write.
+    return BUSY_RESPONSE();
+  }
+  if (!meta) {
+    return Response.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  // Replace only what the request actually sent. A form that does not yet
+  // understand `subdomains` must not silently delete an owner's _atproto
+  // entry just by omitting it from the payload.
+  const head = { ...meta.data };
+  if ('records' in body) head.records = body.records;
+  if ('subdomains' in body) {
+    const subs = body.subdomains;
+    const empty = subs === null || (typeof subs === 'object' && Object.keys(subs).length === 0);
+    if (empty) delete head.subdomains;
+    else head.subdomains = subs;
+  }
+
+  const decision = validateEdit({ base: meta.data, head, editor: session.login });
+  if (!decision.ok) {
+    // An ownership refusal is a 403; anything else is the payload's fault.
+    const forbidden = decision.errors.some((e) => e.startsWith('only the owner'));
+    return Response.json(
+      { error: forbidden ? 'not_owner' : 'invalid_record', details: decision.errors },
+      { status: forbidden ? 403 : 400 },
+    );
+  }
+
+  const result = await putRecordUpdate(head, {
+    token: TOKEN(),
+    sha: meta.sha,
+    editor: session.login,
+  });
+
+  if (result.ok) {
+    return Response.json({ updated: name, commit: result.commit ?? null });
+  }
+  if (result.reason === 'stale') {
+    // The record changed under this edit. Re-read and decide again rather
+    // than overwrite whatever landed in between.
+    return Response.json({ error: 'stale' }, { status: 409 });
+  }
+  if (result.reason === 'ratelimited') return BUSY_RESPONSE();
+  return Response.json({ error: 'server_error' }, { status: 500 });
+}

--- a/app/claim-form.jsx
+++ b/app/claim-form.jsx
@@ -253,6 +253,12 @@ function Claimed({ name, commit }) {
         </a>
         <a
           className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
+          href="/manage"
+        >
+          point it somewhere →
+        </a>
+        <a
+          className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
           href={`/sites/${name}`}
         >
           your page →

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -15,6 +15,13 @@ export default async function Footer() {
           .
         </p>
         <p className="mt-2 font-(family-name:--font-mono) text-xs text-(--color-muted)">
+          Already have a name?{' '}
+          <a className="text-(--color-signal) underline" href="/manage">
+            Point it somewhere
+          </a>
+          .
+        </p>
+        <p className="mt-2 font-(family-name:--font-mono) text-xs text-(--color-muted)">
           Every name here is a file in a public repo.{' '}
           <a
             className="text-(--color-signal) underline"

--- a/app/manage/page.jsx
+++ b/app/manage/page.jsx
@@ -1,0 +1,88 @@
+import { cookies } from 'next/headers';
+import { readSession } from '../../lib/session.js';
+import { getOwnerIndex } from '../../lib/owners.js';
+import { getRecord } from '../../lib/registry.js';
+import RecordForm from './record-form.jsx';
+
+export const metadata = {
+  title: 'Manage your name — runs-on.dev',
+  description: 'Point your runs-on.dev name at your own hosting.',
+  robots: { index: false },
+};
+
+// Always reflects what is actually committed right now: an owner who just
+// saved must not be shown a cached copy of the record they replaced.
+export const dynamic = 'force-dynamic';
+
+const TOKEN = () => process.env.REGISTRY_TOKEN;
+
+export default async function Manage() {
+  const raw = (await cookies()).get('session')?.value;
+  const session = raw ? readSession(raw, process.env.SESSION_SECRET) : null;
+
+  if (!session?.login) {
+    return (
+      <Shell>
+        <p className="text-sm">
+          <a className="text-(--color-signal) underline" href="/api/auth/github">
+            Sign in with GitHub
+          </a>{' '}
+          to edit the record for a name you own.
+        </p>
+      </Shell>
+    );
+  }
+
+  const index = await getOwnerIndex(session.login, { token: TOKEN() }).catch(() => null);
+  const names = index?.names ?? [];
+
+  if (names.length === 0) {
+    return (
+      <Shell>
+        <p className="text-sm">
+          @{session.login} does not own a name yet.{' '}
+          <a className="text-(--color-signal) underline" href="/">
+            Claim one
+          </a>
+          .
+        </p>
+      </Shell>
+    );
+  }
+
+  const records = await Promise.all(
+    names.map((name) => getRecord(name, { token: TOKEN() }).catch(() => null)),
+  );
+
+  return (
+    <Shell>
+      {records.map((record, i) =>
+        record ? (
+          <RecordForm key={names[i]} name={names[i]} record={record} />
+        ) : (
+          <p key={names[i]} className="text-sm text-(--color-muted)">
+            Could not read domains/{names[i]}.json just now. Reload to try again.
+          </p>
+        ),
+      )}
+    </Shell>
+  );
+}
+
+function Shell({ children }) {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-16 sm:py-24">
+      <p className="font-(family-name:--font-mono) text-xs tracking-[0.14em] text-(--color-muted) uppercase">
+        Manage
+      </p>
+      <h1 className="mt-3 font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink) sm:text-3xl">
+        Point your name
+      </h1>
+      <p className="mt-3 text-sm leading-relaxed text-(--color-muted)">
+        Saving writes your record straight to the registry and DNS updates within
+        seconds. Every save is a public commit, the same as a merged pull request.
+      </p>
+      <div className="mt-8 space-y-8">{children}</div>
+    </main>
+  );
+}

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState } from 'react';
+import { commitUrl, shortSha } from '../../lib/repo.js';
+import { modeOf, mxToLines, buildRecords } from '../../lib/record-fields.js';
+
+const MODE_LABELS = [
+  { id: 'card', label: 'profile card', hint: 'No DNS records. The name serves your GitHub card.' },
+  { id: 'cname', label: 'CNAME', hint: 'Point at a host your provider gave you. Stands alone.' },
+  { id: 'advanced', label: 'A / TXT / MX', hint: 'IPv4 addresses, text records, and mail exchangers. Combinable.' },
+  { id: 'url', label: 'URL redirect', hint: 'Redirect visitors to an absolute http(s) URL. Stands alone.' },
+];
+
+export default function RecordForm({ name, record }) {
+  const [mode, setMode] = useState(() => modeOf(record.records));
+  const [cname, setCname] = useState(record.records?.CNAME ?? '');
+  const [url, setUrl] = useState(record.records?.URL ?? '');
+  const [a, setA] = useState((record.records?.A ?? []).join('\n'));
+  const [txt, setTxt] = useState((record.records?.TXT ?? []).join('\n'));
+  const [mx, setMx] = useState(mxToLines(record.records?.MX));
+  const [status, setStatus] = useState(null);
+  const [errors, setErrors] = useState([]);
+  const [commit, setCommit] = useState(null);
+
+  async function save(event) {
+    event.preventDefault();
+    setStatus('saving');
+    setErrors([]);
+
+    const res = await fetch('/api/records', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, records: buildRecords(mode, { cname, url, a, txt, mx }) }),
+    });
+    const body = await res.json().catch(() => ({}));
+
+    if (res.ok) {
+      setCommit(body.commit ?? null);
+      setStatus('saved');
+      return;
+    }
+    setErrors(body.details ?? [MESSAGES[body.error] ?? 'Could not save just now.']);
+    setStatus('error');
+  }
+
+  const sha = shortSha(commit);
+
+  return (
+    <form
+      onSubmit={save}
+      className="border border-(--color-rule) bg-(--color-card) p-6 sm:p-8"
+    >
+      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+        domains/{name}.json
+      </p>
+      <h2 className="mt-1 font-(family-name:--font-display) text-xl font-medium tracking-tight text-(--color-ink)">
+        {name}.runs-on.dev
+      </h2>
+
+      <fieldset className="mt-6">
+        <legend className="sr-only">Record type</legend>
+        <div className="flex flex-wrap gap-2">
+          {MODE_LABELS.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => { setMode(m.id); setStatus(null); setErrors([]); }}
+              aria-pressed={mode === m.id}
+              className="border px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
+              style={mode === m.id
+                ? { borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }
+                : { borderColor: 'var(--color-rule)' }}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-(--color-muted)">
+          {MODE_LABELS.find((m) => m.id === mode)?.hint}
+        </p>
+      </fieldset>
+
+      <div className="mt-5 space-y-4">
+        {mode === 'cname' && (
+          <Input label="CNAME" value={cname} onChange={setCname} placeholder="cname.vercel-dns.com" />
+        )}
+        {mode === 'url' && (
+          <Input label="URL" value={url} onChange={setUrl} placeholder="https://example.com" />
+        )}
+        {mode === 'advanced' && (
+          <>
+            <Area label="A" value={a} onChange={setA} placeholder={'76.76.21.21'} hint="One IPv4 address per line." />
+            <Area label="TXT" value={txt} onChange={setTxt} placeholder={'did=did:plc:abc123'} hint="One string per line, up to 255 characters." />
+            <Area label="MX" value={mx} onChange={setMx} placeholder={'10 mx.example.com'} hint="One 'priority hostname' per line, up to 5." />
+          </>
+        )}
+        {mode === 'card' && (
+          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+            {'"records": {}'}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center gap-4">
+        <button
+          type="submit"
+          disabled={status === 'saving'}
+          className="border px-5 py-2.5 font-(family-name:--font-mono) text-sm transition-opacity hover:opacity-90 disabled:opacity-50"
+          style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}
+        >
+          {status === 'saving' ? 'Saving…' : 'Save record'}
+        </button>
+
+        {status === 'saved' && (
+          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+            {'// '}
+            {sha ? (
+              <a className="text-(--color-signal) underline" href={commitUrl(commit)} target="_blank" rel="noopener noreferrer">
+                commit {sha}
+              </a>
+            ) : 'saved'}
+            {' — DNS updates within seconds'}
+          </p>
+        )}
+      </div>
+
+      {errors.length > 0 && (
+        <ul className="mt-4 space-y-1 font-(family-name:--font-mono) text-xs text-(--color-signal)">
+          {errors.map((e) => <li key={e}>{e}</li>)}
+        </ul>
+      )}
+    </form>
+  );
+}
+
+const MESSAGES = {
+  signin_required: 'Sign in again to save this record.',
+  not_owner: 'Only the owner of this name may change its record.',
+  not_found: 'That record no longer exists.',
+  stale: 'This record changed somewhere else while you were editing. Reload and try again.',
+  busy: 'The registry is busy. Try again in a few seconds.',
+  invalid_name: 'That name is not valid.',
+  server_error: 'Could not save just now.',
+};
+
+function Input({ label, value, onChange, placeholder }) {
+  return (
+    <label className="block">
+      <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{label}</span>
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
+      />
+    </label>
+  );
+}
+
+function Area({ label, value, onChange, placeholder, hint }) {
+  return (
+    <label className="block">
+      <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{label}</span>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        rows={2}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
+      />
+      {hint && <span className="mt-1 block text-xs text-(--color-muted)">{hint}</span>}
+    </label>
+  );
+}

--- a/lib/edit.js
+++ b/lib/edit.js
@@ -1,0 +1,54 @@
+import { validateRecord } from './schema.js';
+
+// GitHub logins are unique case-insensitively, so `Zyaxxy` and `zyaxxy` are the
+// same account. Comparing them raw would let a record written with one casing
+// lock its own owner out of editing it.
+export function sameLogin(a, b) {
+  return typeof a === 'string' && typeof b === 'string'
+    && a.toLowerCase() === b.toLowerCase();
+}
+
+// The complete gate for changing a record that already exists, shared by the
+// two write paths onto the registry: CI reviewing a pull request (lib/pr.js)
+// and the signed-in editor on the site (app/api/records). Both reach the same
+// files with the same consequences -- a record points a name other people
+// trust at somewhere on the internet -- so they must not be allowed to drift
+// into enforcing different rules. Whichever front door is easier to get
+// through is the only one an attacker would ever use.
+//
+// Assumes nothing about how `editor` was authenticated: the PR path takes the
+// pull request's author, the site takes the signed-in session's login.
+export function validateEdit({ base, head, editor }) {
+  const errors = [];
+
+  if (!base) {
+    return { ok: false, errors: ['no existing record to change'] };
+  }
+
+  // Ownership first, and reported alone. Every rule below describes how the
+  // record may differ from its base, which is a detail the person editing it
+  // has no business learning about a record that isn't theirs.
+  if (!sameLogin(base.owner?.github, editor)) {
+    return { ok: false, errors: [`only the owner (@${base.owner?.github}) may change this record`] };
+  }
+
+  const schema = validateRecord(head);
+  if (!schema.ok) errors.push(...schema.errors);
+
+  // The three immutable fields. `owner` and `claimedAt` are the record's
+  // identity -- who holds the name and since when -- and `name` is what the
+  // file is called, so changing it is a rename, which is refused outright
+  // rather than performed as a delete-and-recreate that would drop the name
+  // back into the pool for the length of one commit.
+  if (!sameLogin(head.owner?.github, base.owner?.github)) {
+    errors.push('owner cannot be changed');
+  }
+  if (head.claimedAt !== base.claimedAt) {
+    errors.push('claimedAt cannot be changed');
+  }
+  if (head.name !== base.name) {
+    errors.push('name cannot be changed; claim a new name instead');
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -3,6 +3,7 @@ import { validateRecord } from './schema.js';
 import { isReserved } from './blocklist.js';
 import { checkEligibility } from './eligibility.js';
 import { MAX_NAMES_PER_ACCOUNT } from './claim.js';
+import { sameLogin, validateEdit } from './edit.js';
 
 const DOMAIN_FILE = /^domains\/([a-z0-9-]+)\.json$/;
 
@@ -31,15 +32,6 @@ export function parseRecordFile(path, text) {
     throw new RecordParseError(path, err);
   }
 }
-
-// GitHub logins are unique case-insensitively, so `Zyaxxy` and `zyaxxy` are the
-// same account. Comparing them raw would let a record written with one casing
-// lock its own owner out of editing it.
-function sameLogin(a, b) {
-  return typeof a === 'string' && typeof b === 'string'
-    && a.toLowerCase() === b.toLowerCase();
-}
-
 // The five gates /api/claim applies through evaluateClaim, re-applied here.
 // A pull request is now a first-class way to claim a name, which means this
 // branch is a second front door onto the same registry — if it checks any
@@ -157,23 +149,20 @@ export async function validateChangeset({
   const head = await readFile(file.filename);
   if (!head) return { ok: false, errors: ['could not read the changed file'] };
 
-  const schema = validateRecord(head);
-  if (!schema.ok) errors.push(...schema.errors);
-
   if (!validateName(nameFromPath).ok) errors.push('filename fails the name grammar');
   if (head.name !== nameFromPath) errors.push('filename must match the record name');
 
+  // Changing an existing record is the same operation the site's editor
+  // performs, so it is gated by the same shared validator rather than a
+  // second copy of the rules here. validateEdit runs the schema check for
+  // this branch; the new-claim branch runs its own, so every path validates
+  // the record exactly once.
   if (base) {
-    if (!sameLogin(base.owner?.github, prAuthor)) {
-      errors.push(`only the owner (@${base.owner?.github}) may change this record`);
-    }
-    if (!sameLogin(head.owner?.github, base.owner?.github)) {
-      errors.push('owner cannot be changed by pull request');
-    }
-    if (head.claimedAt !== base.claimedAt) {
-      errors.push('claimedAt cannot be changed');
-    }
+    errors.push(...validateEdit({ base, head, editor: prAuthor }).errors);
   } else {
+    const schema = validateRecord(head);
+    if (!schema.ok) errors.push(...schema.errors);
+
     errors.push(...await validateNewClaim({
       head,
       name: nameFromPath,

--- a/lib/record-fields.js
+++ b/lib/record-fields.js
@@ -1,0 +1,65 @@
+// The translation between what the editor form shows (text in boxes) and the
+// `records` object the registry stores. Kept out of the component so the
+// parsing that decides what actually gets committed is testable on its own,
+// rather than only reachable by rendering a form.
+
+// The four shapes a record can legally take, which is the DNS coexistence
+// rule in schema.js turned into something you can pick from: CNAME must stand
+// alone, URL must stand alone, A/TXT/MX may be combined, and no records at
+// all means the name keeps serving its profile card.
+export const MODES = ['card', 'cname', 'advanced', 'url'];
+
+export function modeOf(records = {}) {
+  if ('URL' in records) return 'url';
+  if ('CNAME' in records) return 'cname';
+  if ('A' in records || 'TXT' in records || 'MX' in records) return 'advanced';
+  return 'card';
+}
+
+export function linesToList(text) {
+  return String(text ?? '').split('\n').map((l) => l.trim()).filter(Boolean);
+}
+
+// "10 mx.example.com" per line — the priority and the host, in the order they
+// appear in every DNS console, rather than two inputs per row. A malformed
+// line still produces an entry (with a NaN priority or an empty value) rather
+// than being dropped, so schema validation reports it instead of the form
+// quietly discarding what someone typed.
+export function parseMx(text) {
+  return linesToList(text).map((line) => {
+    const [priority, ...rest] = line.split(/\s+/);
+    return { priority: Number(priority), value: rest.join(' ') };
+  });
+}
+
+export function mxToLines(mx = []) {
+  return (Array.isArray(mx) ? mx : [])
+    .map((e) => `${e?.priority ?? ''} ${e?.value ?? ''}`.trim())
+    .join('\n');
+}
+
+// Only the active mode's fields are read. Switching mode therefore drops the
+// records that could not have coexisted with the new shape anyway, which is
+// the conservative reading: the record you can see on screen is exactly the
+// record that gets written, with nothing carried invisibly underneath it.
+export function buildRecords(mode, fields = {}) {
+  if (mode === 'cname') {
+    const value = String(fields.cname ?? '').trim();
+    return value ? { CNAME: value } : {};
+  }
+  if (mode === 'url') {
+    const value = String(fields.url ?? '').trim();
+    return value ? { URL: value } : {};
+  }
+  if (mode === 'advanced') {
+    const out = {};
+    const a = linesToList(fields.a);
+    const txt = linesToList(fields.txt);
+    const mx = parseMx(fields.mx);
+    if (a.length) out.A = a;
+    if (txt.length) out.TXT = txt;
+    if (mx.length) out.MX = mx;
+    return out;
+  }
+  return {};
+}

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -86,3 +86,34 @@ export async function putRecord(record, { token, fetchImpl = fetch } = {}) {
   const created = await res.json().catch(() => null);
   return { ok: true, commit: created?.commit?.sha ?? null };
 }
+
+// The update counterpart to putRecord, and its exact inverse on the one
+// detail that matters: putRecord deliberately omits `sha` so GitHub refuses
+// a write over a path that already exists, which is what stops two people
+// claiming the same name. An update must send the sha it read, so GitHub
+// refuses a write over a file that has changed since — compare-and-swap on
+// the same field, in the opposite direction. Without it a stale editor tab
+// would silently clobber a record edited from somewhere else in between.
+export async function putRecordUpdate(record, { token, sha, editor, fetchImpl = fetch } = {}) {
+  if (!validateRecord(record).ok) return { ok: false, reason: 'error' };
+  if (typeof sha !== 'string' || !sha) return { ok: false, reason: 'error' };
+
+  const res = await fetchImpl(`${API}/repos/${REPO}/contents/${pathFor(record.name)}`, {
+    method: 'PUT',
+    headers: { ...headers(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: `records: ${record.name} by @${editor ?? record.owner.github}`,
+      content: Buffer.from(`${JSON.stringify(record, null, 2)}\n`).toString('base64'),
+      sha,
+    }),
+  });
+
+  if (res.status === 403 || res.status === 429) return { ok: false, reason: 'ratelimited' };
+  // A sha mismatch. The record moved under this edit, so the safe answer is
+  // to make the editor re-read and decide again rather than pick a winner.
+  if (res.status === 409 || res.status === 422) return { ok: false, reason: 'stale' };
+  if (!res.ok) return { ok: false, reason: 'error' };
+
+  const written = await res.json().catch(() => null);
+  return { ok: true, commit: written?.commit?.sha ?? null };
+}

--- a/lib/session.js
+++ b/lib/session.js
@@ -44,3 +44,12 @@ export function readSession(cookie, secret, { now = Date.now() } = {}) {
 
   return payload;
 }
+
+// Both write paths onto the registry (claiming and editing) authenticate the
+// same way: one signed cookie, read from the request. Kept here so neither
+// route grows its own idea of how to find it.
+export function sessionFromRequest(request, secret) {
+  const cookie = request.headers.get('cookie') ?? '';
+  const raw = cookie.match(/(?:^|;\s*)session=([^;]+)/)?.[1];
+  return raw ? readSession(raw, secret) : null;
+}

--- a/test/edit.test.mjs
+++ b/test/edit.test.mjs
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateEdit, sameLogin } from '../lib/edit.js';
+
+const base = {
+  name: 'lucas',
+  owner: { github: 'zordhalo' },
+  claimedAt: '2026-08-30T19:12:04Z',
+  records: {},
+};
+
+const edit = (patch, editor = 'zordhalo') =>
+  validateEdit({ base, head: { ...base, ...patch }, editor });
+
+test('accepts an owner pointing their own name', () => {
+  assert.deepEqual(edit({ records: { CNAME: 'cname.vercel-dns.com' } }), { ok: true, errors: [] });
+});
+
+test('accepts clearing every record back to the profile card', () => {
+  const withRecord = { ...base, records: { CNAME: 'cname.vercel-dns.com' } };
+  const out = validateEdit({ base: withRecord, head: { ...withRecord, records: {} }, editor: 'zordhalo' });
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('matches the owner case-insensitively', () => {
+  assert.equal(edit({ records: {} }, 'ZordHalo').ok, true);
+});
+
+test('rejects a non-owner', () => {
+  const out = edit({ records: { CNAME: 'evil.example.com' } }, 'attacker');
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('only the owner')));
+});
+
+test('reports nothing but ownership when the editor is not the owner', () => {
+  // A record that also violates the schema: the caller must not learn that.
+  const out = validateEdit({
+    base,
+    head: { ...base, claimedAt: '2020-01-01T00:00:00Z', records: { A: ['nope'] } },
+    editor: 'attacker',
+  });
+  assert.equal(out.errors.length, 1);
+});
+
+test('rejects changing the owner', () => {
+  const out = edit({ owner: { github: 'attacker' } });
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('owner cannot be changed')));
+});
+
+test('rejects changing claimedAt', () => {
+  const out = edit({ claimedAt: '2020-01-01T00:00:00Z' });
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('claimedAt')));
+});
+
+test('rejects renaming the record', () => {
+  const out = edit({ name: 'somethingelse' });
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('name cannot be changed')));
+});
+
+test('rejects a record that fails the schema', () => {
+  const out = edit({ records: { CNAME: 'not a hostname', A: ['1.2.3.4'] } });
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('CNAME')));
+});
+
+test('rejects a javascript: URL redirect', () => {
+  const out = edit({ records: { URL: 'javascript:alert(1)' } });
+  assert.equal(out.ok, false);
+});
+
+test('rejects an edit with no base record', () => {
+  const out = validateEdit({ base: null, head: base, editor: 'zordhalo' });
+  assert.equal(out.ok, false);
+});
+
+test('sameLogin ignores case and rejects non-strings', () => {
+  assert.equal(sameLogin('Zyaxxy', 'zyaxxy'), true);
+  assert.equal(sameLogin(undefined, 'zyaxxy'), false);
+  assert.equal(sameLogin('zyaxxy', null), false);
+});

--- a/test/record-fields.test.mjs
+++ b/test/record-fields.test.mjs
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { modeOf, linesToList, parseMx, mxToLines, buildRecords } from '../lib/record-fields.js';
+import { validateRecord } from '../lib/schema.js';
+
+test('modeOf reads the shape back out of a stored record', () => {
+  assert.equal(modeOf({}), 'card');
+  assert.equal(modeOf({ CNAME: 'x.example.com' }), 'cname');
+  assert.equal(modeOf({ URL: 'https://example.com' }), 'url');
+  assert.equal(modeOf({ A: ['1.2.3.4'] }), 'advanced');
+  assert.equal(modeOf({ TXT: ['hello'] }), 'advanced');
+  assert.equal(modeOf({ MX: [{ priority: 10, value: 'mx.example.com' }] }), 'advanced');
+  assert.equal(modeOf(undefined), 'card');
+});
+
+test('linesToList trims, drops blanks, and survives stray whitespace', () => {
+  assert.deepEqual(linesToList('  1.2.3.4 \n\n 5.6.7.8  \n'), ['1.2.3.4', '5.6.7.8']);
+  assert.deepEqual(linesToList(''), []);
+  assert.deepEqual(linesToList(undefined), []);
+});
+
+test('MX round-trips through lines and back', () => {
+  const mx = [{ priority: 10, value: 'mx1.example.com' }, { priority: 20, value: 'mx2.example.com' }];
+  assert.deepEqual(parseMx(mxToLines(mx)), mx);
+});
+
+test('a malformed MX line survives parsing so the schema can reject it', () => {
+  // Silently dropping it would tell the owner their record saved fine while
+  // quietly discarding the line they typed.
+  const parsed = parseMx('notanumber mx.example.com');
+  assert.equal(parsed.length, 1);
+  assert.ok(Number.isNaN(parsed[0].priority));
+  const check = validateRecord({
+    name: 'lucas', owner: { github: 'z' }, claimedAt: '2026-01-01T00:00:00Z',
+    records: { MX: parsed },
+  });
+  assert.equal(check.ok, false);
+});
+
+test('buildRecords emits only the active mode, never a coexistence violation', () => {
+  const fields = { cname: 'cname.vercel-dns.com', url: 'https://example.com', a: '1.2.3.4', txt: 'hi', mx: '10 mx.example.com' };
+  assert.deepEqual(buildRecords('cname', fields), { CNAME: 'cname.vercel-dns.com' });
+  assert.deepEqual(buildRecords('url', fields), { URL: 'https://example.com' });
+  assert.deepEqual(buildRecords('card', fields), {});
+  assert.deepEqual(buildRecords('advanced', fields), {
+    A: ['1.2.3.4'], TXT: ['hi'], MX: [{ priority: 10, value: 'mx.example.com' }],
+  });
+});
+
+test('every mode builds a record the schema accepts', () => {
+  const fields = { cname: 'cname.vercel-dns.com', url: 'https://example.com', a: '1.2.3.4', txt: 'hi', mx: '10 mx.example.com' };
+  for (const mode of ['card', 'cname', 'url', 'advanced']) {
+    const out = validateRecord({
+      name: 'lucas', owner: { github: 'z' }, claimedAt: '2026-01-01T00:00:00Z',
+      records: buildRecords(mode, fields),
+    });
+    assert.deepEqual(out, { ok: true, errors: [] }, `mode ${mode}: ${out.errors}`);
+  }
+});
+
+test('an empty field in a stand-alone mode clears the record rather than writing a blank', () => {
+  assert.deepEqual(buildRecords('cname', { cname: '   ' }), {});
+  assert.deepEqual(buildRecords('url', { url: '' }), {});
+  assert.deepEqual(buildRecords('advanced', { a: '', txt: '', mx: '' }), {});
+});

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { getRecord, putRecord } from '../lib/registry.js';
+import { getRecord, putRecord, putRecordUpdate } from '../lib/registry.js';
 
 const record = {
   name: 'lucas',
@@ -99,4 +99,49 @@ test('putRecord reports ratelimited when the existence check is rate limited', a
 test('putRecord reports error when the existence check fails otherwise', async () => {
   const fetchImpl = stubFetch([{ status: 500 }]);
   assert.deepEqual(await putRecord(record, { token: 't', fetchImpl }), { ok: false, reason: 'error' });
+});
+
+test('putRecordUpdate sends the sha so a moved record is not clobbered', async () => {
+  const fetchImpl = stubFetch([{ status: 200, body: { commit: { sha: 'abc123' } } }]);
+  const out = await putRecordUpdate(record, { token: 't', sha: 'base-sha', editor: 'zordhalo', fetchImpl });
+  assert.deepEqual(out, { ok: true, commit: 'abc123' });
+
+  const [write] = fetchImpl.calls;
+  assert.equal(write.init.method, 'PUT');
+  const body = JSON.parse(write.init.body);
+  assert.equal(body.sha, 'base-sha');
+  assert.equal(body.message, 'records: lucas by @zordhalo');
+});
+
+test('putRecordUpdate reports stale when the sha no longer matches', async () => {
+  const fetchImpl = stubFetch([{ status: 409 }]);
+  assert.deepEqual(
+    await putRecordUpdate(record, { token: 't', sha: 'old', fetchImpl }),
+    { ok: false, reason: 'stale' },
+  );
+});
+
+test('putRecordUpdate treats a 422 as stale too', async () => {
+  const fetchImpl = stubFetch([{ status: 422 }]);
+  assert.equal((await putRecordUpdate(record, { token: 't', sha: 'old', fetchImpl })).reason, 'stale');
+});
+
+test('putRecordUpdate refuses to write without a sha', async () => {
+  // No stubbed response: reaching the network here would throw, which is the
+  // point -- a missing sha must be caught before it can become a blind write.
+  const fetchImpl = stubFetch([]);
+  assert.deepEqual(await putRecordUpdate(record, { token: 't', fetchImpl }), { ok: false, reason: 'error' });
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+test('putRecordUpdate rejects a record failing schema validation before any network call', async () => {
+  const fetchImpl = stubFetch([]);
+  const bad = { ...record, records: { CNAME: 'not a hostname' } };
+  assert.deepEqual(await putRecordUpdate(bad, { token: 't', sha: 's', fetchImpl }), { ok: false, reason: 'error' });
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+test('putRecordUpdate reports ratelimited on a 429', async () => {
+  const fetchImpl = stubFetch([{ status: 429 }]);
+  assert.equal((await putRecordUpdate(record, { token: 't', sha: 's', fetchImpl })).reason, 'ratelimited');
 });


### PR DESCRIPTION
## Why

Sixteen of the nineteen names claimed so far point nowhere:

```
19 names claimed
 3 have any DNS record set
16 point nowhere            84%
```

Claiming takes one click. Pointing a name asks for a fork, a hand-edited JSON file, and a pull request. The gap between those two numbers is that asymmetry.

## What

`/manage` — a signed-in owner picks a record type, fills it in, saves. The write commits straight to `main` the same way `/api/claim` already does, and `sync-dns` picks it up on push, so DNS follows within seconds.

The record file is still the registry and every save is still a public commit. What goes away is the git workflow standing between an owner and their own name.

## The shared validator

`lib/edit.js` holds the rules for changing an existing record — only the owner may, and `owner` / `claimedAt` / `name` are immutable. Both `lib/pr.js` (CI reviewing a PR) and `app/api/records` (the site) call it.

Two front doors onto one registry must not enforce different rules; the one that checks less is the only one anyone would use.

## Notes

- **The four form modes are the DNS coexistence rules** turned into something pickable — CNAME alone, URL alone, A/TXT/MX combinable, or nothing for the profile card. The UI cannot compose a record the schema would reject. Server-side validation runs regardless.
- **`putRecordUpdate` is `putRecord`'s inverse on the `sha`.** `putRecord` omits it so GitHub refuses a write over an existing path (safe claiming). An update sends it so GitHub refuses a write over a file that moved (no stale-tab clobbering).
- **Subdomains are preserved on save but not yet editable**, so an `_atproto` entry still needs a PR.
- **No rate limit on the endpoint yet.** An owner can hammer save and burn API quota plus a `sync-dns` run per commit. Low risk at current scale, obvious next hardening.

## Testing

149 → 156 tests, all passing. Rejection paths verified against a live server reading real records:

```
POST /api/records  (signed out)               → 401 signin_required
POST /api/records  (wrong user, real record)  → 403 only the owner (@zordhalo) may change this record
POST /api/records  (nonexistent name)         → 404 not_found
POST /api/records  (invalid name)             → 400 invalid_name
```

The success path has **not** been exercised end to end — doing so writes a real commit to the registry. Worth one manual run against a fork before relying on it.