### PR TITLE
Point shovith.runs-on.dev at Vercel (CNAME + domain-verify TXT)

### DIFF
--- a/domains/shovith.json
+++ b/domains/shovith.json
@@ -4,5 +4,14 @@
     "github": "Hawkay002"
   },
   "claimedAt": "2026-09-02T06:50:41.000Z",
-  "records": {}
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "subdomains": {
+    "_vercel": {
+      "TXT": [
+        "vc-domain-verify=shovith.runs-on.dev,41524820ec7711f5f3ac"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Adds a CNAME record pointing `shovith` at my Vercel-hosted portfolio, plus the `_vercel` TXT record Vercel requires to verify the subdomain (apex belongs to another Vercel account).

Immutable fields (`name`, `owner`, `claimedAt`) untouched — same structure as #21 (hussain) and the Vercel guide.