### PR TITLE
Ration record writes, and fix the dead your-page links

### DIFF
--- a/app/api/records/route.js
+++ b/app/api/records/route.js
@@ -1,9 +1,17 @@
 import { sessionFromRequest } from '../../../lib/session.js';
-import { validateEdit } from '../../../lib/edit.js';
+import { validateEdit, isUnchanged } from '../../../lib/edit.js';
+import { createRateLimiter } from '../../../lib/throttle.js';
 import { getContentsMeta, putRecordUpdate } from '../../../lib/registry.js';
 import { validateName } from '../../../lib/name.js';
 
 const TOKEN = () => process.env.REGISTRY_TOKEN;
+
+// Generous enough that editing a record, looking at it, and editing again
+// never trips it; tight enough that a leaned-on button cannot spend the
+// registry's shared GitHub quota or fire a DNS sync per commit indefinitely.
+const WRITE_WINDOW_MS = 10 * 60 * 1000;
+const WRITE_MAX = 12;
+const takeWrite = createRateLimiter({ windowMs: WRITE_WINDOW_MS, max: WRITE_MAX });
 
 const BUSY_RESPONSE = () =>
   Response.json({ error: 'busy', retryInMs: 4000 }, { status: 503, headers: { 'Retry-After': '4' } });
@@ -25,6 +33,18 @@ export async function POST(request) {
   const name = typeof body.name === 'string' ? body.name.trim().toLowerCase() : '';
   if (!validateName(name).ok) {
     return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+
+  // Ahead of the registry read, not just the write: both spend REGISTRY_TOKEN
+  // quota, which is the same pool /api/claim draws on. Rationing only the
+  // write would still let a loop starve claiming through reads alone.
+  const budget = takeWrite(session.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
   }
 
   let meta;
@@ -49,6 +69,18 @@ export async function POST(request) {
     const empty = subs === null || (typeof subs === 'object' && Object.keys(subs).length === 0);
     if (empty) delete head.subdomains;
     else head.subdomains = subs;
+  }
+
+  // Nothing to do. Answering before the ownership check would leak whether a
+  // record exists in the shape someone guessed, so this sits after the read
+  // but the ownership check below still runs first for a non-owner: a no-op
+  // submitted against someone else's record is refused, not reported as fine.
+  if (isUnchanged(meta.data, head)) {
+    const owns = validateEdit({ base: meta.data, head, editor: session.login });
+    if (!owns.ok) {
+      return Response.json({ error: 'not_owner', details: owns.errors }, { status: 403 });
+    }
+    return Response.json({ updated: name, unchanged: true, commit: null });
   }
 
   const decision = validateEdit({ base: meta.data, head, editor: session.login });

--- a/app/claim-form.jsx
+++ b/app/claim-form.jsx
@@ -274,7 +274,9 @@ function Claimed({ name, commit }) {
         </a>
         <a
           className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
-          href={`/sites/${name}`}
+          href={`https://${name}.runs-on.dev`}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           your page →
         </a>

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -36,7 +36,9 @@ export default function RecordForm({ name, record }) {
 
     if (res.ok) {
       setCommit(body.commit ?? null);
-      setStatus('saved');
+      // A save that changed nothing is not a commit and does not touch DNS,
+      // so it must not claim to have done either.
+      setStatus(body.unchanged ? 'unchanged' : 'saved');
       return;
     }
     setErrors(body.details ?? [MESSAGES[body.error] ?? 'Could not save just now.']);
@@ -108,8 +110,14 @@ export default function RecordForm({ name, record }) {
           className="border px-5 py-2.5 font-(family-name:--font-mono) text-sm transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}
         >
-          {status === 'saving' ? 'Saving…' : 'Save record'}
+          {status === 'saving' ? 'Saving\u2026' : 'Save record'}
         </button>
+
+        {status === 'unchanged' && (
+          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+            {'// no changes to save'}
+          </p>
+        )}
 
         {status === 'saved' && (
           <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
@@ -139,6 +147,7 @@ const MESSAGES = {
   not_found: 'That record no longer exists.',
   stale: 'This record changed somewhere else while you were editing. Reload and try again.',
   busy: 'The registry is busy. Try again in a few seconds.',
+  rate_limited: 'That is a lot of saves in a short window. Give it a few minutes.',
   invalid_name: 'That name is not valid.',
   server_error: 'Could not save just now.',
 };

--- a/app/owned-name.jsx
+++ b/app/owned-name.jsx
@@ -51,7 +51,9 @@ export default function OwnedName({ name, record }) {
         </a>
         <a
           className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
-          href={`/sites/${name}`}
+          href={`https://${name}.runs-on.dev`}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           your page →
         </a>

--- a/lib/edit.js
+++ b/lib/edit.js
@@ -52,3 +52,25 @@ export function validateEdit({ base, head, editor }) {
 
   return { ok: errors.length === 0, errors };
 }
+
+// Key order in a JSON object carries no meaning, but the client rebuilds the
+// records object from form fields and can hand back the same record with its
+// keys in a different order. Comparing canonically keeps that from reading as
+// a change. Arrays stay in order: the order of A records or MX entries is
+// part of what the owner wrote, so reordering them is a real edit.
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value).sort().map((k) => [k, canonical(value[k])]),
+    );
+  }
+  return value;
+}
+
+// True when committing `head` would produce a file identical to `base`. A save
+// that changes nothing should not become a commit, a DNS sync, and a line in
+// the log -- which is what a double-clicked button or a stuck retry produces.
+export function isUnchanged(base, head) {
+  return JSON.stringify(canonical(base)) === JSON.stringify(canonical(head));
+}

--- a/lib/throttle.js
+++ b/lib/throttle.js
@@ -1,0 +1,44 @@
+// A best-effort per-key write limiter, held in memory.
+//
+// Be clear about what this is and is not. Instances are not shared, so a
+// determined caller spreading requests across cold starts gets a fresh
+// allowance each time -- this is not an authorization boundary and must never
+// be the only thing standing between a caller and something expensive.
+// Fluid Compute reuses warm instances, so it does reliably stop the realistic
+// case: one client looping against one instance, which is what a stuck retry
+// or a leaned-on button actually looks like.
+//
+// The durable protections live elsewhere: ownership is checked on every write,
+// the record is schema-validated before it is committed, and the sha makes a
+// stale write fail rather than clobber. This only caps how fast a legitimate
+// owner can spend shared quota.
+const MAX_KEYS = 5000;
+
+export function createRateLimiter({ windowMs, max }) {
+  const hits = new Map();
+
+  return function take(key, now = Date.now()) {
+    const cutoff = now - windowMs;
+
+    // Sweep before inserting, not on a timer: a serverless instance may be
+    // frozen between requests, so a timer is not a thing that reliably runs.
+    if (hits.size > MAX_KEYS) {
+      for (const [k, times] of hits) {
+        const live = times.filter((t) => t > cutoff);
+        if (live.length === 0) hits.delete(k);
+        else hits.set(k, live);
+      }
+    }
+
+    const times = (hits.get(key) ?? []).filter((t) => t > cutoff);
+
+    if (times.length >= max) {
+      // Oldest hit in the window is the one that has to age out.
+      return { ok: false, retryAfterMs: Math.max(0, times[0] + windowMs - now) };
+    }
+
+    times.push(now);
+    hits.set(key, times);
+    return { ok: true, remaining: max - times.length };
+  };
+}

--- a/test/edit.test.mjs
+++ b/test/edit.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateEdit, sameLogin } from '../lib/edit.js';
+import { validateEdit, sameLogin, isUnchanged } from '../lib/edit.js';
 
 const base = {
   name: 'lucas',
@@ -80,4 +80,31 @@ test('sameLogin ignores case and rejects non-strings', () => {
   assert.equal(sameLogin('Zyaxxy', 'zyaxxy'), true);
   assert.equal(sameLogin(undefined, 'zyaxxy'), false);
   assert.equal(sameLogin('zyaxxy', null), false);
+});
+
+test('isUnchanged ignores key order but not value order', () => {
+  const a = { name: 'lucas', records: { A: ['1.2.3.4', '5.6.7.8'], TXT: ['hi'] } };
+  const reordered = { records: { TXT: ['hi'], A: ['1.2.3.4', '5.6.7.8'] }, name: 'lucas' };
+  assert.equal(isUnchanged(a, reordered), true);
+
+  // Reordering A entries is a real edit: the order is what the owner wrote.
+  const swapped = { name: 'lucas', records: { A: ['5.6.7.8', '1.2.3.4'], TXT: ['hi'] } };
+  assert.equal(isUnchanged(a, swapped), false);
+});
+
+test('isUnchanged sees an actual record change', () => {
+  const base = { name: 'lucas', records: {} };
+  assert.equal(isUnchanged(base, { name: 'lucas', records: { CNAME: 'x.example.com' } }), false);
+  assert.equal(isUnchanged(base, { name: 'lucas', records: {} }), true);
+});
+
+test('isUnchanged notices an added or removed subdomains key', () => {
+  const base = { name: 'lucas', records: {} };
+  assert.equal(isUnchanged(base, { ...base, subdomains: { _atproto: { TXT: ['x'] } } }), false);
+});
+
+test('isUnchanged handles nested MX objects', () => {
+  const mx = { name: 'l', records: { MX: [{ priority: 10, value: 'mx.example.com' }] } };
+  const same = { name: 'l', records: { MX: [{ value: 'mx.example.com', priority: 10 }] } };
+  assert.equal(isUnchanged(mx, same), true);
 });

--- a/test/throttle.test.mjs
+++ b/test/throttle.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRateLimiter } from '../lib/throttle.js';
+
+test('allows up to max within the window', () => {
+  const take = createRateLimiter({ windowMs: 1000, max: 3 });
+  assert.equal(take('a', 0).ok, true);
+  assert.equal(take('a', 1).ok, true);
+  assert.equal(take('a', 2).ok, true);
+  assert.equal(take('a', 3).ok, false);
+});
+
+test('keys are independent, so one account cannot throttle another', () => {
+  const take = createRateLimiter({ windowMs: 1000, max: 1 });
+  assert.equal(take('a', 0).ok, true);
+  assert.equal(take('a', 1).ok, false);
+  assert.equal(take('b', 1).ok, true);
+});
+
+test('allowance returns as the window slides', () => {
+  const take = createRateLimiter({ windowMs: 1000, max: 2 });
+  take('a', 0);
+  take('a', 500);
+  assert.equal(take('a', 900).ok, false);
+  // The hit at t=0 has aged out by t=1001.
+  assert.equal(take('a', 1001).ok, true);
+});
+
+test('reports how long until the next slot frees up', () => {
+  const take = createRateLimiter({ windowMs: 1000, max: 1 });
+  take('a', 0);
+  const denied = take('a', 400);
+  assert.equal(denied.ok, false);
+  assert.equal(denied.retryAfterMs, 600);
+});
+
+test('retryAfterMs is never negative', () => {
+  const take = createRateLimiter({ windowMs: 1000, max: 1 });
+  take('a', 0);
+  assert.ok(take('a', 0).retryAfterMs >= 0);
+});
+
+test('does not grow without bound', () => {
+  const take = createRateLimiter({ windowMs: 10, max: 1 });
+  // Every key ages out well before the sweep threshold is crossed.
+  for (let i = 0; i < 6000; i += 1) take(`k${i}`, 1_000_000 + i);
+  assert.equal(take('fresh', 2_000_000).ok, true);
+});


### PR DESCRIPTION
## Hardening `/api/records`

It was an unmetered write endpoint. Every call spends `REGISTRY_TOKEN` quota — the same pool `/api/claim` draws on — and every successful one is a commit, a `sync-dns` run, and a DNS API write.

**1. A no-op no longer writes.** If the submitted record would produce a file identical to what's committed, it returns without writing. Covers the realistic case: a double-clicked button, a stuck retry.

```
POST /api/records  (owner, record unchanged)      → 200 {"updated":"lucas","unchanged":true,"commit":null}
POST /api/records  (non-owner, record unchanged)  → 403 only the owner (@zordhalo) may change this record
```

Ownership is still checked first, so a no-op aimed at someone else's record is refused rather than reported fine.

**2. Twelve writes per 10 minutes per account.**

```
requests 1–12  → processed
request  13    → 429  Retry-After: 600  {"error":"rate_limited","retryInMs":599008}
```

Checked **ahead of the registry read**, not just the write, because reads spend the same quota — rationing only writes would still let a loop starve claiming.

### What this limiter is not

In-memory, so instances are not shared and a caller spreading requests across cold starts gets a fresh allowance. **It is not an authorization boundary.** The durable protections are unchanged: ownership checked on every write, schema validated before commit, `sha` making a stale write fail rather than clobber. This only caps how fast a legitimate owner can spend shared quota — which is the actual risk.

## The dead links

`proxy.js:14` refuses `/sites/*` from the outside on every host by design; the card is only reachable through the internal rewrite from the name's own subdomain. So `"your page →"` pointed at a guaranteed 404:

```
https://runs-on.dev/sites/lucas   HTTP 404
https://lucas.runs-on.dev/        HTTP 307 → advancelabs.dev/lucas
```

Both links now point at `https://<name>.runs-on.dev`. **One of them predates the record editor** (`27ab2f0`), so every claimant since has been handed a broken link on the success screen.

## Tests

159 → 169. New coverage for the limiter (window sliding, key independence, `retryAfterMs`, unbounded growth) and for `isUnchanged` (key order ignored, array order respected, nested MX objects).