### PR TITLE
Fail the health check on drift we caused, not on what someone else hasn't done

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -58,3 +58,46 @@ export function planIssueClosures(rows, issues) {
   }
   return closures;
 }
+
+// --- Drift between what the registry declares and what DNS actually serves ---
+//
+// This is the half of the health check that is ours to fix. A name stuck on
+// the profile card is waiting on its owner; a name whose declared records
+// never reached the zone means sync-dns did not do its job, silently, which
+// is the failure mode behind both #21 and #26. Nothing else looks for it.
+
+// Answers arrive in shapes that differ from what a record file declares:
+// resolvers hand back hostnames with a trailing dot and in arbitrary case,
+// and Node splits a long TXT string into chunks. Comparing raw would report
+// drift that is not there.
+export function normalizeAnswer(type, value) {
+  if (type === 'CNAME' || type === 'MX') {
+    return String(value).toLowerCase().replace(/\.$/, '');
+  }
+  return String(value);
+}
+
+export function expectationKey(type, host) {
+  return `${type} ${String(host).toLowerCase().replace(/\.$/, '')}`;
+}
+
+// `expected` is planDnsChanges output (plus the zone mirror), each entry
+// carrying the host it belongs at. `resolved` maps expectationKey() to the
+// normalized values that host actually serves.
+//
+// A subset check, not an exact match: the zone legitimately holds records
+// this registry never planned -- the apex, the wildcard, anything the
+// operator placed by hand -- and reporting those as drift would make the
+// gate cry wolf on its first run.
+export function findDrift(expected, resolved) {
+  const missing = [];
+  for (const record of expected) {
+    const key = expectationKey(record.type, record.host);
+    const want = normalizeAnswer(record.type, record.type === 'MX'
+      ? `${record.priority} ${record.value}`
+      : record.value);
+    const have = resolved.get(key) ?? [];
+    if (!have.includes(want)) missing.push({ ...record, key, want });
+  }
+  return missing;
+}

--- a/scripts/health-check.mjs
+++ b/scripts/health-check.mjs
@@ -1,6 +1,9 @@
 import { appendFile, readFile, readdir } from 'node:fs/promises';
-import { classifyClaim, planIssueClosures, STUCK_LABEL } from '../lib/health.js';
+import { classifyClaim, planIssueClosures, STUCK_LABEL, findDrift, normalizeAnswer, expectationKey } from '../lib/health.js';
+import { planDnsChanges, planZoneVerificationRecords } from '../lib/dns.js';
+import { Resolver } from 'node:dns/promises';
 
+const DOMAIN = 'runs-on.dev';
 const TIMEOUT_MS = 10_000;
 const CONCURRENCY = 8;
 
