### PR TITLE
fix(ci): stop deploying on data pushes + daily schedule for /stats

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,23 @@ name: deploy
 on:
   push:
     branches: [main]
+    # Registry data pushes (claims, record edits, the owners index, docs)
+    # change nothing the site serves, but each one used to build and upload
+    # the full app anyway. The day the registry got busy that burned through
+    # Vercel's free-tier upload quota ("api-upload-paid, more than 40000")
+    # and every deploy after it failed while claims kept landing. Data
+    # commits no longer deploy at all; the schedule below and
+    # workflow_dispatch remain the paths for forcing one.
+    #
+    # /stats is the one page that reads domains/ at build time rather than
+    # through the runtime API, so it depends on a deploy to stay fresh. The
+    # daily schedule covers it: the numbers are never more than a day stale,
+    # which costs one deploy instead of one per claim.
+    paths-ignore: ['domains/**', 'owners/**', 'data/**', 'docs/**', '*.md']
+  schedule:
+    # Daily at 04:00 UTC, off the top of the hour so it doesn't co-fire with
+    # the health check. Rebuilds /stats from the current state of domains/.
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Split from #53 per review. This is the urgent half: the deploy quota fix, now with the /stats rebuild the review correctly flagged as blocked by paths-ignore.

## What changed

1. `paths-ignore: ['domains/**', 'owners/**', 'data/**', 'docs/**', '*.md']` on the push trigger. Registry data commits change nothing the site serves (everything reads through the runtime GitHub API except /stats), so they stop deploying entirely.

2. `schedule: cron '0 4 * * *'` added to the same workflow. /stats reads `domains/` at build time (`force-static` + `readdirSync`), so it needs a deploy to stay fresh. One scheduled deploy per day instead of one per claim. The numbers are never more than a day stale, and the quota spends one deploy daily instead of dozens.

`workflow_dispatch` stays as the manual force path.

## Why this is urgent

Every push to main since 2026-09-02 17:35 UTC has failed the deploy with `api-upload-paid` (more than 40000 file uploads). The live site is frozen at the 17:35 build. Claims keep landing green (sync-dns and sync-owners are fine), but nothing app-side has deployed since. This PR stops the bleeding and adds the one scheduled rebuild /stats needs.