### PR TITLE
Close a nudge issue once its name comes back

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -12,6 +12,9 @@ on:
 
 permissions:
   contents: read
+  # The run closes the nudge issues whose names have recovered, so the person
+  # who was told their name was broken is told when it is fixed.
+  issues: write
 
 # The probe reads public HTTP and nothing else, so a scheduled run overlapping
 # a manual one is harmless; cancel the older one rather than queue it.
@@ -28,3 +31,5 @@ jobs:
         with:
           node-version: '22'
       - run: node scripts/health-check.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/health.js
+++ b/lib/health.js
@@ -22,3 +22,39 @@ export function classifyClaim(claim, probe) {
   const answeredByCard = probe.finalHost === host && (probe.title ?? '').endsWith(`(${host})`);
   return answeredByCard ? 'stuck' : 'ok';
 }
+
+// The label the nudge issues carry. Matching on a label rather than on the
+// title alone means an unrelated issue that happens to open with a claimed
+// name can never be closed by this.
+export const STUCK_LABEL = 'dns-stuck';
+
+// A nudge issue is titled `<name>.runs-on.dev ...`, so the name it concerns
+// is recoverable from the title. Anything that does not match that shape
+// returns null and is left alone.
+export function issueName(title) {
+  const match = /^([a-z0-9-]+)\.runs-on\.dev\b/.exec(String(title ?? ''));
+  return match ? match[1] : null;
+}
+
+// Only `ok` and `redirect` count as recovered. Deliberately not `card`: a
+// name whose records were removed is no longer stuck, but it is not serving
+// the owner's site either, and closing with "this is working now" would be a
+// lie. A human can close those.
+const RECOVERED = new Set(['ok', 'redirect']);
+
+// Which open nudge issues this run should close. Pure, so the decision is
+// testable without touching the GitHub API — the script owns the network.
+//
+// An issue is only closed when its name is one this run actually probed. An
+// issue naming something absent from the registry is left open: closing an
+// issue we cannot account for is worse than leaving a stale one behind.
+export function planIssueClosures(rows, issues) {
+  const status = new Map((rows ?? []).map((row) => [row.name, row.status]));
+  const closures = [];
+  for (const issue of issues ?? []) {
+    const name = issueName(issue.title);
+    if (!name || !status.has(name)) continue;
+    if (RECOVERED.has(status.get(name))) closures.push({ number: issue.number, name });
+  }
+  return closures;
+}

--- a/scripts/health-check.mjs
+++ b/scripts/health-check.mjs
@@ -1,5 +1,5 @@
 import { appendFile, readFile, readdir } from 'node:fs/promises';
-import { classifyClaim } from '../lib/health.js';
+import { classifyClaim, planIssueClosures, STUCK_LABEL } from '../lib/health.js';
 
 const TIMEOUT_MS = 10_000;
 const CONCURRENCY = 8;
@@ -91,8 +91,67 @@ if (process.env.GITHUB_STEP_SUMMARY) {
   await appendFile(process.env.GITHUB_STEP_SUMMARY, report, 'utf8');
 }
 
+// Close the nudge issues whose names have come back. Without this the probe
+// knows a name recovered and the person who was told it was broken is never
+// told otherwise, so the tracker fills with issues nobody owns closing.
+//
+// Everything here is best effort and deliberately cannot fail the run: the
+// probe result above is the point of this script, and losing it because the
+// issues API had a bad minute would be a poor trade.
+await closeRecoveredIssues(rows);
+
 if (stuck.length > 0) {
   console.error(`health: ${stuck.length} name(s) stuck on the profile card`);
   process.exit(1);
 }
 console.log('health: every pointed name serves something other than the card');
+
+async function closeRecoveredIssues(statusRows) {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  // Absent locally, which is why running this by hand probes and reports but
+  // never writes.
+  if (!token || !repo) return;
+
+  const api = (path, init = {}) =>
+    fetch(`https://api.github.com/repos/${repo}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+    });
+
+  let issues;
+  try {
+    const res = await api(`/issues?state=open&labels=${STUCK_LABEL}&per_page=100`);
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    // The issues endpoint returns pull requests too; they are not nudges.
+    issues = (await res.json()).filter((issue) => !issue.pull_request);
+  } catch (err) {
+    console.error(`health: could not list ${STUCK_LABEL} issues: ${err.message}`);
+    return;
+  }
+
+  for (const { number, name } of planIssueClosures(statusRows, issues)) {
+    try {
+      await api(`/issues/${number}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({
+          body: `\`${name}.runs-on.dev\` is serving your site now, so this is resolved. `
+            + 'Closed automatically by the daily health check — reopen if it regresses.',
+        }),
+      });
+      const res = await api(`/issues/${number}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ state: 'closed', state_reason: 'completed' }),
+      });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      console.log(`closed #${number} (${name} recovered)`);
+    } catch (err) {
+      console.error(`health: could not close #${number}: ${err.message}`);
+    }
+  }
+}

