### PR TITLE
Document Vercel domain verification, which the guide never mentioned

### DIFF
--- a/app/docs/guides/vercel/page.jsx
+++ b/app/docs/guides/vercel/page.jsx
@@ -1,5 +1,5 @@
 import { Section } from '../../../components/Section.jsx';
-import { ApplyNote, C, DocTitle, Eyebrow, Lede, Record } from '../../components.jsx';
+import { ApplyNote, C, DocTitle, Eyebrow, Lede, Record, Warning } from '../../components.jsx';
 
 export const metadata = {
   title: 'Vercel',
@@ -18,8 +18,11 @@ export default function VercelGuide() {
       <Section title="The record">
         <Record path="domains/you.json">{`"records": { "CNAME": "cname.vercel-dns.com" }`}</Record>
         <p className="text-sm leading-relaxed sm:text-base">
-          <C>cname.vercel-dns.com</C> is the fixed target Vercel uses for every custom domain, not
-          something specific to your project.
+          <C>cname.vercel-dns.com</C> is the target Vercel gives most projects. Some accounts get a
+          project-specific one instead, of the form{' '}
+          <C>&lt;hash&gt;.vercel-dns-017.com</C>. Copy whatever your own Domains tab shows rather
+          than the value above, and leave off any trailing dot: <C>example.com.</C> fails the
+          hostname grammar, <C>example.com</C> passes.
         </p>
       </Section>
 
@@ -31,17 +34,48 @@ export default function VercelGuide() {
           <li>Open a pull request. Once merged, the CNAME is synced to DNS automatically.</li>
           <li>
             In the Vercel dashboard: your project → Settings → Domains → add{' '}
-            <C>you.runs-on.dev</C>. Vercel shows this exact <C>cname.vercel-dns.com</C> target when
-            it asks you to configure DNS, confirming there is nothing else to add.
+            <C>you.runs-on.dev</C>. Vercel then shows you the DNS it wants. Usually that is the
+            CNAME alone. If it also shows a <C>TXT</C> record, read the next section before adding
+            anything.
           </li>
         </ol>
+      </Section>
+
+      <Section title="If Vercel also asks for a verification TXT">
+        <p className="text-sm leading-relaxed sm:text-base">
+          Vercel sometimes asks you to prove you control the domain, and shows a <C>TXT</C> record
+          whose value starts with <C>vc-domain-verify=</C>. It belongs at{' '}
+          <C>_vercel.you.runs-on.dev</C>, one label below your name, which is what the{' '}
+          <C>subdomains</C> key is for:
+        </p>
+        <Record path="domains/you.json">{`{
+  "records": { "CNAME": "cname.vercel-dns.com" },
+  "subdomains": {
+    "_vercel": {
+      "TXT": ["vc-domain-verify=you.runs-on.dev,abc123"]
+    }
+  }
+}`}</Record>
+        <Warning>
+          Do not put that <C>TXT</C> beside the <C>CNAME</C> in <C>records</C>. A name carrying a{' '}
+          <C>CNAME</C> cannot carry any other record type, which is a DNS rule rather than something
+          this registry chose, and the record will be rejected. Under <C>subdomains</C> it is a
+          different name, so the two coexist happily.
+        </Warning>
+        <p className="text-sm leading-relaxed sm:text-base">
+          A <C>subdomains</C> entry is the one thing{' '}
+          <a className="text-(--color-signal) underline" href="/manage">the record form</a> cannot
+          set yet, so this case needs a pull request.
+        </p>
       </Section>
 
       <Section title="How to tell it worked">
         <p className="text-sm leading-relaxed sm:text-base">
           The Domains tab in Vercel shows a green &quot;Valid Configuration&quot; once DNS has
-          propagated and the certificate is issued, usually within a few minutes of the pull request
-          merging. Visiting <C>https://you.runs-on.dev</C> should then serve your project.
+          propagated and the certificate is issued, usually within a few minutes of the record
+          landing. Visiting <C>https://you.runs-on.dev</C> should then serve your project. If it
+          stays on &quot;Invalid Configuration&quot;, check the CNAME target character for character
+          against what the Domains tab shows.
         </p>
       </Section>
     </main>

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -43,10 +43,24 @@ few seconds. Full walkthrough: [`/docs/guides/url-redirect`](https://runs-on.dev
 ```
 
 Add `you.runs-on.dev` as a custom domain on the Vercel project (Project →
-Settings → Domains); Vercel shows this exact CNAME target. Fork the
-registry, set the record, open a pull request. Once the CNAME syncs, the
-Domains tab shows the domain verified and issues its own certificate.
-Full walkthrough: [`/docs/guides/vercel`](https://runs-on.dev/docs/guides/vercel).
+Settings → Domains), then set the record to whatever target the Domains tab
+shows you. Most projects get `cname.vercel-dns.com`; some accounts get a
+project-specific `<hash>.vercel-dns-017.com` instead. Leave off any trailing
+dot. Once the CNAME syncs, the Domains tab issues its own certificate.
+
+If Vercel also shows a TXT record starting `vc-domain-verify=`, it goes at
+`_vercel`, one label below your name, not beside the CNAME:
+
+```json
+{
+  "records": { "CNAME": "cname.vercel-dns.com" },
+  "subdomains": { "_vercel": { "TXT": ["vc-domain-verify=you.runs-on.dev,abc123"] } }
+}
+```
+
+`CNAME` cannot coexist with `TXT` at the same name, so putting it in
+`records` is rejected. Full walkthrough:
+[`/docs/guides/vercel`](https://runs-on.dev/docs/guides/vercel).
 
 ## Netlify
 


### PR DESCRIPTION
## Two false claims

The guide said `cname.vercel-dns.com` is:

> the fixed target Vercel uses for every custom domain, not something specific to your project

and that seeing it confirms:

> there is nothing else to add

Both are wrong, and both sent @theonlyhussain the wrong way in #4.

## The evidence

All three Vercel records on the registry:

| name | CNAME target | verification |
| --- | --- | --- |
| `dexi` | `cname.vercel-dns.com` | none |
| `shrey` | `cname.vercel-dns.com` | none |
| `hussain` | `e7a81f500a55fdf8.vercel-dns-017.com` | `_vercel` TXT |

So neither outcome is universal. The guide now describes both rather than asserting either.

## What #4 got wrong because of this

A project-specific target written with its trailing dot (fails the hostname grammar), and the `vc-domain-verify` TXT placed beside the CNAME in `records` — where DNS forbids it and the schema rejects it. The value was correct; only its address was wrong:

```json
{
  "records": { "CNAME": "cname.vercel-dns.com" },
  "subdomains": {
    "_vercel": { "TXT": ["vc-domain-verify=you.runs-on.dev,abc123"] }
  }
}
```

Same shape the Railway guide already describes for the same situation. Verified against `validateRecord` — the documented example passes.

## Also

- Warns about the trailing dot explicitly.
- Notes `subdomains` is the one thing `/manage` cannot set, so this case still needs a PR.
- "Invalid Configuration" troubleshooting points at comparing the target character for character.
- `docs/guides.md` updated to match.