### PR TITLE
Reject a truncated Vercel verification token

### DIFF
--- a/app/docs/guides/vercel/page.jsx
+++ b/app/docs/guides/vercel/page.jsx
@@ -52,7 +52,7 @@ export default function VercelGuide() {
   "records": { "CNAME": "cname.vercel-dns.com" },
   "subdomains": {
     "_vercel": {
-      "TXT": ["vc-domain-verify=you.runs-on.dev,abc123"]
+      "TXT": ["vc-domain-verify=you.runs-on.dev,PASTE-YOUR-TOKEN"]
     }
   }
 }`}</Record>

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -252,7 +252,7 @@ export default function RecordForm({ name, record }) {
 }
 
 const SUB_PLACEHOLDER = {
-  TXT: 'vc-domain-verify=you.runs-on.dev,abc123',
+  TXT: 'vc-domain-verify=you.runs-on.dev,PASTE-YOUR-TOKEN',
   CNAME: 'target.example.com',
   A: '76.76.21.21',
   MX: '10 mx.example.com',

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -54,7 +54,7 @@ If Vercel also shows a TXT record starting `vc-domain-verify=`, it goes at
 ```json
 {
   "records": { "CNAME": "cname.vercel-dns.com" },
-  "subdomains": { "_vercel": { "TXT": ["vc-domain-verify=you.runs-on.dev,abc123"] } }
+  "subdomains": { "_vercel": { "TXT": ["vc-domain-verify=you.runs-on.dev,PASTE-YOUR-TOKEN"] } }
 }
 ```
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -15,6 +15,20 @@ const MAX_SUBDOMAINS = 10;
 const MAX_MX_ENTRIES = 5;
 const MAX_DNS_NAME_LENGTH = 253;
 
+// A TXT beginning `vc-domain-verify=` is a Vercel ownership challenge, and
+// since the zone mirror landed one of these gets copied to `_vercel.<apex>`,
+// where it load-bears verification. A truncated or placeholder token is
+// otherwise completely invisible: schema-valid, published to DNS, and
+// silently never verifying, so the owner finds out from the daily health
+// check or not at all. That is the failure mode issue #26 was, one layer up.
+//
+// Deliberately narrow. Only values already claiming to be this one kind of
+// challenge are checked, and only for the shape `<hostname>,<hex token>` --
+// not a length, which Vercel is free to change. Every other TXT string stays
+// unconstrained beyond the 255-character limit.
+const VERCEL_VERIFY_PREFIX = 'vc-domain-verify=';
+const VERCEL_VERIFY = /^vc-domain-verify=[a-z0-9][a-z0-9.-]*,[0-9a-f]+$/;
+
 function isIPv4(value) {
   const parts = String(value).split('.');
   if (parts.length !== 4) return false;
@@ -98,6 +112,17 @@ function validateRecordsShape(records, errors, { label = '', allowUrl } = {}) {
       && records.TXT.length > 0
       && records.TXT.every((v) => typeof v === 'string' && v.length <= 255);
     if (!ok) errors.push(`${label}TXT must be an array of strings up to 255 chars`);
+    else {
+      for (const value of records.TXT) {
+        if (value.startsWith(VERCEL_VERIFY_PREFIX) && !VERCEL_VERIFY.test(value)) {
+          errors.push(
+            `${label}TXT looks like a truncated Vercel verification token: ${value} `
+            + '(expected vc-domain-verify=<host>,<token>, token being hex only -- '
+            + 'copy the whole value from the Vercel Domains tab)',
+          );
+        }
+      }
+    }
   }
 
   if ('MX' in records) validateMx(records.MX, errors, label);

--- a/test/schema.test.mjs
+++ b/test/schema.test.mjs
@@ -272,3 +272,52 @@ test('the JSON Schema mirror and lib/schema.js agree on unknown owner keys', () 
 test('a well-formed owner is still accepted', () => {
   assert.equal(validateRecord({ ...valid, owner: { github: 'zordhalo' } }).ok, true);
 });
+
+// A vc-domain-verify TXT gets mirrored to the apex, where it load-bears
+// verification for the name. A truncated one is otherwise invisible:
+// schema-valid, published to DNS, and silently never verifying.
+test('rejects a truncated Vercel verification token', () => {
+  const out = validateRecord({
+    name: 'krishna', owner: { github: 'k' }, claimedAt: '2026-01-01T00:00:00Z',
+    records: {},
+    subdomains: { _vercel: { TXT: ['vc-domain-verify=krishna.runs-on.dev,70f2fede6bc7dc6f0...'] } },
+  });
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('truncated Vercel verification token')));
+});
+
+test('rejects a placeholder token pasted from the docs', () => {
+  const out = validateRecord({
+    name: 'you', owner: { github: 'y' }, claimedAt: '2026-01-01T00:00:00Z',
+    records: {},
+    subdomains: { _vercel: { TXT: ['vc-domain-verify=you.runs-on.dev,PASTE-YOUR-TOKEN'] } },
+  });
+  assert.equal(out.ok, false);
+});
+
+test('accepts a real verification token', () => {
+  const out = validateRecord({
+    name: 'hussain', owner: { github: 'h' }, claimedAt: '2026-01-01T00:00:00Z',
+    records: {},
+    subdomains: { _vercel: { TXT: ['vc-domain-verify=hussain.runs-on.dev,696f1780aaddd44898ab'] } },
+  });
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('the guard only applies to vc-domain-verify values', () => {
+  // Every other TXT string stays unconstrained beyond the length limit.
+  const out = validateRecord({
+    name: 'lucas', owner: { github: 'x' }, claimedAt: '2026-01-01T00:00:00Z',
+    records: { TXT: ['anything at all, with commas, dots... and UPPERCASE'] },
+  });
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('the guard applies at the root too, not only under subdomains', () => {
+  const out = validateRecord({
+    name: 'lucas', owner: { github: 'x' }, claimedAt: '2026-01-01T00:00:00Z',
+    records: { TXT: ['vc-domain-verify=lucas.runs-on.dev,nothex...'] },
+  });
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.some((e) => e.includes('truncated Vercel verification token')));
+});


### PR DESCRIPTION
A TXT beginning `vc-domain-verify=` is load-bearing since #27: the zone mirror copies it to `_vercel.<apex>`, where it proves ownership of the name.

A truncated one is invisible — schema-valid, published to DNS, name still serving the wildcard card, nothing erroring anywhere.

## #19 is exactly this

```
"vc-domain-verify=krishna.runs-on.dev,70f2fede6bc7dc6f0..."
                                                       ^^^ literal dots
```

17 hex characters plus three dots. Every real token is 20 hex. Theirs is *also* 20 characters, so a length check waves it through — only the character set catches it.

```
schema accepts it?         true    ← before this PR
mirror would publish it?   true
→ CI green, DNS live, name serves our card, nothing errors
```

## The guard

Narrow on purpose. Only values already claiming to be this kind of challenge are checked, and only for the shape `<hostname>,<hex>` — not a length, which Vercel is free to change. Every other TXT string stays unconstrained beyond the 255-char limit.

**No claim currently on main is affected** — verified against all 92.

## Docs placeholder

It was `abc123`, which is valid hex and would have passed the new guard, so pasting the example verbatim produced a record that silently never verified. Now `PASTE-YOUR-TOKEN`, which the guard rejects.

## A note on the tests

Two of the tests I first wrote used `name: 'x'`, which is one character and fails the name grammar. One failed outright; the other **passed for the wrong reason** — asserting only `ok === false`, which was true because of the name, not the guard. Both now use a valid name and assert on the guard's own message.

211 tests.