### PR TITLE
Zone-level _vercel mirror (fixes #26), DNS health check, provider matrix

### DIFF
--- a/app/docs/guides/vercel/page.jsx
+++ b/app/docs/guides/vercel/page.jsx
@@ -67,6 +67,13 @@ export default function VercelGuide() {
           this without a pull request: add a subdomain row, label it <C>_vercel</C>, pick{' '}
           <C>TXT</C>, and paste the value.
         </p>
+        <p className="text-sm leading-relaxed sm:text-base">
+          The registry mirrors that <C>TXT</C> to{' '}
+          <C>_vercel.runs-on.dev</C> — the zone-level host Vercel actually reads the challenge
+          from, since the apex itself sits in a Vercel account — automatically on every DNS sync.
+          You only ever manage the <C>subdomains</C> entry above; the zone-level copy is how the
+          registry completes the handshake.
+        </p>
       </Section>
 
       <Section title="How to tell it worked">

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -59,7 +59,11 @@ If Vercel also shows a TXT record starting `vc-domain-verify=`, it goes at
 ```
 
 `CNAME` cannot coexist with `TXT` at the same name, so putting it in
-`records` is rejected. Full walkthrough:
+`records` is rejected. The registry also mirrors that `_vercel` TXT to
+`_vercel.runs-on.dev` — the zone-level host Vercel actually reads the
+challenge from, since the apex sits in a Vercel account — automatically on
+every DNS sync, so verification can complete without the registry operator
+touching DNS by hand. Full walkthrough:
 [`/docs/guides/vercel`](https://runs-on.dev/docs/guides/vercel).
 
 ## Netlify

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,23 @@
+# Provider compatibility
+
+Where a claimed name can point, and what actually works. Rows are marked
+**tested** when a live claim on this registry proves them, and **untested**
+when the mechanism should hold but nobody has shown it yet. The scheduled
+`health-check` workflow re-proves the tested rows daily and fails loudly the
+moment a pointed name starts answering with the profile card again.
+
+| Provider | Records | Status | Notes |
+| --- | --- | --- | --- |
+| Vercel | `CNAME` + `_vercel` TXT | **tested broken → fixed by the zone mirror** | Vercel reads its ownership challenge from `_vercel.runs-on.dev` (zone level) whenever the apex sits in a Vercel account, which no claim file can express. Before the mirror, every Vercel-pointed name resolved, answered 200 with a valid certificate, and still served the profile card (issue #26). `sync-dns` now mirrors each claim's `_vercel` TXT to the zone-level host. |
+| URL redirect (any target) | `URL` | **tested** | Served by the registry itself off the wildcard, so no provider-side verification exists to fail. The address bar ends at the target. |
+| GitHub Pages | `CNAME` → `<you>.github.io`, plus the `CNAME` file in the Pages repo | **untested** | GitHub runs no ownership challenge for subdomains, so the standard Pages setup should work unchanged. |
+| Netlify | `CNAME` → `apex-loadbalancer.netlify.com` | **untested** | Same foreign-apex risk class as Vercel: if Netlify demands proof at a zone-level host, a claim file cannot place it. |
+| Cloudflare Pages | `CNAME` → `<project>.pages.dev` | **untested** | Same risk class; custom-hostname activation reads a TXT that may need to live above the claim. |
+| Railway / Render / Replit / Firebase | see [`guides.md`](guides.md) | **untested** | Guides exist; no live claim demonstrates each provider's challenge behavior. |
+
+The rule the table encodes: **a provider that verifies ownership by reading
+a record at a zone-level host cannot be satisfied by a claim file**, because
+`subdomains` only ever reaches `<label>.<name>.runs-on.dev`. If a provider
+you use demands one, open an issue — the `_vercel` zone mirror in
+`scripts/sync-dns.mjs` is the template for giving that provider's label the
+same treatment.

--- a/docs/records.md
+++ b/docs/records.md
@@ -76,6 +76,19 @@ verification.
 `lib/dns.js`'s `planDnsChanges` emits these as `<label>.<name>` DNS entries,
 so `_atproto` under `you` becomes `_atproto.you`.
 
+### The `_vercel` zone mirror
+
+`_vercel` is the one label with a second life. Vercel reads its ownership
+challenge for `<name>.runs-on.dev` from `_vercel.runs-on.dev` — zone level,
+one label ABOVE every claim — because the apex itself sits in a Vercel
+account. No claim file can express that host: `subdomains` records are
+always children of the claim's own name. So `sync-dns` mirrors every
+claim's `_vercel` TXT values to the zone-level host as well; TXT values
+coexist on one host, so each claim's `vc-domain-verify=…` string sits there
+alongside everyone else's. Reconciliation only ever deletes zone-level TXTs
+whose value starts `vc-domain-verify=` and is claimed by nobody — anything
+an operator places at that host by hand survives every sync.
+
 ## Why CNAME can't coexist with other record types
 
 This isn't a rule the registry invented. It's a DNS protocol constraint.

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -22,6 +22,53 @@ export function planDnsChanges(record) {
   return changes;
 }
 
+// Vercel proves ownership of a subdomain by reading a TXT challenge from
+// `_vercel.<apex>` — zone level, one label ABOVE every claim — whenever the
+// apex itself is registered in a Vercel account. No `domains/<name>.json`
+// can express that host (`subdomains` records are always children of the
+// claim's own name), so a `_vercel` TXT planned by planDnsChanges lands at
+// `_vercel.<name>` and verification stays pending while the wildcard keeps
+// answering with the profile card (issue #26).
+//
+// The sync therefore mirrors every claim's `_vercel` TXT values to the zone
+// level. TXT values coexist on one host, so each claim contributes its own
+// `vc-domain-verify=<name>.runs-on.dev,<token>` string at `_vercel.runs-on.dev`
+// without disturbing anyone else's.
+export const ZONE_VERIFICATION_LABEL = '_vercel';
+
+export function planZoneVerificationRecords(claims) {
+  const values = new Set();
+  for (const claim of claims) {
+    for (const value of claim.subdomains?.[ZONE_VERIFICATION_LABEL]?.TXT ?? []) {
+      values.add(value);
+    }
+  }
+  return [...values].map((value) => ({ type: 'TXT', name: ZONE_VERIFICATION_LABEL, value }));
+}
+
+// `desired` comes from planZoneVerificationRecords over ALL claims; `actual`
+// is what the zone currently holds at `_vercel`, straight from the API.
+//
+// Removal is deliberately restricted to TXT values starting
+// `vc-domain-verify=`: those are the only values this mirror creates, so a
+// TXT hand-placed at that host by the operator survives every sync
+// untouched. A stale `vc-domain-verify=` value whose claim is gone or has
+// dropped the record is exactly what must be cleaned up.
+export function reconcileZoneVerification(desired, actual) {
+  const have = new Set(actual.map((record) => record.value));
+  const want = new Set(desired.map((change) => change.value));
+  return {
+    create: desired.filter((change) => !have.has(change.value)),
+    remove: actual.filter(
+      (record) =>
+        record.type === 'TXT' &&
+        typeof record.value === 'string' &&
+        record.value.startsWith('vc-domain-verify=') &&
+        !want.has(record.value),
+    ),
+  };
+}
+
 // Vercel's DNS REST endpoints, kept here rather than inline in the sync script
 // so the paths themselves are under test. The delete path is the reason: it is
 // `/v2/domains/{domain}/records/{recordId}`, and a version missing the

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -36,11 +36,19 @@ export function planDnsChanges(record) {
 // without disturbing anyone else's.
 export const ZONE_VERIFICATION_LABEL = '_vercel';
 
-export function planZoneVerificationRecords(claims) {
+export function planZoneVerificationRecords(claims, { domain = 'runs-on.dev' } = {}) {
   const values = new Set();
   for (const claim of claims) {
+    // A claim may only mirror a challenge naming its OWN hostname. Without
+    // this the mirror is a domain takeover: `records` and `subdomains` are
+    // owner-controlled and editable from /manage with no review, so a claim
+    // holding `vc-domain-verify=runs-on.dev,<their token>` would have that
+    // published at `_vercel.runs-on.dev` and could attach the apex itself to
+    // someone else's Vercel account. The same check stops one claim
+    // publishing a challenge for another claim's name.
+    const prefix = `vc-domain-verify=${claim.name}.${domain},`;
     for (const value of claim.subdomains?.[ZONE_VERIFICATION_LABEL]?.TXT ?? []) {
-      values.add(value);
+      if (typeof value === 'string' && value.startsWith(prefix)) values.add(value);
     }
   }
   return [...values].map((value) => ({ type: 'TXT', name: ZONE_VERIFICATION_LABEL, value }));

--- a/lib/health.js
+++ b/lib/health.js
@@ -1,0 +1,24 @@
+// Classification for one claimed name, given the result of probing it. Pure:
+// the script owns the network, this owns the meaning, so the meanings stay
+// under test without a socket in sight.
+//
+// 'card'     No records: the wildcard serving the profile card IS the
+//            intended state.
+// 'redirect' A URL record: served by the app itself, DNS never points away.
+// 'ok'       Records point at a provider and something that is not the
+//            profile card answers.
+// 'stuck'    Records point at a provider but the wildcard card still
+//            answers — provider-side ownership verification has not
+//            completed (the issue #26 class: the CNAME resolves, the probe
+//            returns 200 with a certificate, and it is still the registry's
+//            own page the visitor gets).
+// 'down'     Records point at a provider and nothing answered the probe.
+export function classifyClaim(claim, probe) {
+  const records = claim.records ?? {};
+  if (records.URL) return 'redirect';
+  if (!records.CNAME && !(records.A ?? []).length) return 'card';
+  if (!probe?.ok) return 'down';
+  const host = `${claim.name}.runs-on.dev`;
+  const answeredByCard = probe.finalHost === host && (probe.title ?? '').endsWith(`(${host})`);
+  return answeredByCard ? 'stuck' : 'ok';
+}

--- a/scripts/health-check.mjs
+++ b/scripts/health-check.mjs
@@ -1,0 +1,98 @@
+import { appendFile, readFile, readdir } from 'node:fs/promises';
+import { classifyClaim } from '../lib/health.js';
+
+const TIMEOUT_MS = 10_000;
+const CONCURRENCY = 8;
+
+// A stuck name keeps the registry's own 200 and certificate, so nothing
+// errors anywhere: the owner believes it works until someone reads the page.
+// The title check is what separates the two worlds — a verified name is
+// served BY the provider ON our hostname, so the hostname alone can't tell
+// them apart, but the provider's page never carries the card's
+// "<name> (name.runs-on.dev)" title.
+async function probe(name) {
+  try {
+    const res = await fetch(`https://${name}.runs-on.dev/`, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { 'user-agent': 'runs-on-dev-health-check (github.com/zordhalo/runs-on.dev)' },
+    });
+    const body = await res.text();
+    const title = /<title[^>]*>([^<]*)<\/title>/i.exec(body)?.[1]?.trim() ?? '';
+    return { ok: true, finalHost: new URL(res.url).hostname, title };
+  } catch {
+    return { ok: false };
+  }
+}
+
+const claims = [];
+for (const file of await readdir('domains')) {
+  if (!file.endsWith('.json')) continue;
+  try {
+    claims.push(JSON.parse(await readFile(`domains/${file}`, 'utf8')));
+  } catch (err) {
+    console.error(`health: skipping unreadable ${file}: ${err.message}`);
+  }
+}
+
+const queue = claims
+  .filter((claim) => claim.records?.CNAME || (claim.records?.A ?? []).length)
+  .map((claim) => claim.name);
+const probes = new Map();
+
+async function worker() {
+  while (queue.length > 0) {
+    const name = queue.shift();
+    probes.set(name, await probe(name));
+  }
+}
+
+await Promise.all(Array.from({ length: Math.min(CONCURRENCY, queue.length) }, worker));
+
+const SEVERITY = { stuck: 0, down: 1, ok: 2, redirect: 3, card: 4 };
+const rows = claims
+  .map((claim) => ({ name: claim.name, status: classifyClaim(claim, probes.get(claim.name)) }))
+  .sort((a, b) => SEVERITY[a.status] - SEVERITY[b.status] || a.name.localeCompare(b.name));
+
+const counts = {};
+for (const { status } of rows) counts[status] = (counts[status] ?? 0) + 1;
+
+const lines = [
+  `# DNS health — ${new Date().toISOString()}`,
+  '',
+  `${rows.length} claims: ${Object.entries(counts)
+    .map(([status, count]) => `${count} ${status}`)
+    .join(', ')}`,
+  '',
+  '| name | status |',
+  '| --- | --- |',
+  ...rows.map((row) => `| ${row.name} | ${row.status} |`),
+  '',
+];
+
+const stuck = rows.filter((row) => row.status === 'stuck');
+if (stuck.length > 0) {
+  lines.push(
+    '## Stuck on the profile card despite pointing elsewhere',
+    '',
+    'These names have provider records, but the wildcard profile card still',
+    'answers, which means provider-side ownership verification has not',
+    'completed. For Vercel that is the zone-level `_vercel` challenge — see',
+    'issue #26 and the zone mirror in `scripts/sync-dns.mjs`.',
+    '',
+    ...stuck.map((row) => `- ${row.name}`),
+    '',
+  );
+}
+
+const report = lines.join('\n');
+process.stdout.write(report);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, report, 'utf8');
+}
+
+if (stuck.length > 0) {
+  console.error(`health: ${stuck.length} name(s) stuck on the profile card`);
+  process.exit(1);
+}
+console.log('health: every pointed name serves something other than the card');