@@ -100,11 +103,73 @@ if (process.env.GITHUB_STEP_SUMMARY) {
 // issues API had a bad minute would be a poor trade.
 await closeRecoveredIssues(rows);
 
-if (stuck.length > 0) {
-  console.error(`health: ${stuck.length} name(s) stuck on the profile card`);
+// `stuck` and `down` are reported, never failed on. Both describe something
+// a third party has not done -- an owner who has not re-run their provider's
+// verification, a host having a bad afternoon -- and a scheduled job that
+// goes red for weeks over someone else's dashboard is a job everyone learns
+// to ignore, including on the day it means something. The open dns-stuck
+// issues track those, one per owner, and close themselves.
+//
+// Drift is different. It means the registry declares a record that DNS does
+// not serve, which can only be sync-dns having failed silently. That is ours,
+// it is actionable, and nothing else looks for it.
+const drift = await findDnsDrift(claims);
+
+if (drift.length > 0) {
+  console.error(`health: ${drift.length} declared record(s) missing from DNS`);
+  for (const record of drift) console.error(`  ${record.type} ${record.host} -> ${record.want}`);
   process.exit(1);
 }
-console.log('health: every pointed name serves something other than the card');
+console.log(`health: every declared record is live in DNS (${stuck.length} name(s) awaiting provider verification)`);
+
+async function findDnsDrift(allClaims) {
+  const expected = [
+    ...allClaims.flatMap((claim) =>
+      planDnsChanges(claim).map((change) => ({ ...change, host: `${change.name}.${DOMAIN}` }))),
+    ...planZoneVerificationRecords(allClaims).map((change) => ({ ...change, host: `${change.name}.${DOMAIN}` })),
+  ];
+
+  // A public resolver rather than the runner's: the runner's may cache an
+  // answer from before a sync, which would read as drift that is not there.
+  const resolver = new Resolver({ timeout: 5000, tries: 2 });
+  resolver.setServers(['1.1.1.1', '8.8.8.8']);
+
+  const resolved = new Map();
+  const hosts = [...new Set(expected.map((e) => expectationKey(e.type, e.host)))];
+  for (const key of hosts) {
+    const [type, host] = key.split(' ');
+    resolved.set(key, await lookup(resolver, type, host));
+  }
+
+  const missing = findDrift(expected, resolved);
+  if (missing.length === 0) return [];
+
+  // Re-check only what looked missing, once, before calling it drift. A
+  // record written minutes before this run may simply not have propagated,
+  // and a daily job that cries wolf over propagation is the noise this
+  // change exists to remove.
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  const recheck = new Map();
+  for (const record of missing) recheck.set(record.key, await lookup(resolver, record.type, record.host));
+  return findDrift(missing, recheck);
+}
+
+async function lookup(resolver, type, host) {
+  try {
+    if (type === 'CNAME') return (await resolver.resolveCname(host)).map((v) => normalizeAnswer('CNAME', v));
+    if (type === 'A') return await resolver.resolve4(host);
+    if (type === 'TXT') return (await resolver.resolveTxt(host)).map((chunks) => chunks.join(''));
+    if (type === 'MX') {
+      return (await resolver.resolveMx(host))
+        .map((mx) => normalizeAnswer('MX', `${mx.priority} ${mx.exchange}`));
+    }
+  } catch {
+    // NXDOMAIN, NODATA, or a resolver hiccup all mean "this host does not
+    // serve what we expect right now", which the caller re-checks before
+    // reporting.
+  }
+  return [];
+}
 
 async function closeRecoveredIssues(statusRows) {
   const token = process.env.GITHUB_TOKEN;

--- a/test/health.test.mjs
+++ b/test/health.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyClaim, issueName, planIssueClosures } from '../lib/health.js';
+import { classifyClaim, issueName, planIssueClosures, normalizeAnswer, findDrift } from '../lib/health.js';
 
 const base = { name: 'lucas', owner: { github: 'zordhalo' }, claimedAt: '2026-08-30T00:00:00Z' };
 
@@ -88,4 +88,45 @@ test('never closes an issue whose title it cannot parse', () => {
 test('a down name keeps its issue open', () => {
   const rows = [{ name: 'dexi', status: 'down' }];
   assert.deepEqual(planIssueClosures(rows, [{ number: 35, title: 'dexi.runs-on.dev x' }]), []);
+});
+
+test('normalizeAnswer strips the trailing dot and case from hostnames', () => {
+  assert.equal(normalizeAnswer('CNAME', 'CNAME.Vercel-DNS.com.'), 'cname.vercel-dns.com');
+  assert.equal(normalizeAnswer('MX', '10 MX.Example.COM.'), '10 mx.example.com');
+  // A TXT value is compared byte for byte: a verification token is case
+  // sensitive and a trailing dot inside one would be part of the value.
+  assert.equal(normalizeAnswer('TXT', 'vc-domain-verify=X.runs-on.dev,AbC.'), 'vc-domain-verify=X.runs-on.dev,AbC.');
+});
+
+test('findDrift reports a declared record the zone does not serve', () => {
+  const expected = [{ type: 'CNAME', host: 'dexi.runs-on.dev', value: 'cname.vercel-dns.com' }];
+  assert.equal(findDrift(expected, new Map()).length, 1);
+  const resolved = new Map([['CNAME dexi.runs-on.dev', ['cname.vercel-dns.com']]]);
+  assert.deepEqual(findDrift(expected, resolved), []);
+});
+
+test('findDrift is a subset check, so unplanned records are not drift', () => {
+  // The zone legitimately holds the apex, the wildcard, and anything placed
+  // by hand. Reporting those would make the gate cry wolf immediately.
+  const expected = [{ type: 'TXT', host: '_vercel.runs-on.dev', value: 'vc-domain-verify=a.runs-on.dev,tok' }];
+  const resolved = new Map([['TXT _vercel.runs-on.dev', [
+    'vc-domain-verify=a.runs-on.dev,tok',
+    'vc-domain-verify=someone-else.runs-on.dev,other',
+    'google-site-verification=whatever',
+  ]]]);
+  assert.deepEqual(findDrift(expected, resolved), []);
+});
+
+test('findDrift matches a resolver answer that came back dotted and uppercased', () => {
+  const expected = [{ type: 'CNAME', host: 'x.runs-on.dev', value: 'cname.vercel-dns.com' }];
+  const resolved = new Map([['CNAME x.runs-on.dev', [normalizeAnswer('CNAME', 'CNAME.Vercel-DNS.com.')]]]);
+  assert.deepEqual(findDrift(expected, resolved), []);
+});
+
+test('findDrift compares MX on priority as well as host', () => {
+  const expected = [{ type: 'MX', host: 'm.runs-on.dev', value: 'mx.example.com', priority: 10 }];
+  const wrongPriority = new Map([['MX m.runs-on.dev', ['20 mx.example.com']]]);
+  assert.equal(findDrift(expected, wrongPriority).length, 1);
+  const right = new Map([['MX m.runs-on.dev', ['10 mx.example.com']]]);
+  assert.deepEqual(findDrift(expected, right), []);
 });


### PR DESCRIPTION
## The problem

`scripts/health-check.mjs` exited 1 whenever any name was stuck. Nine are — waiting on nine other people to re-run verification in their own Vercel dashboards. So the job went red every morning over something this repo cannot fix, and would keep doing so for weeks.

A scheduled job that stays red is one everybody learns to ignore, including on the day it means something.

## What changed

`stuck` and `down` are reported, not failed on. Both describe a third party. The `dns-stuck` issues already track them, one per owner, closing themselves as names recover.

In their place: **every record a claim declares is resolved against public DNS.** A declared record that doesn't answer means `sync-dns` failed silently — the class of bug behind both #21 and #26, which nothing was looking for.

Red now means *the registry says one thing and DNS says another*, which is ours and actionable.

## Verified both directions

Clean, against all 122 claims:

```
health: every declared record is live in DNS (9 name(s) awaiting provider verification)
exit 0
```

And it fires on injected drift:

```
health: 1 declared record(s) missing from DNS
  CNAME lucas.runs-on.dev -> this-target-is-not-in-dns.example.com
exit 1
```

That clean run is itself a useful result: `sync-dns` is correct registry-wide, every declared record for all 122 claims is live.

## Design notes

- **Subset check, not exact match.** The zone legitimately holds the apex, the wildcard, and anything placed by hand; calling those drift would cry wolf on the first run.
- **Anything missing is re-checked once after a pause**, so a record written minutes before the run isn't reported before it propagates.
- **Public resolver (1.1.1.1 / 8.8.8.8)**, not the runner's, which may cache an answer from before a sync.
- Reuses `planDnsChanges` and `planZoneVerificationRecords` — the expectation list is the same code that writes the records, so the two can't drift from each other.

Comparison logic is pure in `lib/health.js` (`normalizeAnswer`, `findDrift`), following the split already there. 5 new tests, 225 total.