--- a/test/health.test.mjs
+++ b/test/health.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyClaim } from '../lib/health.js';
+import { classifyClaim, issueName, planIssueClosures } from '../lib/health.js';
 
 const base = { name: 'lucas', owner: { github: 'zordhalo' }, claimedAt: '2026-08-30T00:00:00Z' };
 
@@ -48,4 +48,44 @@ test('pointed name with nothing answering is down', () => {
     'down',
   );
   assert.equal(classifyClaim({ ...base, records: { A: ['1.2.3.4'] } }, undefined), 'down');
+});
+
+test('issueName reads the claim out of a nudge title', () => {
+  assert.equal(issueName('dexi.runs-on.dev is pointing at Vercel but not serving your project'), 'dexi');
+  assert.equal(issueName('feel-your-phone.runs-on.dev should verify now — worth a re-check'), 'feel-your-phone');
+  assert.equal(issueName('sync-dns fails deleting existing records with 404'), null);
+  assert.equal(issueName(undefined), null);
+});
+
+test('closes a nudge issue once its name serves something real', () => {
+  const rows = [{ name: 'dexi', status: 'ok' }, { name: 'shrey', status: 'stuck' }];
+  const issues = [
+    { number: 35, title: 'dexi.runs-on.dev is pointing at Vercel but not serving your project' },
+    { number: 40, title: 'shrey.runs-on.dev is pointing at Vercel but not serving your project' },
+  ];
+  assert.deepEqual(planIssueClosures(rows, issues), [{ number: 35, name: 'dexi' }]);
+});
+
+test('a redirect counts as recovered, a bare profile card does not', () => {
+  const issues = [{ number: 1, title: 'a.runs-on.dev x' }, { number: 2, title: 'b.runs-on.dev x' }];
+  const rows = [{ name: 'a', status: 'redirect' }, { name: 'b', status: 'card' }];
+  // 'card' means the records were removed: no longer stuck, but not serving
+  // their site either, so "this is working now" would be untrue.
+  assert.deepEqual(planIssueClosures(rows, issues), [{ number: 1, name: 'a' }]);
+});
+
+test('never closes an issue for a name this run did not probe', () => {
+  const rows = [{ name: 'dexi', status: 'ok' }];
+  const issues = [{ number: 9, title: 'someoneelse.runs-on.dev is broken' }];
+  assert.deepEqual(planIssueClosures(rows, issues), []);
+});
+
+test('never closes an issue whose title it cannot parse', () => {
+  const rows = [{ name: 'dexi', status: 'ok' }];
+  assert.deepEqual(planIssueClosures(rows, [{ number: 9, title: 'Something else entirely' }]), []);
+});
+
+test('a down name keeps its issue open', () => {
+  const rows = [{ name: 'dexi', status: 'down' }];
+  assert.deepEqual(planIssueClosures(rows, [{ number: 35, title: 'dexi.runs-on.dev x' }]), []);
 });


### PR DESCRIPTION
Ten owners (#34–#43) were told their name serves the profile card instead of their site. Nothing tells them when it's fixed, so those issues go stale and closing them becomes a manual chore — which is exactly what the health check exists to eliminate.

## What it does

The daily run closes any `dns-stuck` issue whose name has recovered, with a comment saying so.

**Dry run against live data just now:**

```
yousufwizdan      ok
waruna            stuck
talha             stuck
shrey             stuck
shovith           stuck
mytldr            stuck
hussain           stuck
feel-your-phone   stuck
dexi              stuck
baibhavstha       stuck

WOULD CLOSE: [{"number":43,"name":"yousufwizdan"}]
```

## Safety

- **Label first, title second.** An unrelated issue opening with a claimed name can't be closed by this.
- **Never closes a name this run didn't probe.** An issue naming something absent from the registry is left alone — closing what we can't account for is worse than a stale issue.
- **`card` is not recovery.** A name whose records were removed is no longer stuck, but isn't serving its owner's site either; "this is working now" would be untrue.
- **Best effort, cannot fail the run.** The probe result is the point of the script; losing it to a bad minute on the issues API would be a poor trade.
- **Read-only locally.** No `GITHUB_TOKEN`, no writes — running it by hand still probes and reports.

## Splitting

`planIssueClosures` is pure and lives in `lib/health.js` alongside `classifyClaim`, following the split already there: the lib owns meaning, the script owns the network. Six new tests, 220 total.

Workflow gains `issues: write`.