### PR TITLE
sync-dns: add a manual repair trigger

### DIFF
--- a/.github/workflows/sync-dns.yml
+++ b/.github/workflows/sync-dns.yml
@@ -4,9 +4,27 @@ on:
   push:
     branches: [main]
     paths: ['domains/**']
+  # A push only ever syncs the names that push touched, so a run that fails
+  # leaves those names stale with no way back: re-running it checks out the
+  # original commit, which is the code that just failed. This is the repair
+  # path. Names are required rather than defaulting to "all" -- deleteStale
+  # runs before the creates, so a full resync would drop every name's DNS for
+  # the length of the run.
+  workflow_dispatch:
+    inputs:
+      names:
+        description: 'Names to re-sync, space or comma separated (e.g. "laurentmaxhuni dexi")'
+        required: true
+        type: string
 
 permissions:
   contents: read
+
+# A manual repair run and an automatic push run touching the same name would
+# race: both list the zone, then both delete what the other just created.
+concurrency:
+  group: sync-dns
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -19,7 +37,45 @@ jobs:
         with:
           node-version: '22'
       - id: changed
+        env:
+          # Via the environment, never interpolated into the script body: a
+          # `${{ ... }}` expansion inside `run:` is substituted before bash sees
+          # it, so a crafted dispatch input would be executed rather than read.
+          DISPATCH_NAMES: ${{ inputs.names }}
         run: |
