### PR TITLE
Show a returning owner their name instead of a claim form

### DIFF
--- a/app/api/claim/route.js
+++ b/app/api/claim/route.js
@@ -38,7 +38,13 @@ export async function POST(request) {
     ownedCount: ownerIndex?.names?.length ?? 0,
   });
   if (!decision.ok) {
-    return Response.json({ error: decision.code }, { status: decision.status });
+    // Hand back the names this account already holds. Only limit_reached
+    // needs them, but they cost nothing to include and they are the caller's
+    // own records, not anyone else's. Without them the form can only say "you
+    // already have a name" without saying which -- a dead end at exactly the
+    // moment a returning owner is trying to reach their record.
+    const owned = ownerIndex?.names?.length ? ownerIndex.names : undefined;
+    return Response.json({ error: decision.code, owned }, { status: decision.status });
   }
 
   const result = await putRecord(decision.record, { token: TOKEN() });

--- a/app/claim-form.jsx
+++ b/app/claim-form.jsx
@@ -15,6 +15,7 @@ export default function ClaimForm({ signedIn }) {
   const [name, setName] = useState('');
   const [status, setStatus] = useState(null);
   const [commit, setCommit] = useState(null);
+  const [ownedName, setOwnedName] = useState(null);
   const [inputWidth, setInputWidth] = useState(null);
   const [animKey, setAnimKey] = useState(0);
   const nameRef = useRef('');
@@ -84,6 +85,9 @@ export default function ClaimForm({ signedIn }) {
 
     const body = await res.json();
     if (res.ok) setCommit(body.commit ?? null);
+    // A limit_reached rejection carries the name this account already holds,
+    // so the message below can point at it instead of dead-ending.
+    if (Array.isArray(body.owned) && body.owned.length) setOwnedName(body.owned[0]);
     setStatus(res.ok ? 'claimed' : body.error);
   }
 
@@ -184,13 +188,24 @@ export default function ClaimForm({ signedIn }) {
         <Field name={'"records":'} value="{}" />
         <p className="record-field">{'}'}</p>
         {status && (
-          <p className="record-field mt-2 text-(--color-muted)">// {message(status, displayName)}</p>
+          <p className="record-field mt-2 text-(--color-muted)">// {message(status, displayName, ownedName)}</p>
         )}
       </div>
 
       <div className="mt-5">
         {status === 'claimed' ? (
           <Claimed name={displayName} commit={commit} />
+        ) : status === 'limit_reached' ? (
+          // Being told "you already have a name" is only useful if it comes
+          // with a way to reach that name. This is where a returning owner
+          // ends up, so it has to lead somewhere.
+          <a
+            href="/manage"
+            className="inline-block border px-5 py-2.5 font-(family-name:--font-mono) text-sm transition-opacity hover:opacity-90"
+            style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}
+          >
+            {ownedName ? `Point ${ownedName}.runs-on.dev somewhere →` : 'Point your name somewhere →'}
+          </a>
         ) : signedIn ? (
           <button
             onClick={() => claim()}
@@ -278,7 +293,7 @@ function Field({ name, value, valueClass = 'text-(--color-ink)' }) {
   );
 }
 
-function message(status, name) {
+function message(status, name, ownedName) {
   const map = {
     available: `${name}.runs-on.dev is available.`,
     taken: 'Already claimed.',
@@ -298,7 +313,9 @@ function message(status, name) {
     signin_required: 'Sign in with GitHub first.',
     ineligible_age: 'Your GitHub account must be at least 30 days old.',
     ineligible_repos: 'Your GitHub account needs at least one public repository.',
-    limit_reached: 'You already have a name. One per account for now.',
+    limit_reached: ownedName
+      ? `You already own ${ownedName}.runs-on.dev. One per account for now.`
+      : 'You already have a name. One per account for now.',
   };
   return map[status] ?? 'Something went wrong.';
 }

--- a/app/owned-name.jsx
+++ b/app/owned-name.jsx
@@ -1,0 +1,80 @@
+import { REPO_URL } from '../lib/repo.js';
+
+// One name per account, so a signed-in owner has nothing to claim. Showing
+// them the claim form anyway offers an action that can only be refused, and
+// the refusal is where a returning owner used to dead-end. This replaces the
+// form with the thing they actually came back for: their own record, and a
+// way into it.
+export default function OwnedName({ name, record }) {
+  const records = record?.records ?? {};
+  const types = Object.keys(records);
+  const pointing = types.length > 0;
+
+  return (
+    <div>
+      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+        domains/{name}.json
+      </p>
+
+      <h2 className="mt-2 font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink) sm:text-3xl">
+        {name}.runs-on.dev is yours
+      </h2>
+
+      {pointing ? (
+        <dl className="mt-4 space-y-1 font-(family-name:--font-mono) text-xs sm:text-[13px]">
+          {types.map((type) => (
+            <div key={type} className="flex gap-2">
+              <dt className="w-16 shrink-0 text-(--color-muted)">{type}</dt>
+              <dd className="break-all text-(--color-ink)">{describe(records[type])}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p className="mt-3 max-w-xl text-sm leading-relaxed text-(--color-muted)">
+          It isn&apos;t pointing anywhere yet, so it serves a profile card built from your
+          GitHub account. Point it at your own site, a redirect, or an email
+          forwarder whenever you like.
+        </p>
+      )}
+
+      <div className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-3">
+        <a
+          href="/manage"
+          className="inline-block border px-5 py-2.5 font-(family-name:--font-mono) text-sm transition-opacity hover:opacity-90"
+          style={{
+            borderColor: 'var(--color-signal)',
+            background: 'var(--color-signal)',
+            color: 'var(--color-paper)',
+          }}
+        >
+          {pointing ? 'Edit your record →' : 'Point it somewhere →'}
+        </a>
+        <a
+          className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
+          href={`/sites/${name}`}
+        >
+          your page →
+        </a>
+        <a
+          className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
+          href={`${REPO_URL}/blob/main/domains/${name}.json`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          the record →
+        </a>
+      </div>
+    </div>
+  );
+}
+
+// Records hold a string, a list of strings, or MX objects, so each renders as
+// the one line a person would read it as rather than as raw JSON.
+function describe(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => (v && typeof v === 'object' ? `${v.priority} ${v.value}` : v))
+      .join(', ');
+  }
+  return String(value);
+}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,8 +1,11 @@
 import { cookies } from 'next/headers';
 import ClaimForm from './claim-form.jsx';
+import OwnedName from './owned-name.jsx';
 import JsonLd from './components/JsonLd.jsx';
 import { Section, Quote } from './components/Section.jsx';
 import { readSession } from '../lib/session.js';
+import { getOwnerIndex } from '../lib/owners.js';
+import { getRecord } from '../lib/registry.js';
 
 export const metadata = {
   title: 'runs-on.dev — free subdomains',
@@ -30,9 +33,26 @@ const websiteJsonLd = {
   ],
 };
 
+// Only for a signed-in visitor: this page is the highest-traffic route on the
+// site and these reads come out of REGISTRY_TOKEN's quota, the same one
+// claiming depends on. It already renders dynamically because it reads
+// cookies, so nothing is being given up on caching. Fails soft -- a lookup
+// that cannot run falls back to the claim form, which is what every visitor
+// saw before.
+async function ownedName(session) {
+  if (!session?.login) return null;
+  const token = process.env.REGISTRY_TOKEN;
+  const index = await getOwnerIndex(session.login, { token }).catch(() => null);
+  const name = index?.names?.[0];
+  if (!name) return null;
+  const record = await getRecord(name, { token }).catch(() => null);
+  return { name, record };
+}
+
 export default async function Home() {
   const raw = (await cookies()).get('session')?.value;
   const session = raw ? readSession(raw, process.env.SESSION_SECRET) : null;
+  const owned = await ownedName(session);
 
   return (
     <main className="mx-auto max-w-4xl px-6 py-14 sm:py-20">
@@ -45,7 +65,11 @@ export default async function Home() {
       </p>
 
       <div className="mt-3">
-        <ClaimForm signedIn={Boolean(session)} />
+        {owned ? (
+          <OwnedName name={owned.name} record={owned.record} />
+        ) : (
+          <ClaimForm signedIn={Boolean(session)} />
+        )}
       </div>
 
       <Section title="What this is">


### PR DESCRIPTION
## The dead end

`app/claim-form.jsx` told a returning owner:

> You already have a name. One per account for now.

No name, no link, nowhere to go — at exactly the moment someone signs in to do something with the name they own.

Underneath it, `app/page.jsx` passed only `Boolean(session)` to the form, so the homepage knew *that* you were signed in but never *what you owned*. A returning owner got a claim box for a name they cannot claim.

## Changes

**1. The homepage recognizes an owner.** Looks up what they hold and renders the record instead of the form, leading with whether it points anywhere — which for 16 of 20 names it does not.

**2. A rejected claim names the name.** `/api/claim` already had `ownerIndex` in scope before rejecting; it now returns it, so the message becomes *"You already own `lucas`.runs-on.dev"* with a button through to `/manage`.

## Verified

```
anonymous                 panel=—      signin_btn=True   claim_btn=False  cta=—
signed in, owns nothing   panel=—      signin_btn=False  claim_btn=True   cta=—
owns ali (no records)     panel=ali    signin_btn=False  claim_btn=False  cta=Point it somewhere →
owns lucas (URL record)   panel=lucas  signin_btn=False  claim_btn=False  cta=Edit your record →

POST /api/claim (eligible, already owns) → 403 {"error":"limit_reached","owned":["lucas"]}
```

## Cost

Two GitHub reads per **signed-in** homepage view, gated on session so anonymous traffic never pays it. The page already rendered dynamically (it reads cookies), so no caching is given up. Fails soft to the claim form.