### PR TITLE
fix: the JSON Schema mirror had drifted from lib/schema.js

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -146,6 +146,15 @@ export function validateRecord(obj) {
 
   if (!obj.owner || typeof obj.owner.github !== 'string' || !obj.owner.github) {
     errors.push('owner.github is required');
+  } else {
+    // Unknown keys under `owner` are rejected for the same reason unknown
+    // top-level keys are: a field nothing reads still looks authoritative
+    // sitting in a file that says who holds the name.
+    // schema/record.schema.json has always declared additionalProperties:
+    // false here, so this is the mirror and the validator agreeing again.
+    for (const key of Object.keys(obj.owner)) {
+      if (key !== 'github') errors.push(`unknown key: owner.${key}`);
+    }
   }
 
   if (typeof obj.claimedAt !== 'string' || Number.isNaN(Date.parse(obj.claimedAt))) {

--- a/schema/record.schema.json
+++ b/schema/record.schema.json
@@ -5,7 +5,13 @@
   "additionalProperties": false,
   "required": ["name", "owner", "claimedAt", "records"],
   "properties": {
-    "name": { "type": "string", "pattern": "^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$" },
+    "name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 32,
+      "pattern": "^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$",
+      "not": { "pattern": "^..--" }
+    },
     "owner": {
       "type": "object",
       "additionalProperties": false,

--- a/test/schema.test.mjs
+++ b/test/schema.test.mjs
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { validateRecord } from '../lib/schema.js';
 
 const valid = {
@@ -197,4 +198,77 @@ test('accepts a subdomain MX alongside A', () => {
     },
   });
   assert.equal(out.ok, true);
+});
+
+// --- schema/record.schema.json stays in step with lib/schema.js ---
+//
+// The JSON Schema file is published to contributors: the pull request
+// template asks them to tick "My records validate against
+// schema/record.schema.json", and README.md, docs/records.md and the
+// resources page all link to it. Nothing loads it at runtime, though --
+// CI validates through scripts/validate-pr.mjs -> lib/schema.js -- so
+// the two drifted apart with nothing to notice. A record could satisfy
+// the published schema and still be rejected by the check that actually
+// runs, which makes the checkbox a lie.
+//
+// This walks the constraints the mirror declares and asserts lib/schema.js
+// reaches the same verdict on each case. It is not a JSON Schema
+// implementation (the repo has no validator dependency and does not need
+// one) -- it covers the keywords the mirror actually uses for the fields
+// that drifted.
+
+const mirror = JSON.parse(
+  await readFile(new URL('../schema/record.schema.json', import.meta.url), 'utf8'),
+);
+
+function mirrorAcceptsName(name) {
+  const s = mirror.properties.name;
+  if (typeof name !== 'string') return false;
+  if (name.length < s.minLength || name.length > s.maxLength) return false;
+  if (!new RegExp(s.pattern).test(name)) return false;
+  return !new RegExp(s.not.pattern).test(name);
+}
+
+test('the JSON Schema mirror and lib/schema.js agree on names', () => {
+  // Each of these was accepted by the mirror and rejected by validateName
+  // before the mirror grew minLength/maxLength/not.
+  const names = [
+    ['lucas', true],
+    ['my-name', true],
+    ['ab', true],
+    ['a', false], // minLength: validateName requires 2
+    ['1', false],
+    ['xn--abc', false], // punycode prefix
+    ['ab--cd', false], // `--` in the 3rd and 4th position
+    ['zz--hi', false],
+    ['a'.repeat(32), true],
+    ['a'.repeat(33), false], // maxLength
+    ['-lead', false],
+    ['trail-', false],
+    ['UPPER', false],
+  ];
+
+  for (const [name, expected] of names) {
+    assert.equal(
+      mirrorAcceptsName(name),
+      expected,
+      `schema/record.schema.json disagrees on ${JSON.stringify(name)}`,
+    );
+    assert.equal(
+      validateRecord({ ...valid, name }).ok,
+      expected,
+      `lib/schema.js disagrees on ${JSON.stringify(name)}`,
+    );
+  }
+});
+
+test('the JSON Schema mirror and lib/schema.js agree on unknown owner keys', () => {
+  assert.equal(mirror.properties.owner.additionalProperties, false);
+  const out = validateRecord({ ...valid, owner: { github: 'zordhalo', email: 'a@b.com' } });
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.includes('unknown key: owner.email'));
+});
+
+test('a well-formed owner is still accepted', () => {
+  assert.equal(validateRecord({ ...valid, owner: { github: 'zordhalo' } }).ok, true);
 });


### PR DESCRIPTION
`schema/record.schema.json` is published to contributors. The pull request template asks them to tick *"My records validate against `schema/record.schema.json`"*, and `README.md`, `docs/records.md` and `app/docs/resources` all link to it as "the JSON Schema mirror".

Nothing loads it at runtime — CI validates through `scripts/validate-pr.mjs` → `lib/schema.js` — so it drifted from the validator that actually runs, with nothing to catch it.

### The drift

Its `name` pattern was copied from `SHAPE` in `lib/name.js:1`, but `validateName` applies three more rules *after* that regex:

| name | mirror | `lib/name.js` |
|---|---|---|
| `a` | accept | reject (length) |
| `1` | accept | reject (length) |
| `xn--abc` | accept | reject (punycode) |
| `ab--cd` | accept | reject (punycode) |
| `zz--hi` | accept | reject (punycode) |

And in the other direction: the mirror declares `owner.additionalProperties: false`, but `validateRecord` ignored unknown keys under `owner`, so `{ "github": "x", "email": "y" }` returned `{ ok: true }`.

Either way the checkbox is unreliable — you can satisfy the published schema and still be rejected by CI, or pass CI with a file the published schema calls invalid.

### The change

- **`schema/record.schema.json`** — adds `minLength: 2`, `maxLength: 32`, and `"not": { "pattern": "^..--" }` to `name`. The single `not` covers both punycode rules, since the `xn--` prefix is just a case of `--` in the 3rd and 4th position.
- **`lib/schema.js`** — rejects unknown keys under `owner`, matching what the mirror always claimed, and matching what `validateRecord` already does for unknown top-level keys.
- **`test/schema.test.mjs`** — runs a shared case table through both so they can't drift again silently. Verified it fails against the old mirror (`not ok - the JSON Schema mirror and lib/schema.js agree on names`) and passes against the new one.

### Notes

- All 104 records under `domains/` pass before and after. This is latent, not a live break.
- The `lib/schema.js` hunk is the only behavior change — it makes the validator stricter. `lib/claim.js:67` is the only place an `owner` object is constructed and it writes `github` alone, so nothing in the repo produces a record this would newly reject. If you'd rather loosen the mirror than tighten the validator, that hunk can be dropped and the other two still stand.
- No files under `domains/` are touched, so `validate.yml` and its one-file-per-PR rule don't apply here. `npm test` (209 pass) and `npm run build` both green.