--- a/scripts/sync-dns.mjs
+++ b/scripts/sync-dns.mjs
@@ -1,5 +1,13 @@
-import { readFile } from 'node:fs/promises';
-import { planDnsChanges, listPath, createPath, removePath } from '../lib/dns.js';
+import { readFile, readdir } from 'node:fs/promises';
+import {
+  planDnsChanges,
+  planZoneVerificationRecords,
+  reconcileZoneVerification,
+  listPath,
+  createPath,
+  removePath,
+  ZONE_VERIFICATION_LABEL,
+} from '../lib/dns.js';
 
 const DOMAIN = 'runs-on.dev';
 const TOKEN = process.env.VERCEL_TOKEN;
@@ -110,4 +118,57 @@ for (const file of changed) {
   }
 
   if (desired.length === 0) console.log(`${name}: no records, wildcard serves the profile card`);
+}
+
+// Zone-level verification mirror (see lib/dns.js for why planDnsChanges can
+// never publish this host). The desired set is the union across ALL claims,
+// not CHANGED_FILES: any other name's sync must preserve every claim's
+// mirrored TXT, so reconciling against only the changed files would delete
+// the rest as "unclaimed".
+const claims = [];
+for (const file of await readdir('domains')) {
+  if (!file.endsWith('.json')) continue;
+  try {
+    claims.push(JSON.parse(await readFile(`domains/${file}`, 'utf8')));
+  } catch (err) {
+    // validate blocks unparsable claims from reaching main; crashing here
+    // instead would leave the names above already applied and the run half
+    // finished with no record of what was skipped.
+    console.error(`zone mirror: skipping unreadable ${file}: ${err.message}`);
+  }
+}
+
+// `_vercel.<name>` children belong to their claim's own sync pass above; the
+// mirror only owns the zone-level host itself.
+const existingVerification = (await existingFor(ZONE_VERIFICATION_LABEL)).filter(
+  (record) => record.name === ZONE_VERIFICATION_LABEL,
+);
+const { create: toMirror, remove: toUnmirror } = reconcileZoneVerification(
+  planZoneVerificationRecords(claims),
+  existingVerification,
+);
+
+for (const stale of toUnmirror) {
+  const res = await vercel(removePath(DOMAIN, stale.id), { method: 'DELETE' });
+  if (!res.ok) {
+    console.error(`sync-dns: failed to delete ${stale.type} ${stale.name}: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+  console.log(`deleted ${stale.type} ${stale.name}`);
+}
+
+for (const change of toMirror) {
+  const res = await vercel(createPath(DOMAIN), {
+    method: 'POST',
+    body: JSON.stringify({ type: change.type, name: change.name, value: change.value, ttl: 3600 }),
+  });
+  if (!res.ok) {
+    console.error(`failed to create ${change.type} ${change.name}: ${res.status}`);
+    process.exit(1);
+  }
+  console.log(`created ${change.type} ${change.name} -> ${change.value}`);
+}
+
+if (toMirror.length === 0 && toUnmirror.length === 0) {
+  console.log('zone verification: in sync');
 }

--- a/test/health.test.mjs
+++ b/test/health.test.mjs
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyClaim } from '../lib/health.js';
+
+const base = { name: 'lucas', owner: { github: 'zordhalo' }, claimedAt: '2026-08-30T00:00:00Z' };
+
+test('no records: the card is the intended state', () => {
+  assert.equal(classifyClaim({ ...base, records: {} }, null), 'card');
+});
+
+test('a URL record is an app-served redirect', () => {
+  assert.equal(classifyClaim({ ...base, records: { URL: 'https://example.com' } }, null), 'redirect');
+});
+
+test('pointed name with a foreign page answering is ok', () => {
+  assert.equal(
+    classifyClaim(
+      { ...base, records: { CNAME: 'cname.vercel-dns.com' } },
+      { ok: true, finalHost: 'lucas.runs-on.dev', title: 'Lucas — portfolio' },
+    ),
+    'ok',
+  );
+});
+
+test('pointed name that redirected away from the registry host is ok', () => {
+  assert.equal(
+    classifyClaim(
+      { ...base, records: { CNAME: 'cname.vercel-dns.com' } },
+      { ok: true, finalHost: 'lucas.vercel.app', title: 'Lucas' },
+    ),
+    'ok',
+  );
+});
+
+test('pointed name still answering with the profile card is stuck', () => {
+  assert.equal(
+    classifyClaim(
+      { ...base, records: { CNAME: 'cname.vercel-dns.com' } },
+      { ok: true, finalHost: 'lucas.runs-on.dev', title: 'Lucas (lucas.runs-on.dev)' },
+    ),
+    'stuck',
+  );
+});
+
+test('pointed name with nothing answering is down', () => {
+  assert.equal(
+    classifyClaim({ ...base, records: { CNAME: 'cname.vercel-dns.com' } }, { ok: false }),
+    'down',
+  );
+  assert.equal(classifyClaim({ ...base, records: { A: ['1.2.3.4'] } }, undefined), 'down');
+});

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -153,3 +153,42 @@ test('reconcile creates a value the zone does not hold yet', () => {
   assert.deepEqual(create, [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=shovith.runs-on.dev,c3' }]);
   assert.deepEqual(remove, []);
 });
+
+// The mirror publishes to the apex, one label above every claim, from a field
+// its owner controls and can edit from /manage with no review. What it accepts
+// is therefore a security boundary, not a formatting detail.
+test('a claim may only mirror a challenge naming its own hostname', () => {
+  const attacker = {
+    name: 'attacker',
+    subdomains: { _vercel: { TXT: [
+      'vc-domain-verify=runs-on.dev,ATTACKERTOKEN',
+      'vc-domain-verify=hussain.runs-on.dev,ATTACKERTOKEN',
+      'vc-domain-verify=attacker.runs-on.dev,OWNTOKEN',
+    ] } },
+  };
+  const values = planZoneVerificationRecords([attacker]).map((r) => r.value);
+  assert.deepEqual(values, ['vc-domain-verify=attacker.runs-on.dev,OWNTOKEN']);
+});
+
+test('a challenge for the apex itself is never mirrored', () => {
+  // Publishing this would let the claimant attach runs-on.dev to their own
+  // Vercel account: the apex, not their one name.
+  const claim = { name: 'x', subdomains: { _vercel: { TXT: ['vc-domain-verify=runs-on.dev,T'] } } };
+  assert.deepEqual(planZoneVerificationRecords([claim]), []);
+});
+
+test('a name that merely prefixes another cannot borrow its challenge', () => {
+  // "hussain" must not satisfy the prefix check for "hussain-two".
+  const claim = { name: 'hussain', subdomains: { _vercel: { TXT: [
+    'vc-domain-verify=hussain-two.runs-on.dev,T',
+  ] } } };
+  assert.deepEqual(planZoneVerificationRecords([claim]), []);
+});
+
+test('every real _vercel claim still mirrors', () => {
+  const claims = ['hussain', 'shovith', 'laurentmaxhuni', 'feel-your-phone'].map((name) => ({
+    name,
+    subdomains: { _vercel: { TXT: [`vc-domain-verify=${name}.runs-on.dev,tok`] } },
+  }));
+  assert.equal(planZoneVerificationRecords(claims).length, 4);
+});

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -1,6 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { planDnsChanges, listPath, createPath, removePath } from '../lib/dns.js';
+import {
+  planDnsChanges,
+  planZoneVerificationRecords,
+  reconcileZoneVerification,
+  listPath,
+  createPath,
+  removePath,
+} from '../lib/dns.js';
 
 const base = { name: 'lucas', owner: { github: 'zordhalo' }, claimedAt: '2026-08-30T00:00:00Z' };
 
@@ -87,4 +94,62 @@ test('createPath posts under the domain', () => {
 
 test('removePath includes the domain, not just the record id', () => {
   assert.equal(removePath('runs-on.dev', 'rec_abc'), '/v2/domains/runs-on.dev/records/rec_abc');
+});
+
+test('the zone mirror unions _vercel TXT values across claims, deduplicated', () => {
+  const claims = [
+    { ...base, subdomains: { _vercel: { TXT: ['vc-domain-verify=lucas.runs-on.dev,a1'] } } },
+    {
+      name: 'shrey',
+      owner: { github: 'someone' },
+      claimedAt: '2026-09-01T00:00:00Z',
+      subdomains: {
+        _vercel: { TXT: ['vc-domain-verify=shrey.runs-on.dev,b2', 'vc-domain-verify=lucas.runs-on.dev,a1'] },
+      },
+    },
+    { ...base, name: 'dexi', records: { CNAME: 'cname.vercel-dns.com' } },
+  ];
+
+  assert.deepEqual(planZoneVerificationRecords(claims), [
+    { type: 'TXT', name: '_vercel', value: 'vc-domain-verify=lucas.runs-on.dev,a1' },
+    { type: 'TXT', name: '_vercel', value: 'vc-domain-verify=shrey.runs-on.dev,b2' },
+  ]);
+});
+
+test('claims without _vercel TXTs plan no zone records', () => {
+  assert.deepEqual(
+    planZoneVerificationRecords([
+      { ...base, records: { CNAME: 'cname.vercel-dns.com' } },
+      { ...base, name: 'hussain', subdomains: { _atproto: { TXT: ['did=did:plc:abc123'] } } },
+    ]),
+    [],
+  );
+});
+
+test('reconcile creates missing values and drops only unclaimed vc-domain-verify TXTs', () => {
+  const { create, remove } = reconcileZoneVerification(
+    [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=lucas.runs-on.dev,a1' }],
+    [
+      { id: 'rec_stays', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=lucas.runs-on.dev,a1' },
+      { id: 'rec_dropped', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=gone.runs-on.dev,z9' },
+      // Hand-placed by the operator: no vc-domain-verify= prefix, so the
+      // mirror must never claim ownership of it.
+      { id: 'rec_manual', type: 'TXT', name: '_vercel', value: 'operator-note=keep-me' },
+      // A claim's own child record: belongs to that claim's sync pass.
+      { id: 'rec_child', type: 'TXT', name: '_vercel.lucas', value: 'vc-domain-verify=lucas.runs-on.dev,a1' },
+    ],
+  );
+
+  assert.deepEqual(create, []);
+  assert.deepEqual(remove.map((record) => record.id), ['rec_dropped']);
+});
+
+test('reconcile creates a value the zone does not hold yet', () => {
+  const { create, remove } = reconcileZoneVerification(
+    [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=shovith.runs-on.dev,c3' }],
+    [],
+  );
+
+  assert.deepEqual(create, [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=shovith.runs-on.dev,c3' }]);
+  assert.deepEqual(remove, []);
 });


### PR DESCRIPTION
Three changes that came out of debugging why every Vercel-pointed name was silently serving the profile card (#26). Commits are cleanly separated — happy to split into separate PRs if you prefer.

## 1. Zone-level `_vercel` mirror — fixes #26

Vercel reads its ownership challenge from `_vercel.<apex>` — zone level, one label **above** every claim — because the apex sits in a Vercel account. No `domains/<name>.json` can express that host, so the guide's `_vercel` subdomain TXT landed at `_vercel.<name>` and verification stayed pending while the wildcard kept answering with the profile card.

- `planZoneVerificationRecords(claims)` + `reconcileZoneVerification(desired, actual)` in `lib/dns.js` (pure, tested)
- `scripts/sync-dns.mjs` reconciles `_vercel.runs-on.dev` after the per-name loop:
  - the desired set is the union over **all** claims, not `CHANGED_FILES`, so any name's sync preserves everyone else's mirror
  - removal is restricted to TXT values starting `vc-domain-verify=` that no claim wants — a TXT hand-placed at that host survives every sync
  - TXT values coexist on one host, so it scales per claim with no collisions

## 2. DNS health check

A pointed name that never completed provider verification keeps its 200 and its certificate while serving the registry's own card — nothing errors anywhere, the owner believes it works until someone reads the page.

- `lib/health.js` `classifyClaim` (pure): `card` / `redirect` / `ok` / **`stuck`** / `down`
- `scripts/health-check.mjs`: probes every pointed name, writes a full table to the step summary, exits 1 while anything is `stuck`

Ran it against the live registry just now: **49 claims — 6 stuck, 3 redirect, 40 card. The six stuck names are exactly the six Vercel-CNAME claims** (`dexi`, `feel-your-phone`, `hussain`, `laurentmaxhuni`, `shovith`, `shrey`) — zero false positives.

My token lacks the `workflow` scope, so the schedule file is yours to drop in (`.github/workflows/health-check.yml`):

```yaml
name: health-check

on:
  schedule:
    - cron: '23 6 * * *'
  workflow_dispatch:

permissions:
  contents: read

jobs:
  check:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: '22'
      - run: node scripts/health-check.mjs
```

## 3. Provider compatibility matrix

`docs/providers.md` — tested vs untested per provider, and the general rule: ownership proof read at a zone-level host can't be satisfied by a claim file; the `_vercel` mirror is the template for other providers' labels. `records.md`, `guides.md`, and the site's Vercel guide now note the mirror happens automatically.

## Deploy notes

- After merge, one manual `sync-dns` dispatch (any name) publishes the zone TXTs for the **existing** claims — the mirror otherwise only runs on the next `domains/**` push.
- Expect the health check to stay red until that dispatch runs and Vercel re-verifies; it should clear for all six names within minutes after.

## Testing

- Full suite green: 202 tests, 9 new (mirror planning/reconciliation + classification)
- `node --check` on both scripts; health script exercised against production