### PR TITLE
Schedule the DNS health check

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,30 @@
+name: health-check
+
+# A name whose provider verification never completed keeps its 200 and its
+# certificate while the wildcard answers with the registry's own profile card.
+# Nothing errors anywhere, so the only way this surfaces is by asking what each
+# pointed name actually serves. Issue #26 went unnoticed for exactly that
+# reason, across seventeen names.
+on:
+  schedule:
+    - cron: '23 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# The probe reads public HTTP and nothing else, so a scheduled run overlapping
+# a manual one is harmless; cancel the older one rather than queue it.
+concurrency:
+  group: health-check
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: node scripts/health-check.mjs


### PR DESCRIPTION
The script landed with #27. The workflow couldn't — @Hawkay002's token had no `workflow` scope, so they left the YAML in the PR body for someone else to drop in.

Verified against production before the mirror has published anything:

```
$ node scripts/health-check.mjs
health: 13 name(s) stuck on the profile card
$ echo $?
1
```

So the scheduled run goes red while the condition holds, which is the intended state until `sync-dns` publishes the zone TXTs and Vercel re-verifies.

Added a `concurrency` group beyond the YAML in #27's body — the probe reads public HTTP and nothing else, so an overlapping scheduled and manual run is harmless and the older one should just be cancelled.