### PR TITLE
fix: diff-based DNS reconciliation — failed sync can no longer wipe a working name

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -98,3 +98,29 @@ export function createPath(domain) {
 export function removePath(domain, recordId) {
   return `/v2/domains/${domain}/records/${encodeURIComponent(recordId)}`;
 }
+
+// The diff that makes a sync safe: only the records that genuinely changed
+// are touched, and everything else survives untouched. The old flow —
+// delete every record for the name, then recreate them all — meant a single
+// failed create after a successful delete left a working name with no DNS
+// at all (issue #54). This shrinks the blast radius of a mid-sync failure
+// from "every record the name has" to "only the part being changed".
+//
+// Records are matched by type + name + value + MX priority. The Vercel API
+// returns `mxPriority` on existing records while planDnsChanges emits
+// `priority` on desired ones, so the key reads both.
+export function reconcileDnsRecords(existing, desired) {
+  const key = (record) => {
+    const priority = record.mxPriority ?? record.priority ?? '';
+    return `${record.type}|${record.name}|${record.value}|${priority}`;
+  };
+
+  const existingKeys = new Set(existing.map(key));
+  const desiredKeys = new Set(desired.map(key));
+
+  return {
+    unchanged: existing.filter((r) => desiredKeys.has(key(r))),
+    remove: existing.filter((r) => !desiredKeys.has(key(r))),
+    create: desired.filter((r) => !existingKeys.has(key(r))),
+  };
+}

--- a/scripts/sync-dns.mjs
+++ b/scripts/sync-dns.mjs
@@ -3,6 +3,7 @@ import {
   planDnsChanges,
   planZoneVerificationRecords,
   reconcileZoneVerification,
+  reconcileDnsRecords,
   listPath,
   createPath,
   removePath,
@@ -64,17 +65,78 @@ async function existingFor(name) {
   }
 }
 
-async function deleteStale(name) {
-  for (const stale of await existingFor(name)) {
-    const res = await vercel(removePath(DOMAIN, stale.id), { method: 'DELETE' });
-    // A rejected delete must stop the sync here: continuing on to create the new
-    // records would leave the stale ones live alongside them, with a green
-    // workflow log claiming everything is in sync.
-    if (!res.ok) {
-      console.error(`sync-dns: failed to delete ${stale.type} ${stale.name}: ${res.status} ${res.statusText}`);
+async function deleteRecord(stale) {
+  const res = await vercel(removePath(DOMAIN, stale.id), { method: 'DELETE' });
+  if (!res.ok) {
+    console.error(`sync-dns: failed to delete ${stale.type} ${stale.name}: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+  console.log(`deleted ${stale.type} ${stale.name}`);
+}
+
+async function createRecord(change) {
+  const body = { type: change.type, name: change.name, value: change.value, ttl: 3600 };
+  // Vercel's records API takes MX priority as a separate field, not folded
+  // into `value`.
+  if (change.type === 'MX') body.mxPriority = change.priority;
+  const res = await vercel(createPath(DOMAIN), {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    console.error(`failed to create ${change.type} ${change.name}: ${res.status}`);
+    return false;
+  }
+  console.log(`created ${change.type} ${change.name} -> ${change.value}`);
+  return true;
+}
+
+// Best-effort rollback when a create fails mid-sync. The records being
+// restored here are the ones that were just deleted as stale — restoring
+// them returns the name to its pre-sync state rather than leaving it with
+// a half-applied change. Each restore is attempted independently because
+// the API may still be in the transient state that caused the original
+// failure, and a second failure here means the name needs manual attention
+// regardless.
+async function rollback(deleted) {
+  if (deleted.length === 0) return;
+  console.error(`sync-dns: create failed — rolling back ${deleted.length} deleted record(s)`);
+  for (const stale of deleted) {
+    const change = { type: stale.type, name: stale.name, value: stale.value, priority: stale.mxPriority };
+    const ok = await createRecord(change).catch(() => false);
+    if (!ok) console.error(`sync-dns: ROLLBACK FAILED for ${stale.type} ${stale.name} — manual intervention needed`);
+  }
+}
+
+// Diff-based reconciliation (issue #54). Only records that genuinely
+// changed are deleted and recreated — everything else survives untouched,
+// so a mid-sync API failure can't take out records that weren't being
+// changed. If a create does fail, the just-deleted stale records are
+// restored as a best-effort rollback to the pre-sync state.
+async function reconcile(name, desired) {
+  const existing = await existingFor(name);
+  const { unchanged, remove, create } = reconcileDnsRecords(existing, desired);
+
+  if (unchanged.length > 0) {
+    console.log(`${name}: ${unchanged.length} record(s) unchanged, not touched`);
+  }
+
+  const deleted = [];
+  for (const stale of remove) {
+    await deleteRecord(stale);
+    deleted.push(stale);
+  }
+
+  for (const change of create) {
+    const ok = await createRecord(change);
+    if (!ok) {
+      await rollback(deleted);
       process.exit(1);
     }
-    console.log(`deleted ${stale.type} ${stale.name}`);
+  }
+
+  if (remove.length === 0 && create.length === 0 && unchanged.length > 0) {
+    console.log(`${name}: already in sync`);
   }
 }
 
@@ -92,30 +154,13 @@ for (const file of changed) {
     // The record file is gone (owner released the name, or a maintainer removed
     // it). Without this, readFile throws and the workflow crashes here, leaving
     // the ex-owner's DNS live indefinitely.
-    await deleteStale(name);
+    for (const stale of await existingFor(name)) await deleteRecord(stale);
     console.log(`${name}: record removed, DNS cleared`);
     continue;
   }
 
   const desired = planDnsChanges(record);
-
-  await deleteStale(name);
-
-  for (const change of desired) {
-    const body = { type: change.type, name: change.name, value: change.value, ttl: 3600 };
-    // Vercel's records API takes MX priority as a separate field, not folded
-    // into `value`.
-    if (change.type === 'MX') body.mxPriority = change.priority;
-    const res = await vercel(createPath(DOMAIN), {
-      method: 'POST',
-      body: JSON.stringify(body),
-    });
-    if (!res.ok) {
-      console.error(`failed to create ${change.type} ${change.name}: ${res.status}`);
-      process.exit(1);
-    }
-    console.log(`created ${change.type} ${change.name} -> ${change.value}`);
-  }
+  await reconcile(name, desired);
 
   if (desired.length === 0) console.log(`${name}: no records, wildcard serves the profile card`);
 }
@@ -149,24 +194,12 @@ const { create: toMirror, remove: toUnmirror } = reconcileZoneVerification(
 );
 
 for (const stale of toUnmirror) {
-  const res = await vercel(removePath(DOMAIN, stale.id), { method: 'DELETE' });
-  if (!res.ok) {
-    console.error(`sync-dns: failed to delete ${stale.type} ${stale.name}: ${res.status} ${res.statusText}`);
-    process.exit(1);
-  }
-  console.log(`deleted ${stale.type} ${stale.name}`);
+  await deleteRecord(stale);
 }
 
 for (const change of toMirror) {
-  const res = await vercel(createPath(DOMAIN), {
-    method: 'POST',
-    body: JSON.stringify({ type: change.type, name: change.name, value: change.value, ttl: 3600 }),
-  });
-  if (!res.ok) {
-    console.error(`failed to create ${change.type} ${change.name}: ${res.status}`);
-    process.exit(1);
-  }
-  console.log(`created ${change.type} ${change.name} -> ${change.value}`);
+  const ok = await createRecord(change);
+  if (!ok) process.exit(1);
 }
 
 if (toMirror.length === 0 && toUnmirror.length === 0) {

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -4,6 +4,7 @@ import {
   planDnsChanges,
   planZoneVerificationRecords,
   reconcileZoneVerification,
+  reconcileDnsRecords,
   listPath,
   createPath,
   removePath,
@@ -124,6 +125,87 @@ test('claims without _vercel TXTs plan no zone records', () => {
     ]),
     [],
   );
+});
+
+// --- reconcileDnsRecords (issue #54) ---
+
+test('identical existing and desired records are all unchanged — nothing touched', () => {
+  const existing = [
+    { id: 'rec_1', type: 'CNAME', name: 'lucas', value: 'cname.vercel-dns.com' },
+  ];
+  const desired = [
+    { type: 'CNAME', name: 'lucas', value: 'cname.vercel-dns.com' },
+  ];
+  const { unchanged, remove, create } = reconcileDnsRecords(existing, desired);
+  assert.equal(unchanged.length, 1);
+  assert.equal(remove.length, 0);
+  assert.equal(create.length, 0);
+});
+
+test('a CNAME value change produces exactly one remove and one create, not a full wipe', () => {
+  const existing = [
+    { id: 'rec_1', type: 'CNAME', name: 'lucas', value: 'old.vercel-dns.com' },
+    { id: 'rec_2', type: 'TXT', name: '_vercel.lucas', value: 'vc-domain-verify=lucas.runs-on.dev,abc' },
+  ];
+  const desired = [
+    { type: 'CNAME', name: 'lucas', value: 'new.vercel-dns.com' },
+    { type: 'TXT', name: '_vercel.lucas', value: 'vc-domain-verify=lucas.runs-on.dev,abc' },
+  ];
+  const { unchanged, remove, create } = reconcileDnsRecords(existing, desired);
+  // The TXT is untouched even though the CNAME changed — this is the exact
+  // safety property issue #54 asks for: a failed create only takes down the
+  // record being changed, not the whole name.
+  assert.equal(unchanged.length, 1);
+  assert.equal(unchanged[0].type, 'TXT');
+  assert.equal(remove.length, 1);
+  assert.equal(remove[0].value, 'old.vercel-dns.com');
+  assert.equal(create.length, 1);
+  assert.equal(create[0].value, 'new.vercel-dns.com');
+});
+
+test('an empty desired set removes everything (name released)', () => {
+  const existing = [
+    { id: 'rec_1', type: 'CNAME', name: 'lucas', value: 'x.example.com' },
+  ];
+  const { remove, create, unchanged } = reconcileDnsRecords(existing, []);
+  assert.equal(remove.length, 1);
+  assert.equal(create.length, 0);
+  assert.equal(unchanged.length, 0);
+});
+
+test('MX records with the same priority match across mxPriority and priority field names', () => {
+  const existing = [
+    { id: 'rec_1', type: 'MX', name: 'lucas', value: 'mx1.example.com', mxPriority: 10 },
+  ];
+  const desired = [
+    { type: 'MX', name: 'lucas', value: 'mx1.example.com', priority: 10 },
+  ];
+  const { unchanged, remove, create } = reconcileDnsRecords(existing, desired);
+  assert.equal(unchanged.length, 1);
+  assert.equal(remove.length, 0);
+  assert.equal(create.length, 0);
+});
+
+test('MX priority change produces a remove + create pair', () => {
+  const existing = [
+    { id: 'rec_1', type: 'MX', name: 'lucas', value: 'mx1.example.com', mxPriority: 10 },
+  ];
+  const desired = [
+    { type: 'MX', name: 'lucas', value: 'mx1.example.com', priority: 20 },
+  ];
+  const { remove, create } = reconcileDnsRecords(existing, desired);
+  assert.equal(remove.length, 1);
+  assert.equal(create.length, 1);
+});
+
+test('a no-op save touches zero DNS records', () => {
+  // The scenario a double-clicked Save produces: same record, same values.
+  // The old flow deleted and recreated everything; this must be a no-op.
+  const record = { type: 'CNAME', name: 'lucas', value: 'cname.vercel-dns.com' };
+  const existing = [{ id: 'rec_1', ...record }];
+  const { unchanged, remove, create } = reconcileDnsRecords(existing, [record]);
+  assert.deepEqual({ remove, create }, { remove: [], create: [] });
+  assert.equal(unchanged.length, 1);
 });
 
 test('reconcile creates missing values and drops only unclaimed vc-domain-verify TXTs', () => {


### PR DESCRIPTION
Fixes #54.

## What changed

The sync flow was delete-everything-then-recreate-everything. A single failed create after a successful delete left a working name with no DNS at all — a transient Vercel API error, rate limit, or rejected record turned a working domain into an outage.

`reconcileDnsRecords(existing, desired)` in `lib/dns.js` computes a three-way diff:

- **unchanged** — exist in both sets → untouched entirely, zero API calls
- **remove** — exist but not in desired → deleted (genuinely stale)
- **create** — in desired but don't exist → created (genuinely new)

A mid-sync failure now affects only the record being changed, not the rest of the name's configuration. If a create does fail after stale records were deleted, a **best-effort rollback** restores them to the pre-sync state, logging any restore that also fails so the name is flagged for manual attention.

## The scenario that motivated this

A name with `CNAME + _vercel TXT` edits only the CNAME target. Under the old flow:
1. `deleteStale` removes both the CNAME and the TXT
2. The CNAME create succeeds
3. The TXT create hits a rate limit → script exits
4. The name is now serving DNS with no verification TXT — silently broken

Under the new flow:
1. `reconcileDnsRecords` identifies the old CNAME as stale, the TXT as unchanged
2. Only the old CNAME is deleted
3. The new CNAME is created
4. If it fails → rollback restores the old CNAME → the name keeps working with its previous configuration

## MX priority normalization

The Vercel API returns `mxPriority` on existing records while `planDnsChanges` emits `priority` on desired ones. The match key reads both, so an unchanged MX round-trips as unchanged rather than producing a spurious delete+create pair.

## Testing

- 231/231 tests green (6 new covering: identical sets → zero-touch, partial change → only the changed record is replaced, empty desired → full cleanup, MX field-name matching, MX priority change, and the no-op save scenario)
- `node --check` on the script
- The zone-mirror section at the bottom already used its own idempotent reconciliation and now shares the same `deleteRecord`/`createRecord` helpers