### PR TITLE
Report a malformed record instead of crashing on it

### DIFF
--- a/lib/pr.js
+++ b/lib/pr.js
@@ -6,6 +6,32 @@ import { MAX_NAMES_PER_ACCOUNT } from './claim.js';
 
 const DOMAIN_FILE = /^domains\/([a-z0-9-]+)\.json$/;
 
+// Raised when a record file cannot be parsed at all, so the caller can tell a
+// contributor's stray brace apart from an internal fault and report it as the
+// review finding it is.
+export class RecordParseError extends Error {
+  constructor(path, cause) {
+    super(`${path} is not valid JSON: ${cause.message}`);
+    this.name = 'RecordParseError';
+    this.path = path;
+    this.cause = cause;
+  }
+}
+
+// Hand-editing the JSON is the documented way to change a record, so a stray
+// brace is a routine contributor mistake rather than a broken pipeline. Left
+// as a bare JSON.parse it throws out of the whole validation run, replacing
+// the list of findings with a Node stack trace -- which is precisely the
+// state that leaves someone unable to see what is wrong with their own pull
+// request. Parsing through here turns it back into a reportable error.
+export function parseRecordFile(path, text) {
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new RecordParseError(path, err);
+  }
+}
+
 // GitHub logins are unique case-insensitively, so `Zyaxxy` and `zyaxxy` are the
 // same account. Comparing them raw would let a record written with one casing
 // lock its own owner out of editing it.

--- a/scripts/validate-pr.mjs
+++ b/scripts/validate-pr.mjs
@@ -1,4 +1,4 @@
-import { validateChangeset } from '../lib/pr.js';
+import { validateChangeset, parseRecordFile, RecordParseError } from '../lib/pr.js';
 
 const REPO = process.env.GITHUB_REPOSITORY;
 const PR = process.env.PR_NUMBER;
@@ -29,7 +29,7 @@ async function readAt(path, ref) {
   const res = await api(`/repos/${REPO}/contents/${path}?ref=${ref}`);
   if (!res.ok) return null;
   const body = await res.json();
-  return JSON.parse(Buffer.from(body.content, 'base64').toString('utf8'));
+  return parseRecordFile(path, Buffer.from(body.content, 'base64').toString('utf8'));
 }
 
 // Eligibility is read from the PR author's public GitHub profile, the same two
@@ -65,7 +65,7 @@ async function countOwnedNames(login) {
       const r = await api(`/repos/${REPO}/contents/domains/${entry.name}?ref=${BASE_SHA}`);
       if (!r.ok) throw new Error(`GET domains/${entry.name} -> ${r.status}`);
       const body = await r.json();
-      return JSON.parse(Buffer.from(body.content, 'base64').toString('utf8'));
+      return parseRecordFile(path, Buffer.from(body.content, 'base64').toString('utf8'));
     }));
     for (const rec of parsed) {
       if (String(rec?.owner?.github ?? '').toLowerCase() === target) owned += 1;
@@ -89,18 +89,30 @@ if (!filesRes.ok) {
 }
 const files = await filesRes.json();
 
-const result = await validateChangeset({
-  files: files.map((f) => ({
-    filename: f.filename,
-    status: f.status,
-    previous_filename: f.previous_filename,
-  })),
-  prAuthor: user.login,
-  readFile: (p) => readAt(p, HEAD_SHA),
-  readBase: (p) => readAt(p, BASE_SHA),
-  getUser,
-  countOwnedNames,
-});
+// A RecordParseError is a finding about the pull request, not a crash, so it
+// is reported through the same channel as every other finding below. Anything
+// else escaping validateChangeset is genuinely unexpected and still fails
+// loudly with its stack, which is what a maintainer needs to debug it.
+let result;
+try {
+  result = await validateChangeset({
+    files: files.map((f) => ({
+      filename: f.filename,
+      status: f.status,
+      previous_filename: f.previous_filename,
+    })),
+    prAuthor: user.login,
+    readFile: (p) => readAt(p, HEAD_SHA),
+    readBase: (p) => readAt(p, BASE_SHA),
+    getUser,
+    countOwnedNames,
+  });
+} catch (err) {
+  if (!(err instanceof RecordParseError)) throw err;
+  console.error('Registry validation failed:');
+  console.error(`  - ${err.message}`);
+  process.exit(1);
+}
 
 if (!result.ok) {
   console.error('Registry validation failed:');

--- a/test/validate-pr.test.mjs
+++ b/test/validate-pr.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateChangeset } from '../lib/pr.js';
+import { validateChangeset, parseRecordFile, RecordParseError } from '../lib/pr.js';
 
 const owned = {
   name: 'lucas',
@@ -266,4 +266,31 @@ test('rejects a rename even when only previous_filename is set', async () => {
     readBase: async () => null,
   });
   assert.equal(out.ok, false);
+});
+
+// Hand-edited record files are the documented way to change a record, so a
+// malformed one is a routine contributor mistake. It must arrive as a finding
+// the contributor can read, not as a crash that replaces the findings.
+test('parseRecordFile returns the record for valid JSON', () => {
+  assert.deepEqual(parseRecordFile('domains/lucas.json', '{"name":"lucas"}'), { name: 'lucas' });
+});
+
+test('parseRecordFile names the file and the parse problem', () => {
+  const bad = '{\n  "records": {}\n}\n}\n';
+  assert.throws(
+    () => parseRecordFile('domains/rudrakeshwani.json', bad),
+    (err) => {
+      assert.ok(err instanceof RecordParseError);
+      assert.match(err.message, /domains\/rudrakeshwani\.json is not valid JSON/);
+      return true;
+    },
+  );
+});
+
+test('a RecordParseError is distinguishable from any other failure', () => {
+  // The script rethrows anything that is not one of these, so an unexpected
+  // fault still fails loudly with its stack instead of being reported as a
+  // contributor mistake.
+  assert.equal(new RecordParseError('p', new Error('x')) instanceof RecordParseError, true);
+  assert.equal(new TypeError('boom') instanceof RecordParseError, false);
 });


### PR DESCRIPTION
## The bug

`readAt` in `scripts/validate-pr.mjs` parsed the record file with a bare `JSON.parse`, so a stray brace threw out of the whole validation run:

```
SyntaxError: Unexpected non-whitespace character after JSON at position 205
    at JSON.parse (<anonymous>)
    at readAt (scripts/validate-pr.mjs:32:15)
    at async validateChangeset (lib/pr.js:131:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
```

The `Registry validation failed:` list the script prints a few lines below never ran. The contributor gets a stack trace from a script they have never read.

## Why it matters

Hand-editing `domains/<name>.json` is the documented way to change a record, so malformed JSON is a routine contributor mistake rather than a broken pipeline. #8 is exactly this — an extra closing brace, and an author commenting *"I don't understand why the first check fails"*. Every contributor who miscounts a brace hits the same wall.

## After

```
Registry validation failed:
  - domains/rudrakeshwani.json is not valid JSON: Unexpected non-whitespace character after JSON at position 205 (line 10 column 1)
```

Verified by running `parseRecordFile` against the actual file on #8's head.

## Scope

Only `RecordParseError` is caught. Anything else escaping `validateChangeset` is genuinely unexpected and still fails loudly with its stack, which is what a maintainer needs to debug it.

The parse lives in `lib/pr.js` rather than the script because `scripts/validate-pr.mjs` executes at import time and can't be unit-tested. 131 → 134 tests.