+          if [ "${{ github.event_name }}" = 'workflow_dispatch' ]; then
+            if [ -z "$DISPATCH_NAMES" ]; then
+              echo '::error::names input is required'
+              exit 1
+            fi
+
+            # Word-splitting the input is wanted; globbing it is not. Left
+            # unquoted without this, a dispatch of `*` expands against the
+            # checkout into `app lib data docs test ...` -- all shaped like
+            # claimable names, none of them files under domains/, so
+            # sync-dns.mjs would take its "record removed" branch and delete
+            # the DNS of whoever owns those names.
+            set -f
+            NAMES=$(printf '%s' "$DISPATCH_NAMES" | tr ',' ' ')
+
+            # Validate before emitting anything. sync-dns.mjs silently skips a
+            # path that misses its ^domains/([a-z0-9-]+)\.json$ guard, so a typo
+            # -- "Dexi", "dexi.json" -- would otherwise produce a green run that
+            # synced nothing and looked like a repair.
+            for name in $NAMES; do
+              case "$name" in
+                *[!a-z0-9-]*) echo "::error::not a claimable name: $name"; exit 1 ;;
+              esac
+            done
+
+            echo 'files<<EOF' >> $GITHUB_OUTPUT
+            for name in $NAMES; do
+              echo "domains/$name.json" >> $GITHUB_OUTPUT
+            done
+            echo 'EOF' >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Diff the whole push range, not HEAD^..HEAD. Actions fires one push event per
           # push, not per commit, so a rebase-merge or a batch of merges lands several
           # commits at once and HEAD^..HEAD would silently skip every domains/ file touched

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -22,6 +22,13 @@ export default async function Footer() {
           .
         </p>
         <p className="mt-2 font-(family-name:--font-mono) text-xs text-(--color-muted)">
+          Curious how it's going?{' '}
+          <a className="text-(--color-signal) underline" href="/stats">
+            See the numbers
+          </a>
+          .
+        </p>
+        <p className="mt-2 font-(family-name:--font-mono) text-xs text-(--color-muted)">
           Every name here is a file in a public repo.{' '}
           <a
             className="text-(--color-signal) underline"

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -22,10 +22,15 @@ export default function sitemap() {
     '/docs/guides/discord-verification',
   ];
 
+  // The pages that actually change. /stats is regenerated from the registry on
+  // every claim, so a monthly hint understates it by the widest margin of any
+  // route here; the rest are prose that changes when someone edits it.
+  const fresh = new Set(['', '/stats']);
+
   return routes.map((route) => ({
     url: `https://runs-on.dev${route}`,
     lastModified: now,
-    changeFrequency: route === '' ? 'weekly' : 'monthly',
+    changeFrequency: fresh.has(route) ? 'weekly' : 'monthly',
     priority: route === '' ? 1 : 0.6,
   }));
 }

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -4,7 +4,7 @@
 export default function sitemap() {
   const now = new Date();
   const routes = [
-    '', '/about', '/faq', '/policy',
+    '', '/about', '/faq', '/policy', '/stats',
     '/docs', '/docs/quickstart', '/docs/records', '/docs/seo', '/docs/resources',
     '/docs/guides',
     '/docs/guides/url-redirect',

--- a/app/stats/growth-chart.jsx
+++ b/app/stats/growth-chart.jsx
@@ -1,0 +1,65 @@
+// A step line, not a smooth curve: the total holds flat until a name is
+// claimed, then jumps. Interpolating between points would draw growth on days
+// nothing happened, which is exactly the lie a registry chart shouldn't tell.
+//
+// Hand-rolled SVG rather than a chart library. The dataset is one small array
+// of {date, total}, the marks are two paths, and inline SVG picks up the theme
+// tokens directly -- so a charting dependency would cost more than it saves.
+
+const W = 720;
+const H = 200;
+const PAD = 8;
+
+export function GrowthChart({ series }) {
+  if (series.length < 2) return null;
+
+  const max = series[series.length - 1].total;
+  const span = W - PAD * 2;
+  const x = (i) => PAD + (i / (series.length - 1)) * span;
+  const y = (total) => H - PAD - (total / Math.max(max, 1)) * (H - PAD * 2);
+
+  let line = `M ${x(0)} ${y(series[0].total)}`;
+  for (let i = 1; i < series.length; i += 1) {
+    line += ` H ${x(i)} V ${y(series[i].total)}`;
+  }
+  const area = `${line} V ${H - PAD} H ${x(0)} Z`;
+
+  const first = series[0].date;
+  const last = series[series.length - 1].date;
+
+  return (
+    <figure className="mt-4">
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        className="h-auto w-full"
+        role="img"
+        aria-label={`Cumulative names claimed, ${first} to ${last}, ending at ${max}`}
+      >
+        <line
+          x1={PAD}
+          y1={H - PAD}
+          x2={W - PAD}
+          y2={H - PAD}
+          stroke="var(--rule)"
+          strokeWidth="1"
+        />
+        <path d={area} fill="var(--signal)" fillOpacity="0.08" />
+        <path
+          d={line}
+          fill="none"
+          stroke="var(--signal)"
+          strokeWidth="2"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      <figcaption className="mt-2 flex justify-between font-(family-name:--font-mono) text-xs text-(--color-muted)">
+        <span>{first}</span>
+        <span>
+          {max} name{max === 1 ? '' : 's'}
+        </span>
+        <span>{last}</span>
+      </figcaption>
+    </figure>
+  );
+}

--- a/app/stats/page.jsx
+++ b/app/stats/page.jsx
@@ -1,0 +1,144 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Section } from '../components/Section.jsx';
+import { summarize } from '../../lib/stats.js';
+import { GrowthChart } from './growth-chart.jsx';
+
+export const metadata = {
+  title: 'Stats',
+  description:
+    'How many names have been claimed on runs-on.dev, by whom, and what people point them at. Counted straight from the public registry.',
+  alternates: { canonical: 'https://runs-on.dev/stats' },
+  openGraph: { title: 'Stats — runs-on.dev' },
+};
+
+// Read at build time, never per request. Deploys run from GitHub Actions on
+// merge to main, so a claim and this page's rebuild are the same event -- the
+// numbers are never more than one merge stale. Reading `domains/` off disk
+// also keeps the page off the GitHub API entirely, which matters because the
+// wildcard makes that quota trivially easy to exhaust (see app/sites).
+export const dynamic = 'force-static';
+
+function readRegistry() {
+  const dir = join(process.cwd(), 'domains');
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(readFileSync(join(dir, f), 'utf8')));
+}
+
+const USAGE_LABELS = {
+  card: 'Profile card',
+  cname: 'Pointed at a host',
+  url: 'Redirect to a URL',
+  advanced: 'Custom DNS records',
+};
+
+function Stat({ label, value }) {
+  return (
+    <div className="border border-(--color-rule) bg-(--color-card) p-4">
+      <div className="font-(family-name:--font-display) text-3xl font-medium tracking-tight text-(--color-ink)">
+        {value}
+      </div>
+      <div className="mt-1 font-(family-name:--font-mono) text-xs tracking-[0.08em] text-(--color-muted) uppercase">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function day(iso) {
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+export default function Stats() {
+  const stats = summarize(readRegistry());
+  const usage = Object.entries(stats.usage).filter(([, count]) => count > 0);
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="font-(family-name:--font-display) text-3xl font-medium tracking-tight text-(--color-ink) sm:text-4xl">
+        Stats
+      </h1>
+      <p className="mt-4 text-sm leading-relaxed text-(--color-muted)">
+        Every name here is a file in a public repo, so these numbers are just that repo
+        counted. Nothing is estimated and nothing is tracked about visitors.
+      </p>
+
+      <Section title="Where things stand">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <Stat label="Names claimed" value={stats.total} />
+          <Stat label="People" value={stats.owners} />
+          <Stat label="Claimed this week" value={stats.claimedThisWeek} />
+        </div>
+      </Section>
+
+      {stats.cumulative.length > 1 && (
+        <Section title="Names claimed over time">
+          <GrowthChart series={stats.cumulative} />
+        </Section>
+      )}
+
+      {usage.length > 0 && (
+        <Section title="What people do with them">
+          <ul className="divide-y divide-(--color-rule) border border-(--color-rule) bg-(--color-card)">
+            {usage
+              .sort((a, b) => b[1] - a[1])
+              .map(([mode, count]) => (
+                <li key={mode} className="flex items-baseline justify-between px-4 py-3">
+                  <span className="text-sm text-(--color-ink)">{USAGE_LABELS[mode]}</span>
+                  <span className="font-(family-name:--font-mono) text-sm text-(--color-muted)">
+                    {count}
+                  </span>
+                </li>
+              ))}
+          </ul>
+        </Section>
+      )}
+
+      {stats.hosts.length > 0 && (
+        <Section title="Where the sites are hosted">
+          <ul className="divide-y divide-(--color-rule) border border-(--color-rule) bg-(--color-card)">
+            {stats.hosts.map((host) => (
+              <li
+                key={host.provider}
+                className="flex items-baseline justify-between px-4 py-3"
+              >
+                <span className="text-sm text-(--color-ink)">{host.provider}</span>
+                <span className="font-(family-name:--font-mono) text-sm text-(--color-muted)">
+                  {host.count}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs leading-relaxed text-(--color-muted)">
+            Counted from CNAME targets. Anything self-hosted or unrecognised is
+            &ldquo;Other&rdquo; &mdash; the hostname stays out of it.
+          </p>
+        </Section>
+      )}
+
+      {stats.recent.length > 0 && (
+        <Section title="Recently claimed">
+          <ul className="divide-y divide-(--color-rule) border border-(--color-rule) bg-(--color-card)">
+            {stats.recent.map((claim) => (
+              <li
+                key={claim.name}
+                className="flex flex-wrap items-baseline justify-between gap-x-3 px-4 py-3"
+              >
+                <a
+                  className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
+                  href={`https://${claim.name}.runs-on.dev`}
+                >
+                  {claim.name}.runs-on.dev
+                </a>
+                <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+                  @{claim.github} · {day(claim.claimedAt)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+    </main>
+  );
+}

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -21,3 +21,25 @@ export function planDnsChanges(record) {
 
   return changes;
 }
+
+// Vercel's DNS REST endpoints, kept here rather than inline in the sync script
+// so the paths themselves are under test. The delete path is the reason: it is
+// `/v2/domains/{domain}/records/{recordId}`, and a version missing the
+// `{domain}` segment returns 404 for every record that exists, which reads as
+// "already gone" but is really "wrong URL".
+//
+// Listing stays on v4 deliberately. v5 is current, but v4 is what this zone has
+// been paginated with in production; moving versions is a separate, verifiable
+// change and not part of fixing the delete.
+export function listPath(domain, cursor = '') {
+  const base = `/v4/domains/${domain}/records?limit=100`;
+  return cursor ? `${base}&until=${cursor}` : base;
+}
+
+export function createPath(domain) {
+  return `/v2/domains/${domain}/records`;
+}
+
+export function removePath(domain, recordId) {
+  return `/v2/domains/${domain}/records/${encodeURIComponent(recordId)}`;
+}

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,0 +1,129 @@
+// Aggregation for the public /stats page. Pure functions over an array of
+// already-parsed registry records: no fs, no fetch, no Next. The page reads
+// `domains/` off disk at build time and hands the array in, which keeps the
+// arithmetic testable on its own rather than only reachable by rendering.
+import { modeOf } from './record-fields.js';
+
+const DAY = 86_400_000;
+
+// UTC throughout. `claimedAt` is written as an ISO instant by the claim API,
+// and a growth curve that shifts a claim into a different bucket depending on
+// where the build machine sits is a curve nobody can reconcile with the repo.
+function dayOf(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function claimDate(record) {
+  const ms = Date.parse(record?.claimedAt);
+  return Number.isNaN(ms) ? null : new Date(ms);
+}
+
+export function summarize(records = [], { now = new Date(), recentLimit = 8 } = {}) {
+  const list = Array.isArray(records) ? records : [];
+
+  const owners = new Set();
+  const usage = { card: 0, cname: 0, url: 0, advanced: 0 };
+  const hosts = new Map();
+  const dated = [];
+
+  for (const record of list) {
+    const login = record?.owner?.github;
+    if (typeof login === 'string' && login) owners.add(login.toLowerCase());
+
+    usage[modeOf(record?.records ?? {})] += 1;
+
+    const provider = providerFor(record?.records ?? {});
+    if (provider) hosts.set(provider, (hosts.get(provider) ?? 0) + 1);
+
+    // schema.js already rejects an unparseable claimedAt, so this guard only
+    // fires on a record that reached disk some other way. It stays counted in
+    // `total` -- the name is claimed either way -- but it can't be placed on a
+    // timeline, so it sits out of the curve rather than landing on epoch zero.
+    const at = claimDate(record);
+    if (at) dated.push({ record, at });
+  }
+
+  dated.sort((a, b) => a.at - b.at);
+
+  const weekAgo = now.getTime() - 7 * DAY;
+
+  return {
+    total: list.length,
+    owners: owners.size,
+    claimedThisWeek: dated.filter(({ at }) => at.getTime() >= weekAgo).length,
+    first: dated.length ? dated[0].record.claimedAt : null,
+    latest: dated.length ? dated[dated.length - 1].record.claimedAt : null,
+    cumulative: cumulativeSeries(dated, now),
+    usage,
+    // Busiest first, ties alphabetical, so the order is stable between builds
+    // rather than following whatever order readdir happened to return.
+    hosts: [...hosts]
+      .map(([provider, count]) => ({ provider, count }))
+      .sort((a, b) => b.count - a.count || a.provider.localeCompare(b.provider)),
+    recent: dated
+      .slice(-recentLimit)
+      .reverse()
+      .map(({ record }) => ({
+        name: record.name,
+        github: record.owner.github,
+        claimedAt: record.claimedAt,
+      })),
+  };
+}
+
+// One point per day from the first claim through today, including the days
+// nothing happened. A sparse series would draw a straight line between two
+// distant claims and imply steady growth that never occurred; a flat step is
+// the honest shape.
+function cumulativeSeries(dated, now) {
+  if (!dated.length) return [];
+
+  const perDay = new Map();
+  for (const { at } of dated) {
+    const key = dayOf(at);
+    perDay.set(key, (perDay.get(key) ?? 0) + 1);
+  }
+
+  const out = [];
+  let running = 0;
+  const end = Date.parse(`${dayOf(now)}T00:00:00.000Z`);
+  for (let t = Date.parse(`${dayOf(dated[0].at)}T00:00:00.000Z`); t <= end; t += DAY) {
+    const date = dayOf(new Date(t));
+    const claims = perDay.get(date) ?? 0;
+    running += claims;
+    out.push({ date, claims, total: running });
+  }
+  return out;
+}
+
+// Known CNAME targets, longest-suffix-first so `vercel-dns-017.com` doesn't
+// have to be enumerated separately from `vercel-dns.com`.
+const HOSTS = [
+  [/\.vercel-dns(-\d+)?\.com$/, 'Vercel'],
+  [/\.vercel\.app$/, 'Vercel'],
+  [/\.netlify\.app$/, 'Netlify'],
+  [/\.github\.io$/, 'GitHub Pages'],
+  [/\.pages\.dev$/, 'Cloudflare Pages'],
+  [/\.onrender\.com$/, 'Render'],
+  [/\.up\.railway\.app$/, 'Railway'],
+  [/\.web\.app$/, 'Firebase'],
+  [/\.firebaseapp\.com$/, 'Firebase'],
+  [/\.replit\.app$/, 'Replit'],
+  [/\.codeberg\.page$/, 'Codeberg Pages'],
+];
+
+export function providerFor(records = {}) {
+  const target = String(records?.CNAME ?? '').trim().toLowerCase().replace(/\.$/, '');
+  if (!target) return null;
+
+  for (const [pattern, label] of HOSTS) {
+    if (pattern.test(target)) return label;
+  }
+
+  // Deliberately not the target's apex domain. Showing `ingress.my-homelab.example`
+  // would be better data, but it publishes a self-hosting owner's infrastructure
+  // hostname on a page they never chose to appear on -- and the record exists so
+  // DNS can resolve it, not so this page can enumerate it. "Other" keeps the
+  // counts summing to the CNAME total without that trade.
+  return 'Other';
+}

--- a/scripts/sync-dns.mjs
+++ b/scripts/sync-dns.mjs
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { planDnsChanges } from '../lib/dns.js';
+import { planDnsChanges, listPath, createPath, removePath } from '../lib/dns.js';
 
 const DOMAIN = 'runs-on.dev';
 const TOKEN = process.env.VERCEL_TOKEN;
@@ -31,7 +31,7 @@ async function existingFor(name) {
   let cursor = '';
 
   for (;;) {
-    const res = await vercel(`/v4/domains/${DOMAIN}/records?limit=100${cursor}`);
+    const res = await vercel(listPath(DOMAIN, cursor));
     if (!res.ok) {
       console.error(`sync-dns: failed to list records for ${DOMAIN}: ${res.status} ${res.statusText}`);
       process.exit(1);
@@ -52,13 +52,13 @@ async function existingFor(name) {
 
     const next = body.pagination?.next;
     if (!next) return found;
-    cursor = `&until=${next}`;
+    cursor = next;
   }
 }
 
 async function deleteStale(name) {
   for (const stale of await existingFor(name)) {
-    const res = await vercel(`/v2/domains/records/${stale.id}`, { method: 'DELETE' });
+    const res = await vercel(removePath(DOMAIN, stale.id), { method: 'DELETE' });
     // A rejected delete must stop the sync here: continuing on to create the new
     // records would leave the stale ones live alongside them, with a green
     // workflow log claiming everything is in sync.
@@ -98,7 +98,7 @@ for (const file of changed) {
     // Vercel's records API takes MX priority as a separate field, not folded
     // into `value`.
     if (change.type === 'MX') body.mxPriority = change.priority;
-    const res = await vercel(`/v2/domains/${DOMAIN}/records`, {
+    const res = await vercel(createPath(DOMAIN), {
       method: 'POST',
       body: JSON.stringify(body),
     });

--- a/test/stats.test.mjs
+++ b/test/stats.test.mjs
@@ -1,0 +1,174 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { summarize, providerFor } from '../lib/stats.js';
+
+const at = (iso) => new Date(iso);
+
+function rec(over = {}) {
+  return {
+    name: 'a',
+    owner: { github: 'Someone' },
+    claimedAt: '2026-01-01T12:00:00.000Z',
+    records: {},
+    ...over,
+  };
+}
+
+test('an empty registry summarises to zeroes, not NaN or undefined', () => {
+  const s = summarize([], { now: at('2026-01-10T00:00:00.000Z') });
+  assert.equal(s.total, 0);
+  assert.equal(s.owners, 0);
+  assert.equal(s.claimedThisWeek, 0);
+  assert.equal(s.first, null);
+  assert.equal(s.latest, null);
+  assert.deepEqual(s.cumulative, []);
+  assert.deepEqual(s.recent, []);
+});
+
+test('counts names and owners, deduping logins case-insensitively', () => {
+  const s = summarize(
+    [
+      rec({ name: 'one', owner: { github: 'Zyaxxy' } }),
+      rec({ name: 'two', owner: { github: 'zyaxxy' } }),
+      rec({ name: 'three', owner: { github: 'lucas' } }),
+    ],
+    { now: at('2026-01-02T00:00:00.000Z') },
+  );
+  assert.equal(s.total, 3);
+  assert.equal(s.owners, 2);
+});
+
+test('cumulative is a dense daily series through today, so gaps read as flat', () => {
+  const s = summarize(
+    [
+      rec({ name: 'one', claimedAt: '2026-01-01T12:00:00.000Z' }),
+      rec({ name: 'two', claimedAt: '2026-01-04T12:00:00.000Z' }),
+    ],
+    { now: at('2026-01-05T09:00:00.000Z') },
+  );
+  assert.deepEqual(
+    s.cumulative,
+    [
+      { date: '2026-01-01', claims: 1, total: 1 },
+      { date: '2026-01-02', claims: 0, total: 1 },
+      { date: '2026-01-03', claims: 0, total: 1 },
+      { date: '2026-01-04', claims: 1, total: 2 },
+      { date: '2026-01-05', claims: 0, total: 2 },
+    ],
+  );
+});
+
+test('claims on the same day collapse into one bucket', () => {
+  const s = summarize(
+    [
+      rec({ name: 'one', claimedAt: '2026-01-01T00:30:00.000Z' }),
+      rec({ name: 'two', claimedAt: '2026-01-01T23:30:00.000Z' }),
+    ],
+    { now: at('2026-01-01T23:59:00.000Z') },
+  );
+  assert.deepEqual(s.cumulative, [{ date: '2026-01-01', claims: 2, total: 2 }]);
+});
+
+test('reports the first and latest claim timestamps', () => {
+  const s = summarize(
+    [
+      rec({ name: 'mid', claimedAt: '2026-01-04T12:00:00.000Z' }),
+      rec({ name: 'old', claimedAt: '2026-01-01T12:00:00.000Z' }),
+      rec({ name: 'new', claimedAt: '2026-01-06T12:00:00.000Z' }),
+    ],
+    { now: at('2026-01-07T00:00:00.000Z') },
+  );
+  assert.equal(s.first, '2026-01-01T12:00:00.000Z');
+  assert.equal(s.latest, '2026-01-06T12:00:00.000Z');
+});
+
+test('claimedThisWeek counts only the trailing seven days', () => {
+  const s = summarize(
+    [
+      rec({ name: 'recent', claimedAt: '2026-01-09T00:00:00.000Z' }),
+      rec({ name: 'old', claimedAt: '2026-01-01T00:00:00.000Z' }),
+    ],
+    { now: at('2026-01-10T00:00:00.000Z') },
+  );
+  assert.equal(s.claimedThisWeek, 1);
+});
+
+test('recent claims come back newest first, capped at the limit', () => {
+  const s = summarize(
+    [
+      rec({ name: 'a', claimedAt: '2026-01-01T00:00:00.000Z' }),
+      rec({ name: 'b', claimedAt: '2026-01-03T00:00:00.000Z' }),
+      rec({ name: 'c', claimedAt: '2026-01-02T00:00:00.000Z' }),
+    ],
+    { now: at('2026-01-04T00:00:00.000Z'), recentLimit: 2 },
+  );
+  assert.deepEqual(
+    s.recent,
+    [
+      { name: 'b', github: 'Someone', claimedAt: '2026-01-03T00:00:00.000Z' },
+      { name: 'c', github: 'Someone', claimedAt: '2026-01-02T00:00:00.000Z' },
+    ],
+  );
+});
+
+test('usage breaks names down by record mode, always with all four keys', () => {
+  const s = summarize(
+    [
+      rec({ name: 'card' }),
+      rec({ name: 'host', records: { CNAME: 'cname.vercel-dns.com' } }),
+      rec({ name: 'link', records: { URL: 'https://example.com' } }),
+    ],
+    { now: at('2026-01-02T00:00:00.000Z') },
+  );
+  assert.deepEqual(s.usage, { card: 1, cname: 1, url: 1, advanced: 0 });
+});
+
+test('a name with an unparseable claimedAt still counts but skips the curve', () => {
+  const s = summarize(
+    [
+      rec({ name: 'good', claimedAt: '2026-01-01T00:00:00.000Z' }),
+      rec({ name: 'broken', claimedAt: 'not a date' }),
+    ],
+    { now: at('2026-01-01T12:00:00.000Z') },
+  );
+  assert.equal(s.total, 2);
+  assert.deepEqual(s.cumulative, [{ date: '2026-01-01', claims: 1, total: 1 }]);
+});
+
+test('providerFor names the host behind a known CNAME target', () => {
+  assert.equal(providerFor({ CNAME: 'cname.vercel-dns.com' }), 'Vercel');
+  assert.equal(providerFor({ CNAME: 'e7a81f500a55fdf8.vercel-dns-017.com' }), 'Vercel');
+  assert.equal(providerFor({ CNAME: 'myapp.netlify.app' }), 'Netlify');
+  assert.equal(providerFor({ CNAME: 'user.github.io' }), 'GitHub Pages');
+  assert.equal(providerFor({ CNAME: 'site.pages.dev' }), 'Cloudflare Pages');
+});
+
+test('providerFor calls an unrecognised host Other, not by its hostname', () => {
+  assert.equal(providerFor({ CNAME: 'ingress.my-homelab.example' }), 'Other');
+  assert.equal(providerFor({ CNAME: 'fly.dev.' }), 'Other');
+});
+
+test('providerFor has nothing to say about a name with no CNAME', () => {
+  assert.equal(providerFor({}), null);
+  assert.equal(providerFor({ URL: 'https://example.com' }), null);
+  assert.equal(providerFor({ A: ['1.2.3.4'] }), null);
+});
+
+test('hosts counts CNAME targets by provider, busiest first', () => {
+  const s = summarize(
+    [
+      rec({ name: 'a', records: { CNAME: 'cname.vercel-dns.com' } }),
+      rec({ name: 'b', records: { CNAME: 'x.vercel-dns-017.com' } }),
+      rec({ name: 'c', records: { CNAME: 'site.netlify.app' } }),
+      rec({ name: 'd', records: { CNAME: 'ingress.my-homelab.example' } }),
+      rec({ name: 'e', records: { URL: 'https://example.com' } }),
+      rec({ name: 'f' }),
+    ],
+    { now: at('2026-01-02T00:00:00.000Z') },
+  );
+  assert.deepEqual(s.hosts, [
+    { provider: 'Vercel', count: 2 },
+    { provider: 'Netlify', count: 1 },
+    { provider: 'Other', count: 1 },
+  ]);
+});

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { planDnsChanges } from '../lib/dns.js';
+import { planDnsChanges, listPath, createPath, removePath } from '../lib/dns.js';
 
 const base = { name: 'lucas', owner: { github: 'zordhalo' }, claimedAt: '2026-08-30T00:00:00Z' };
 
@@ -67,4 +67,24 @@ test('plans both root and nested subdomain records together', () => {
       { type: 'TXT', name: '_discord.lucas', value: 'verify=abc' },
     ],
   );
+});
+
+// The Vercel DNS endpoint paths. These lived as inline template strings in
+// scripts/sync-dns.mjs, where nothing could assert them: the delete path was
+// missing its {domain} segment, so every delete 404'd from the day it was
+// written and the sync only stayed green while no name had records to replace.
+test('listPath asks for the domain\'s records, a page at a time', () => {
+  assert.equal(listPath('runs-on.dev'), '/v4/domains/runs-on.dev/records?limit=100');
+  assert.equal(
+    listPath('runs-on.dev', 'abc123'),
+    '/v4/domains/runs-on.dev/records?limit=100&until=abc123',
+  );
+});
+
+test('createPath posts under the domain', () => {
+  assert.equal(createPath('runs-on.dev'), '/v2/domains/runs-on.dev/records');
+});
+
+test('removePath includes the domain, not just the record id', () => {
+  assert.equal(removePath('runs-on.dev', 'rec_abc'), '/v2/domains/runs-on.dev/records/rec_abc');
 });


### PR DESCRIPTION
Follow-up to the delete-URL fix. That fix is live, but it can't repair the name it was found on: a push only syncs the names that push touched, and re-running a failed run checks out the original commit — the code that just failed.

`laurentmaxhuni` is currently live with a CNAME from one edit ago and no `_vercel` TXT at all, so that owner's Vercel domain verification can't complete. This is the way back.

## Decisions worth reviewing

**Names are required, not optional-defaulting-to-all.** `deleteStale` runs before the creates, so a full resync would drop every name's DNS for the length of the run.

**The input arrives via `env:`, never interpolated into the script body.** A `${{ }}` expansion inside `run:` is substituted before bash sees it, so a crafted input would execute rather than be read.

**Globbing is disabled around the word-split.** Found by testing the shell locally: `for name in $NAMES` glob-expands as well as word-splits, so a dispatch of `*` expands against the checkout into `app lib data docs test …` — all shaped like claimable names, none of them files under `domains/`. `sync-dns.mjs` reads a missing file as "record removed" and calls `deleteStale`, so that dispatch would have deleted the DNS of whoever owns those names. `set -f` keeps `*` literal so it's rejected on its own merits.

**Adds a `concurrency` group.** A manual repair and an automatic push run touching the same name would each delete what the other just created — a race this change would otherwise introduce.

## Verification

Shell logic exercised locally against: single name, comma+space separated, uppercase typo, `dexi.json` typo, `dexi; rm -rf /`, bare `*` (with decoy files present), empty input, and the push path. Rejections and accepts all as intended.

Not verifiable locally: the dispatch itself, which needs the real zone. Confirmation is a `deleted CNAME laurentmaxhuni` line plus a `created TXT _vercel.laurentmaxhuni` line on the first dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK57s1212Kocjs9sccWKcq