### PR TITLE
Profile cards (link-in-bio), manage DNS-verification panel, per-claim banners

### DIFF
--- a/app/api/dns-check/route.js
+++ b/app/api/dns-check/route.js
@@ -1,0 +1,85 @@
+import dns from 'node:dns/promises';
+import { validateName } from '../../../lib/name.js';
+import { getRecord } from '../../../lib/registry.js';
+import { classifyClaim } from '../../../lib/health.js';
+
+// Node runtime for node:dns — edge has no resolver. Dynamic because the
+// answer is a live DNS reading; caching it would turn "did it work?" into
+// "did it work five minutes ago".
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ZONE = 'runs-on.dev';
+const PROBE_TIMEOUT_MS = 8000;
+
+// Everything this endpoint returns is already public: DNS answers and the
+// page a name serves. It accepts any grammar-valid name for that reason —
+// but it still reads the record through the same short revalidate window the
+// card uses, so a poll loop costs the registry's GitHub quota almost
+// nothing rather than one authenticated read per poll.
+async function safe(fn, fallback) {
+  try {
+    return await fn();
+  } catch {
+    return fallback;
+  }
+}
+
+function flattenTxt(records) {
+  return (records ?? []).map((chunks) => chunks.join(''));
+}
+
+async function probe(name) {
+  try {
+    const res = await fetch(`https://${name}.${ZONE}/`, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      headers: { 'user-agent': 'runs-on-dev-dns-check (github.com/zordhalo/runs-on.dev)' },
+    });
+    const body = await res.text();
+    const title = /<title[^>]*>([^<]*)<\/title>/i.exec(body)?.[1]?.trim() ?? '';
+    return { ok: true, finalHost: new URL(res.url).hostname, title, finalUrl: res.url };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export async function GET(request) {
+  const name = (new URL(request.url).searchParams.get('name') ?? '').trim().toLowerCase();
+  if (!validateName(name).ok) {
+    return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+
+  const token = process.env.CARD_TOKEN ?? process.env.REGISTRY_TOKEN;
+  const fetchImpl = (url, init) => fetch(url, { ...init, next: { revalidate: 30 } });
+  const record = await safe(() => getRecord(name, { token, fetchImpl }), null);
+  if (!record) return Response.json({ error: 'not_found' }, { status: 404 });
+
+  const [cname, a, txtName, txtVercelLabel, txtVercelZone, servingProbe] = await Promise.all([
+    safe(() => dns.resolveCname(`${name}.${ZONE}`), []),
+    safe(() => dns.resolve4(`${name}.${ZONE}`), []),
+    safe(() => dns.resolveTxt(`${name}.${ZONE}`), []),
+    safe(() => dns.resolveTxt(`_vercel.${name}.${ZONE}`), []),
+    // The zone-level host the mirror publishes to: reading it here is what
+    // lets the panel say "published at the zone" instead of making the owner
+    // trust a green checkmark they cannot see anywhere.
+    safe(() => dns.resolveTxt(`_vercel.${ZONE}`), []),
+    probe(name),
+  ]);
+
+  return Response.json({
+    name,
+    cname,
+    a,
+    txt: {
+      name: flattenTxt(txtName),
+      vercelLabel: flattenTxt(txtVercelLabel),
+      zoneVercel: flattenTxt(txtVercelZone),
+    },
+    serving: {
+      status: classifyClaim(record, servingProbe),
+      title: servingProbe.ok ? servingProbe.title : null,
+      finalUrl: servingProbe.ok ? servingProbe.finalUrl : null,
+    },
+  });
+}

--- a/app/api/dns-check/route.js
+++ b/app/api/dns-check/route.js
@@ -2,6 +2,7 @@ import dns from 'node:dns/promises';
 import { validateName } from '../../../lib/name.js';
 import { getRecord } from '../../../lib/registry.js';
 import { classifyClaim } from '../../../lib/health.js';
+import { createRateLimiter } from '../../../lib/throttle.js';
 
 // Node runtime for node:dns — edge has no resolver. Dynamic because the
 // answer is a live DNS reading; caching it would turn "did it work?" into
@@ -11,6 +12,42 @@ export const dynamic = 'force-dynamic';
 
 const ZONE = 'runs-on.dev';
 const PROBE_TIMEOUT_MS = 8000;
+
+// Same budget the write routes use: generous for a real owner polling after
+// a save, tight enough that a leaned-on loop can't spend the registry's DNS
+// resolver or outbound bandwidth indefinitely. Keyed on the requested name,
+// which is the natural abuse unit (one name per poller).
+const CHECK_WINDOW_MS = 60 * 1000;
+const CHECK_MAX = 10;
+const takeCheck = createRateLimiter({ windowMs: CHECK_WINDOW_MS, max: CHECK_MAX });
+
+// SSRF guard: the record's A entries and any redirect target must not point
+// at a private network the server can reach. lib/schema.js accepts any valid
+// IPv4 including loopback, link-local, and RFC 1918 ranges — the schema
+// governs what DNS can express, not what this endpoint should fetch.
+const PRIVATE_RANGES = [
+  /^10\./,
+  /^127\./,
+  /^169\.254\./,
+  /^172\.(1[6-9]|2[0-9]|3[01])\./,
+  /^192\.168\./,
+  /^0\./,
+  /^::1$/,
+  /^f[cd][0-9a-f]{2}:/i,
+];
+
+export function isPrivateAddress(host) {
+  if (PRIVATE_RANGES.some((pattern) => pattern.test(host))) return true;
+  // An A record pointing at a private range is the same attack: the name
+  // resolves, the fetch goes to the private address, and the response body
+  // comes back through this endpoint.
+  return false;
+}
+
+async function resolveAndCheckPrivate(hostname) {
+  const addresses = await dns.resolve4(hostname).catch(() => []);
+  return addresses.some((addr) => PRIVATE_RANGES.some((pattern) => pattern.test(addr)));
+}
 
 // Everything this endpoint returns is already public: DNS answers and the
 // page a name serves. It accepts any grammar-valid name for that reason —
@@ -29,16 +66,33 @@ function flattenTxt(records) {
   return (records ?? []).map((chunks) => chunks.join(''));
 }
 
+// No redirect following. The initial URL is always <name>.runs-on.dev
+// (grammar-validated), so the destination is constrained by DNS, not by
+// whoever set the record. A URL-redirect name will still be classified
+// correctly: the registry's own wildcard serves the 307 itself, and the
+// probe sees the registry's page, not the redirect target.
 async function probe(name) {
+  const host = `${name}.${ZONE}`;
   try {
-    const res = await fetch(`https://${name}.${ZONE}/`, {
-      redirect: 'follow',
+    // SSRF: if the name's A records point at a private range, the fetch
+    // would reach inside the network. Resolve first, refuse before fetching.
+    if (await resolveAndCheckPrivate(host)) {
+      return { ok: true, refused: true, finalHost: host, title: '', finalUrl: `https://${host}/` };
+    }
+    const res = await fetch(`https://${host}/`, {
+      redirect: 'manual',
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
       headers: { 'user-agent': 'runs-on-dev-dns-check (github.com/zordhalo/runs-on.dev)' },
     });
+    const location = res.headers.get('location');
+    // A 3xx without following the redirect: classify by the status, don't
+    // fetch wherever it points.
+    if (res.status >= 300 && res.status < 400 && location) {
+      return { ok: true, finalHost: host, title: '', finalUrl: location, redirected: true };
+    }
     const body = await res.text();
     const title = /<title[^>]*>([^<]*)<\/title>/i.exec(body)?.[1]?.trim() ?? '';
-    return { ok: true, finalHost: new URL(res.url).hostname, title, finalUrl: res.url };
+    return { ok: true, finalHost: host, title, finalUrl: `https://${host}/` };
   } catch {
     return { ok: false };
   }
@@ -48,6 +102,15 @@ export async function GET(request) {
   const name = (new URL(request.url).searchParams.get('name') ?? '').trim().toLowerCase();
   if (!validateName(name).ok) {
     return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+
+  const budget = takeCheck(name);
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
   }
 
   const token = process.env.CARD_TOKEN ?? process.env.REGISTRY_TOKEN;
@@ -78,7 +141,7 @@ export async function GET(request) {
     },
     serving: {
       status: classifyClaim(record, servingProbe),
-      title: servingProbe.ok ? servingProbe.title : null,
+      title: servingProbe.ok && !servingProbe.refused ? servingProbe.title : null,
       finalUrl: servingProbe.ok ? servingProbe.finalUrl : null,
     },
   });

--- a/app/api/records/route.js
+++ b/app/api/records/route.js
@@ -61,7 +61,10 @@ export async function POST(request) {
 
   // Replace only what the request actually sent. A form that does not yet
   // understand `subdomains` must not silently delete an owner's _atproto
-  // entry just by omitting it from the payload.
+  // entry just by omitting it from the payload. `profile` follows the same
+  // contract, with `null` as the explicit "remove it" signal, because
+  // omitting the key and emptying the fields are different intents: the
+  // first is an older form, the second is an owner clearing their card.
   const head = { ...meta.data };
   if ('records' in body) head.records = body.records;
   if ('subdomains' in body) {
@@ -69,6 +72,10 @@ export async function POST(request) {
     const empty = subs === null || (typeof subs === 'object' && Object.keys(subs).length === 0);
     if (empty) delete head.subdomains;
     else head.subdomains = subs;
+  }
+  if ('profile' in body) {
+    if (body.profile === null) delete head.profile;
+    else head.profile = body.profile;
   }
 
   // Nothing to do. Answering before the ownership check would leak whether a

--- a/app/banner/[name]/route.js
+++ b/app/banner/[name]/route.js
@@ -1,0 +1,25 @@
+import { ImageResponse } from 'next/og';
+import { ClaimBanner, BANNER_SIZE, claimBannerData } from '../../../lib/claim-banner.jsx';
+import { validateName } from '../../../lib/name.js';
+
+// The shareable per-claim banner: /banner/<name>?theme=dark for the GitHub
+// README look, light by default to match the site. Everything it renders is
+// public record, so the response caches at the edge for five minutes — long
+// enough that a popular README costs nothing per view, short enough that a
+// just-saved profile change shows up promptly.
+export async function GET(request, { params }) {
+  const { name } = await params;
+  if (!validateName(name).ok) {
+    return new Response('not found', { status: 404 });
+  }
+
+  const data = await claimBannerData(name);
+  if (!data) {
+    return new Response('not found', { status: 404 });
+  }
+
+  const theme = new URL(request.url).searchParams.get('theme') === 'dark' ? 'dark' : 'light';
+  const res = new ImageResponse(<ClaimBanner {...data} theme={theme} />, { ...BANNER_SIZE });
+  res.headers.set('Cache-Control', 'public, max-age=300, stale-while-revalidate=600');
+  return res;
+}

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { commitUrl, shortSha } from '../../lib/repo.js';
 import {
   modeOf, mxToLines, buildRecords,
   SUBDOMAIN_TYPES, buildSubdomains, subdomainsToRows,
+  buildProfile, profileToRows,
 } from '../../lib/record-fields.js';
 
 const MAX_SUBDOMAINS = 10;
+const MAX_LINKS = 8;
 
 const MODE_LABELS = [
   { id: 'card', label: 'profile card', hint: 'No DNS records. The name serves your GitHub card.' },
@@ -27,6 +29,9 @@ export default function RecordForm({ name, record }) {
   const [errors, setErrors] = useState([]);
   const [commit, setCommit] = useState(null);
   const [subRows, setSubRows] = useState(() => subdomainsToRows(record.subdomains));
+  const [displayName, setDisplayName] = useState(record.profile?.name ?? '');
+  const [bio, setBio] = useState(record.profile?.bio ?? '');
+  const [linkRows, setLinkRows] = useState(() => profileToRows(record.profile));
 
   function setRow(i, patch) {
     setSubRows((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r)));
@@ -44,6 +49,16 @@ export default function RecordForm({ name, record }) {
     setStatus(null);
   }
 
+  function setLinkRow(i, patch) {
+    setLinkRows((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r)));
+    setStatus(null);
+  }
+
+  function removeLink(i) {
+    setLinkRows((rows) => rows.filter((_, j) => j !== i));
+    setStatus(null);
+  }
+
   async function save(event) {
     event.preventDefault();
     setStatus('saving');
@@ -56,6 +71,10 @@ export default function RecordForm({ name, record }) {
         name,
         records: buildRecords(mode, { cname, url, a, txt, mx }),
         subdomains: buildSubdomains(subRows),
+        // null is the explicit "no profile" — it removes the block from the
+        // record, where omitting the key would leave an older form's profile
+        // silently in place.
+        profile: buildProfile({ name: displayName, bio, linkRows }) ?? null,
       }),
     });
     const body = await res.json().catch(() => ({}));
@@ -213,6 +232,81 @@ export default function RecordForm({ name, record }) {
         )}
       </fieldset>
 
+      <fieldset className="mt-8 border-t border-(--color-rule) pt-5">
+        <legend className="sr-only">Profile card</legend>
+        <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+          profile
+        </p>
+        <p className="mt-1 text-xs leading-relaxed text-(--color-muted)">
+          What the profile card shows at{' '}
+          <span className="font-(family-name:--font-mono)">{name}.runs-on.dev</span>. Every
+          field falls back to your GitHub profile when empty; links are yours to add.
+        </p>
+
+        <div className="mt-4 space-y-4">
+          <Input
+            label="display name"
+            value={displayName}
+            onChange={(v) => { setDisplayName(v); setStatus(null); }}
+            placeholder="GitHub profile name"
+          />
+          <Area
+            label="bio"
+            value={bio}
+            onChange={(v) => { setBio(v); setStatus(null); }}
+            placeholder="GitHub profile bio"
+            hint="Up to 200 characters."
+          />
+
+          {linkRows.length > 0 && (
+            <div className="space-y-2">
+              {linkRows.map((row, i) => (
+                <div key={i} className="flex flex-wrap items-center gap-2">
+                  <input
+                    value={row.label}
+                    onChange={(e) => setLinkRow(i, { label: e.target.value })}
+                    placeholder="My portfolio"
+                    aria-label="Link label"
+                    className="w-36 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
+                  />
+                  <input
+                    value={row.url}
+                    onChange={(e) => setLinkRow(i, { url: e.target.value })}
+                    placeholder="https://…"
+                    aria-label="Link URL"
+                    spellCheck={false}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    className="min-w-0 flex-1 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeLink(i)}
+                    className="font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)"
+                  >
+                    remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {linkRows.length < MAX_LINKS ? (
+            <button
+              type="button"
+              onClick={() => { setLinkRows((rows) => [...rows, { label: '', url: '' }]); setStatus(null); }}
+              className="border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
+            >
+              + add a link
+            </button>
+          ) : (
+            <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+              {`// ${MAX_LINKS} is the limit`}
+            </p>
+          )}
+        </div>
+      </fieldset>
+
       <div className="mt-6 flex flex-wrap items-center gap-4">
         <button
           type="submit"
@@ -247,8 +341,135 @@ export default function RecordForm({ name, record }) {
           {errors.map((e) => <li key={e}>{e}</li>)}
         </ul>
       )}
+
+      {status === 'saved' && (
+        <VerifyPanel
+          name={name}
+          cname={mode === 'cname' ? cname.trim() : null}
+          url={mode === 'url' ? url.trim() : null}
+          hasDns={mode !== 'card' && mode !== 'url' || subRows.length > 0}
+          vercelTxt={subRows
+            .filter((r) => r.label.trim().toLowerCase() === '_vercel' && r.type === 'TXT')
+            .flatMap((r) => r.value.split('\n').map((v) => v.trim()).filter(Boolean))}
+        />
+      )}
     </form>
   );
+}
+
+// The "did it work?" half of saving. DNS answers and the wildcard are public,
+// so this reads /api/dns-check (no session, no secrets) and compares live
+// resolution against what was just committed, until everything checks out or
+// a few minutes pass. The Vercel line exists because a freshly published
+// CNAME + TXT still serves the profile card until Vercel is asked to
+// re-check — the exact trap that every early Vercel-pointed name fell into
+// while looking perfectly configured.
+function VerifyPanel({ name, cname, url, hasDns, vercelTxt }) {
+  const [check, setCheck] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/dns-check?name=${encodeURIComponent(name)}`);
+        if (res.ok && alive) setCheck(await res.json());
+      } catch {
+        // Next tick retries; a transient network failure is not a verdict.
+      }
+    };
+    tick();
+    const done = check && cnameOk(check, cname) && pageOk(check, { cname, url, hasDns, vercelTxt });
+    const timer = done ? null : setInterval(tick, 8000);
+    return () => {
+      alive = false;
+      if (timer) clearInterval(timer);
+    };
+  }, [name, cname, url, hasDns, vercelTxt, check]);
+
+  if (!check) {
+    return (
+      <div className="mt-6 border border-(--color-rule) p-4 font-(family-name:--font-mono) text-xs text-(--color-muted)">
+        {'// did it work? — checking DNS…'}
+      </div>
+    );
+  }
+
+  const rows = [];
+  if (cname) {
+    const resolved = check.cname ?? [];
+    rows.push({
+      ok: resolved.includes(cname) || resolved.some((r) => r.toLowerCase() === cname.toLowerCase()),
+      text: resolved.length
+        ? `CNAME → ${resolved[0]}`
+        : `CNAME not visible yet (updates within seconds, caches up to 10 min)`,
+    });
+  }
+  if (vercelTxt.length > 0) {
+    const zone = check.txt?.zoneVercel ?? [];
+    const published = vercelTxt.some((v) => zone.includes(v));
+    rows.push({
+      ok: published,
+      text: published
+        ? '_vercel TXT published at the zone'
+        : '_vercel TXT not at the zone yet — the mirror publishes it on the sync',
+    });
+  }
+
+  const page = pageState(check, { cname, url, hasDns });
+  rows.push({ ok: page.ok, text: page.text });
+
+  return (
+    <div className="mt-6 border border-(--color-rule) p-4">
+      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+        {'// did it work?'}
+      </p>
+      <ul className="mt-2 space-y-1 font-(family-name:--font-mono) text-xs sm:text-[13px]">
+        {rows.map((row, i) => (
+          <li key={i} className={row.ok ? 'text-(--color-ink)' : 'text-(--color-muted)'}>
+            {row.ok ? '✓' : '…'} {row.text}
+          </li>
+        ))}
+      </ul>
+      {page.hint && (
+        <p className="mt-2 border-t border-(--color-rule) pt-2 text-xs leading-relaxed text-(--color-muted)">
+          {page.hint}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function cnameOk(check, cname) {
+  if (!cname) return true;
+  const resolved = check.cname ?? [];
+  return resolved.some((r) => r.toLowerCase() === cname.toLowerCase());
+}
+
+function pageOk(check, expected) {
+  return pageState(check, expected).ok;
+}
+
+function pageState(check, { cname, url, hasDns }) {
+  const status = check.serving?.status;
+  const isVercel = typeof cname === 'string' && cname.includes('vercel-dns');
+
+  if (status === 'ok') return { ok: true, text: `serving your site — ${check.serving.title ?? ''}` };
+  if (status === 'redirect' && url) {
+    return { ok: true, text: `redirecting to ${check.serving.finalUrl ?? url}` };
+  }
+  if (status === 'card' && !hasDns && !cname) {
+    return { ok: true, text: 'serving the profile card (no DNS records — as picked)' };
+  }
+  if (status === 'card' || status === 'stuck') {
+    return {
+      ok: false,
+      text: 'still serving the profile card',
+      hint: isVercel
+        ? 'DNS is live but Vercel has not re-checked ownership yet: your Vercel project → Settings → Domains → hit Refresh next to the domain.'
+        : 'DNS may still be propagating; if it persists, your provider may be waiting on a verification record.',
+    };
+  }
+  return { ok: false, text: 'no answer yet — DNS may still be propagating' };
 }
 
 const SUB_PLACEHOLDER = {

--- a/app/owned-name.jsx
+++ b/app/owned-name.jsx
@@ -65,6 +65,22 @@ export default function OwnedName({ name, record }) {
         >
           the record →
         </a>
+        <a
+          className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
+          href={`/banner/${name}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          your banner →
+        </a>
+        <a
+          className="font-(family-name:--font-mono) text-sm text-(--color-signal) underline"
+          href={`/banner/${name}?theme=dark`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          dark, for GitHub →
+        </a>
       </div>
     </div>
   );

--- a/app/sites/[name]/page.jsx
+++ b/app/sites/[name]/page.jsx
@@ -15,10 +15,12 @@ const CARD_TOKEN = process.env.CARD_TOKEN ?? process.env.REGISTRY_TOKEN;
 
 async function githubProfile(login) {
   const res = await fetch(`https://api.github.com/users/${login}`, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${CARD_TOKEN}`,
-    },
+    // Authorization only when a token actually exists: `Bearer undefined`
+    // is a malformed credential GitHub answers with 401, not an anonymous
+    // request — the same trap lib/claim-banner.jsx guards against.
+    headers: CARD_TOKEN
+      ? { Accept: 'application/vnd.github+json', Authorization: `Bearer ${CARD_TOKEN}` }
+      : { Accept: 'application/vnd.github+json' },
     next: { revalidate: 3600 },
   });
   if (!res.ok) return null;
@@ -42,7 +44,15 @@ export async function generateMetadata({ params }) {
   if (!record) return { title: { absolute: 'Not found' }, robots: { index: false } };
 
   const profile = await githubProfile(record.owner.github);
-  return cardMetadata({ name, record, profile });
+  // Field-by-field merge, same as the page below: record.profile wins where
+  // set, GitHub fills the rest, so title/description and the rendered card
+  // can never disagree.
+  const merged = {
+    ...profile,
+    name: record.profile?.name ?? profile?.name,
+    bio: record.profile?.bio ?? profile?.bio,
+  };
+  return cardMetadata({ name, record, profile: merged });
 }
 
 export default async function Site({ params }) {
@@ -64,6 +74,16 @@ export default async function Site({ params }) {
 
   const profile = await githubProfile(record.owner.github);
 
+  // The record's profile block overrides what GitHub reports, field by
+  // field: an owner who set profile.name keeps their chosen display name
+  // even when the GitHub profile says something else, and an unset field
+  // falls back rather than blanking the card. cardMetadata receives the
+  // merged view so the page and its meta tags can never disagree.
+  const overrides = record.profile ?? {};
+  const displayName = overrides.name ?? profile?.name;
+  const bio = overrides.bio ?? profile?.bio;
+  const links = Array.isArray(overrides.links) ? overrides.links : [];
+
   return (
     <main className="mx-auto max-w-2xl px-6 py-16 sm:py-24">
       <p className="font-(family-name:--font-mono) text-xs tracking-[0.14em] text-(--color-muted) uppercase">
@@ -82,14 +102,45 @@ export default async function Site({ params }) {
             />
           )}
           <div>
-            <h1 className="font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink) sm:text-3xl">
-              {name}.runs-on.dev
-            </h1>
-            {profile?.name && <p className="text-sm text-(--color-muted)">{profile.name}</p>}
+            <div className="flex items-center gap-2">
+              <a
+                href={`https://${name}.runs-on.dev`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink) underline decoration-(--color-muted) underline-offset-4 transition-colors hover:text-(--color-signal) hover:decoration-(--color-signal) sm:text-3xl"
+              >
+                {name}.runs-on.dev
+              </a>
+              <a
+                href="/manage"
+                className="flex items-center justify-center border border-(--color-rule) px-2.5 py-1 font-(family-name:--font-mono) text-xs text-(--color-muted) transition-colors hover:border-(--color-signal) hover:text-(--color-signal)"
+              >
+                manage
+              </a>
+            </div>
+            {displayName && <p className="text-sm text-(--color-muted)">{displayName}</p>}
           </div>
         </div>
 
-        {profile?.bio && <p className="mt-4 text-sm leading-relaxed">{profile.bio}</p>}
+        {bio && <p className="mt-4 text-sm leading-relaxed">{bio}</p>}
+
+        {links.length > 0 && (
+          <ul className="mt-6 space-y-2">
+            {links.map((link) => (
+              <li key={`${link.label}-${link.url}`}>
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between border border-(--color-rule) px-4 py-3 font-(family-name:--font-mono) text-sm text-(--color-ink) transition-colors hover:border-(--color-signal)"
+                >
+                  <span className="truncate">{link.label}</span>
+                  <span aria-hidden className="ml-3 shrink-0 text-(--color-muted)">↗</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
 
         <dl className="mt-6 space-y-1 border-t border-(--color-rule) pt-4 font-(family-name:--font-mono) text-xs sm:text-[13px]">
           <div className="flex gap-2">
@@ -109,6 +160,32 @@ export default async function Site({ params }) {
               <dd className="text-(--color-ink)">{record.claimedAt}</dd>
             </div>
           )}
+          {/* The banner links must be absolute to the apex: this page renders
+              on <name>.runs-on.dev hosts, where a relative /banner/<name>
+              would be rewritten by proxy.js into /sites/<name>/banner/... and
+              404. The banner route lives on runs-on.dev itself. */}
+          <div className="flex gap-2">
+            <dt className="w-24 shrink-0 text-(--color-muted)">share</dt>
+            <dd>
+              <a
+                className="text-(--color-signal) underline"
+                href={`https://runs-on.dev/banner/${name}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                banner
+              </a>
+              {' / '}
+              <a
+                className="text-(--color-signal) underline"
+                href={`https://runs-on.dev/banner/${name}?theme=dark`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                dark
+              </a>
+            </dd>
+          </div>
         </dl>
       </div>
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -98,11 +98,11 @@ profile; `links` exist only here.
 
 ```json
 "profile": {
-  "name": "Shovith Debnath",
-  "bio": "Full stack & AI developer",
+  "name": "Your Display Name",
+  "bio": "A line about what you build",
   "links": [
-    { "label": "Portfolio", "url": "https://shovith-dev.vercel.app" },
-    { "label": "GitHub", "url": "https://github.com/Hawkay002" }
+    { "label": "Portfolio", "url": "https://your-site.example.com" },
+    { "label": "GitHub", "url": "https://github.com/your-login" }
   ]
 }
 ```

--- a/docs/records.md
+++ b/docs/records.md
@@ -89,6 +89,34 @@ alongside everyone else's. Reconciliation only ever deletes zone-level TXTs
 whose value starts `vc-domain-verify=` and is claimed by nobody — anything
 an operator places at that host by hand survives every sync.
 
+## `profile`
+
+An optional object controlling what the profile card shows at
+`<name>.runs-on.dev` when the name has no DNS records pointing it
+elsewhere. Every field is optional and falls back to the owner's GitHub
+profile; `links` exist only here.
+
+```json
+"profile": {
+  "name": "Shovith Debnath",
+  "bio": "Full stack & AI developer",
+  "links": [
+    { "label": "Portfolio", "url": "https://shovith-dev.vercel.app" },
+    { "label": "GitHub", "url": "https://github.com/Hawkay002" }
+  ]
+}
+```
+
+- `name`: 1–60 characters, replaces the GitHub display name.
+- `bio`: 1–200 characters, replaces the GitHub bio.
+- `links`: 1–8 entries of `{ "label": 1–40 chars, "url": absolute
+  http(s) URL }`. Links render as rows on the card, so each URL is held to
+  the same scheme rules as a `URL` record: `javascript:`, `data:`, and
+  protocol-relative forms are rejected.
+- No other keys. The card art also feeds a shareable banner at
+  `https://runs-on.dev/banner/<name>` (add `?theme=dark` for GitHub
+  READMEs) and the social preview when the link is shared.
+
 ## Why CNAME can't coexist with other record types
 
 This isn't a rule the registry invented. It's a DNS protocol constraint.

--- a/lib/claim-banner.jsx
+++ b/lib/claim-banner.jsx
@@ -1,0 +1,160 @@
+import { getRecord } from './registry.js';
+import { REPO_URL } from './repo.js';
+
+// The per-claim banner artwork, rendered by next/og from two places:
+// app/banner/[name]/route.js (the downloadable/shareable image, both themes)
+// and app/sites/[name]/opengraph-image.js (the light card, as the social
+// preview for a claimed name's own page). One component so the two can never
+// drift apart — the same contract lib/banner-card.jsx holds for the
+// registry's own artwork.
+//
+// Satori (what next/og renders with) supports a subset of CSS: flexbox only,
+// no shorthand, explicit sizes on images. Everything here stays inside that
+// subset on purpose.
+
+export const BANNER_SIZE = { width: 1200, height: 630 };
+
+const THEMES = {
+  light: {
+    ground: '#F4F5F3',
+    muted: '#5E6668',
+    ink: '#14181B',
+    rule: '#D8DBD7',
+    signal: '#1B4DFF',
+  },
+  dark: {
+    ground: '#18140F',
+    muted: '#A89C89',
+    ink: '#EFE7D9',
+    rule: '#3A342B',
+    signal: '#8399FF',
+  },
+};
+
+// One registry read + one GitHub read, shared by both render sites, with the
+// same short revalidate the card page uses so a banner reflects a fresh
+// claim within minutes rather than an hour.
+export async function claimBannerData(name) {
+  const token = process.env.CARD_TOKEN ?? process.env.REGISTRY_TOKEN;
+  const fetchImpl = (url, init) => fetch(url, { ...init, next: { revalidate: 300 } });
+
+  const record = await getRecord(name, { token, fetchImpl }).catch(() => null);
+  if (!record) return null;
+
+  const res = await fetch(`https://api.github.com/users/${record.owner.github}`, {
+    // Authorization only when a token actually exists: `Bearer undefined`
+    // is a malformed credential GitHub answers with 401, not an anonymous
+    // request. registry.js's headers() plays the same trick.
+    headers: token
+      ? { Accept: 'application/vnd.github+json', Authorization: `Bearer ${token}` }
+      : { Accept: 'application/vnd.github+json' },
+    next: { revalidate: 3600 },
+  }).catch(() => null);
+  const profile = res && res.ok ? await res.json().catch(() => null) : null;
+
+  // The ?s= parameter asks GitHub for a square render at a size worth
+  // putting on a 1200px-wide card. The avatar is fetched here and embedded
+  // as a data: URL rather than handed to <img src> as a remote link, because
+  // satori's own remote-image fetching depends on the runtime it runs in —
+  // an avatar that silently renders as an empty circle in one environment
+  // is exactly the failure a shareable banner cannot afford.
+  let avatarUrl = profile?.avatar_url ?? null;
+  if (avatarUrl) {
+    const sized = new URL(avatarUrl);
+    sized.searchParams.set('s', '256');
+    const imgRes = await fetch(sized.href, { next: { revalidate: 3600 } }).catch(() => null);
+    if (imgRes?.ok) {
+      const buf = Buffer.from(await imgRes.arrayBuffer());
+      const mime = (imgRes.headers.get('content-type') ?? 'image/png').split(';')[0];
+      avatarUrl = `data:${mime};base64,${buf.toString('base64')}`;
+    } else {
+      avatarUrl = null;
+    }
+  }
+
+  const overrides = record.profile ?? {};
+  return {
+    name,
+    login: record.owner.github,
+    displayName: overrides.name ?? profile?.name ?? null,
+    bio: overrides.bio ?? profile?.bio ?? null,
+    claimedYear: (record.claimedAt ?? '').slice(0, 4) || null,
+    avatarUrl,
+  };
+}
+
+export function ClaimBanner({ name, login, displayName, bio, claimedYear, avatarUrl, theme = 'light' }) {
+  const t = THEMES[theme] ?? THEMES.light;
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: 72,
+        background: t.ground,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt=""
+            width={96}
+            height={96}
+            style={{ borderRadius: 96, border: `2px solid ${t.rule}` }}
+          />
+        ) : (
+          <div
+            style={{
+              width: 96,
+              height: 96,
+              borderRadius: 96,
+              border: `2px solid ${t.rule}`,
+              display: 'flex',
+            }}
+          />
+        )}
+        <div style={{ marginLeft: 28, display: 'flex', flexDirection: 'column' }}>
+          <span style={{ fontSize: 30, color: t.ink, display: 'flex' }}>
+            {displayName ?? `@${login}`}
+          </span>
+          <span style={{ fontSize: 22, color: t.muted, marginTop: 6, display: 'flex' }}>
+            {claimedYear ? `claimed ${claimedYear}` : `@${login}`}
+          </span>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <span style={{ fontSize: 88, fontWeight: 600, color: t.ink, display: 'flex' }}>
+          {name}
+          <span style={{ fontSize: 88, fontWeight: 600, color: t.muted, display: 'flex' }}>.runs-on.dev</span>
+        </span>
+        {bio ? (
+          <span style={{ fontSize: 26, color: t.muted, marginTop: 20, display: 'flex', maxWidth: 900 }}>
+            {bio.length > 120 ? `${bio.slice(0, 117)}…` : bio}
+          </span>
+        ) : null}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span
+          style={{
+            fontFamily: 'monospace',
+            fontSize: 22,
+            letterSpacing: 4,
+            textTransform: 'uppercase',
+            color: t.muted,
+            display: 'flex',
+          }}
+        >
+          A FREE SUBDOMAIN REGISTRY
+        </span>
+        <span style={{ fontSize: 24, color: t.signal, display: 'flex' }}>{REPO_URL.replace('https://', '')}</span>
+      </div>
+    </div>
+  );
+}

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -17,6 +17,12 @@ export function cardMetadata({ name, record, profile }) {
   const description =
     bio || `${name}.runs-on.dev is a subdomain claimed by @${login} on the runs-on.dev registry.`;
 
+  // The per-claim banner route, not a file-convention image: /sites/* is
+  // blocked from the outside by proxy.js, so an OG URL under it would 404
+  // for every crawler. /banner/<name> is public, absolute, and the same art
+  // a person gets when they share the link by hand.
+  const banner = `https://runs-on.dev/banner/${name}`;
+
   return {
     // `absolute` bypasses the layout's '%s — runs-on.dev' template, which
     // would otherwise render 'shrey.runs-on.dev — runs-on.dev'.
@@ -29,6 +35,7 @@ export function cardMetadata({ name, record, profile }) {
       url,
       title,
       description,
+      images: [{ url: banner, width: 1200, height: 630, alt: title }],
     },
     // X reads twitter:* in preference to og:*, so these have to be set
     // explicitly. Inheriting them is what made every claimed name unfurl as
@@ -37,6 +44,7 @@ export function cardMetadata({ name, record, profile }) {
       card: 'summary_large_image',
       title,
       description,
+      images: [banner],
     },
   };
 }

--- a/lib/record-fields.js
+++ b/lib/record-fields.js
@@ -124,3 +124,35 @@ function formatValue(type, value) {
   if (Array.isArray(value)) return value.join('\n');
   return String(value ?? '');
 }
+
+// --- profile ---
+
+// The form holds profile links as flat {label, url} rows, seeded by
+// profileToRows and folded back by buildProfile. Same discipline as
+// subdomains rows: a row that is entirely empty is someone who has not
+// filled it in yet, but a half-filled row survives parsing so schema
+// validation reports it instead of the form quietly dropping what was
+// typed.
+export function profileToRows(profile = {}) {
+  return (Array.isArray(profile?.links) ? profile.links : [])
+    .map((link) => ({ label: String(link?.label ?? ''), url: String(link?.url ?? '') }));
+}
+
+export function buildProfile(fields = {}) {
+  const name = String(fields.name ?? '').trim();
+  const bio = String(fields.bio ?? '').trim();
+  const rows = Array.isArray(fields.linkRows) ? fields.linkRows : [];
+
+  const links = rows
+    .filter((row) => String(row?.label ?? '').trim() !== '' || String(row?.url ?? '').trim() !== '')
+    .map((row) => ({ label: String(row?.label ?? '').trim(), url: String(row?.url ?? '').trim() }));
+
+  const out = {};
+  if (name) out.name = name;
+  if (bio) out.bio = bio;
+  if (links.length) out.links = links;
+  // undefined (not {}) tells the API route the owner removed everything,
+  // which deletes the profile block from the record rather than committing
+  // a `profile: {}` that means nothing.
+  return Object.keys(out).length ? out : undefined;
+}

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,6 +1,6 @@
 import { validateName } from './name.js';
 
-const TOP_LEVEL = new Set(['name', 'owner', 'claimedAt', 'records', 'subdomains']);
+const TOP_LEVEL = new Set(['name', 'owner', 'claimedAt', 'records', 'subdomains', 'profile']);
 const RECORD_TYPES = new Set(['CNAME', 'A', 'TXT', 'MX', 'URL']);
 // URL only makes sense at the claimed name itself: the app serves it by
 // looking up that one name and issuing a redirect, and it doesn't route
@@ -157,6 +157,58 @@ function validateSubdomains(subdomains, rootName, errors) {
   }
 }
 
+const MAX_PROFILE_NAME = 60;
+const MAX_PROFILE_BIO = 200;
+const MAX_PROFILE_LINKS = 8;
+const MAX_LINK_LABEL = 40;
+
+// `profile` is the only part of a record that says something rather than
+// points somewhere: it overrides the GitHub-derived name/bio on the card and
+// adds links. Links render as clickable rows on a domain other people trust,
+// so each URL is held to the same absolute-http(s)-only rule as a URL record
+// (isValidRedirectUrl rejects javascript:, data:, and protocol-relative
+// forms). Every field is optional, but nothing half-filled is: an empty
+// string as a display name would read as a deliberate blank card, so
+// presence means content.
+function validateProfile(profile, errors) {
+  if (profile === null || typeof profile !== 'object' || Array.isArray(profile)) {
+    errors.push('profile must be an object');
+    return;
+  }
+
+  for (const key of Object.keys(profile)) {
+    if (key !== 'name' && key !== 'bio' && key !== 'links') {
+      errors.push(`unknown key: profile.${key}`);
+    }
+  }
+
+  if ('name' in profile && (typeof profile.name !== 'string' || profile.name.length < 1 || profile.name.length > MAX_PROFILE_NAME)) {
+    errors.push(`profile.name must be a string of 1 to ${MAX_PROFILE_NAME} characters`);
+  }
+
+  if ('bio' in profile && (typeof profile.bio !== 'string' || profile.bio.length < 1 || profile.bio.length > MAX_PROFILE_BIO)) {
+    errors.push(`profile.bio must be a string of 1 to ${MAX_PROFILE_BIO} characters`);
+  }
+
+  if ('links' in profile) {
+    if (!Array.isArray(profile.links) || profile.links.length === 0 || profile.links.length > MAX_PROFILE_LINKS) {
+      errors.push(`profile.links must be an array of 1 to ${MAX_PROFILE_LINKS} entries`);
+      return;
+    }
+    for (const link of profile.links) {
+      const shape = link !== null && typeof link === 'object' && !Array.isArray(link)
+        && Object.keys(link).length === 2
+        && typeof link.label === 'string' && link.label.length >= 1 && link.label.length <= MAX_LINK_LABEL
+        && typeof link.url === 'string';
+      if (!shape) {
+        errors.push(`profile.links entries must be { label: 1-${MAX_LINK_LABEL} chars, url }`);
+      } else if (!isValidRedirectUrl(link.url)) {
+        errors.push(`profile.links url must be an absolute http(s) URL: ${link.label}`);
+      }
+    }
+  }
+}
+
 export function validateRecord(obj) {
   const errors = [];
   if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
@@ -192,6 +244,10 @@ export function validateRecord(obj) {
   if ('subdomains' in obj) {
     const rootName = typeof obj.name === 'string' ? obj.name : '';
     validateSubdomains(obj.subdomains, rootName, errors);
+  }
+
+  if ('profile' in obj) {
+    validateProfile(obj.profile, errors);
   }
 
   return { ok: errors.length === 0, errors };

--- a/schema/record.schema.json
+++ b/schema/record.schema.json
@@ -25,9 +25,32 @@
       "maxProperties": 10,
       "propertyNames": { "pattern": "^_?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" },
       "additionalProperties": { "$ref": "#/$defs/subdomainRecords" }
-    }
+    },
+    "profile": { "$ref": "#/$defs/profile" }
   },
   "$defs": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 60 },
+        "bio": { "type": "string", "minLength": 1, "maxLength": 200 },
+        "links": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 8,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["label", "url"],
+            "properties": {
+              "label": { "type": "string", "minLength": 1, "maxLength": 40 },
+              "url": { "type": "string", "format": "uri", "pattern": "^https?://" }
+            }
+          }
+        }
+      }
+    },
     "records": {
       "type": "object",
       "additionalProperties": false,

--- a/test/record-fields.test.mjs
+++ b/test/record-fields.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   modeOf, linesToList, parseMx, mxToLines, buildRecords,
-  buildSubdomains, subdomainsToRows,
+  buildSubdomains, subdomainsToRows, buildProfile, profileToRows,
 } from '../lib/record-fields.js';
 import { validateRecord } from '../lib/schema.js';
 
@@ -127,4 +127,55 @@ test('the Vercel verification record the guide documents builds correctly', () =
     ]),
   });
   assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+// --- profile ---
+
+test('buildProfile emits only filled fields', () => {
+  assert.deepEqual(
+    buildProfile({ name: '  Lucas ', bio: '', linkRows: [] }),
+    { name: 'Lucas' },
+  );
+  assert.deepEqual(buildProfile({ name: '', bio: 'hello', linkRows: [] }), { bio: 'hello' });
+});
+
+test('buildProfile returns undefined when everything is empty — the API removes the block', () => {
+  assert.equal(
+    buildProfile({ name: '  ', bio: '', linkRows: [{ label: '', url: '' }] }),
+    undefined,
+  );
+});
+
+test('half-filled link rows survive so the schema reports them', () => {
+  // Same discipline as malformed MX lines: drop nothing the owner typed.
+  const out = buildProfile({ linkRows: [{ label: 'Site', url: '' }] });
+  assert.deepEqual(out, { links: [{ label: 'Site', url: '' }] });
+  assert.equal(
+    validateRecord({
+      name: 'lucas', owner: { github: 'z' }, claimedAt: '2026-01-01T00:00:00Z',
+      records: {}, profile: out,
+    }).ok,
+    false,
+  );
+});
+
+test('a complete profile builds a record the schema accepts', () => {
+  const profile = buildProfile({
+    name: 'Lucas',
+    bio: 'Builds',
+    linkRows: [{ label: 'Site', url: 'https://example.com' }, { label: '', url: '' }],
+  });
+  const out = validateRecord({
+    name: 'lucas', owner: { github: 'z' }, claimedAt: '2026-01-01T00:00:00Z',
+    records: {}, profile,
+  });
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('profile links round-trip through rows', () => {
+  const profile = { name: 'L', links: [{ label: 'a', url: 'https://a.com' }] };
+  assert.deepEqual(
+    buildProfile({ name: 'L', bio: '', linkRows: profileToRows(profile) }),
+    profile,
+  );
 });

--- a/test/schema.test.mjs
+++ b/test/schema.test.mjs
@@ -3,6 +3,69 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { validateRecord } from '../lib/schema.js';
 
+// --- profile ---
+
+test('accepts a full profile block', () => {
+  const out = validateRecord({
+    ...valid,
+    profile: {
+      name: 'Lucas',
+      bio: 'Builds things',
+      links: [{ label: 'Site', url: 'https://example.com' }],
+    },
+  });
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('accepts a partial profile — any subset of fields', () => {
+  assert.equal(validateRecord({ ...valid, profile: {} }).ok, true);
+  assert.equal(validateRecord({ ...valid, profile: { name: 'L' } }).ok, true);
+  assert.equal(
+    validateRecord({ ...valid, profile: { links: [{ label: 'a', url: 'http://x.com' }] } }).ok,
+    true,
+  );
+});
+
+test('rejects unknown profile keys', () => {
+  const out = validateRecord({ ...valid, profile: { nickname: 'L' } });
+  assert.equal(out.ok, false);
+  assert.ok(out.errors.includes('unknown key: profile.nickname'));
+});
+
+test('rejects an empty or overlong name/bio', () => {
+  // Presence means content: an empty string would render as a deliberate blank.
+  assert.equal(validateRecord({ ...valid, profile: { name: '' } }).ok, false);
+  assert.equal(validateRecord({ ...valid, profile: { bio: 'x'.repeat(201) } }).ok, false);
+  assert.equal(validateRecord({ ...valid, profile: { name: 'x'.repeat(61) } }).ok, false);
+});
+
+test('rejects profile links that are not absolute http(s) URLs', () => {
+  // Links render as clickable rows on a trusted domain, so they follow the
+  // URL-record rules, not looser ones.
+  for (const url of ['javascript:alert(1)', 'data:text/html,x', '//evil.com', 'not a url']) {
+    const out = validateRecord({ ...valid, profile: { links: [{ label: 'x', url }] } });
+    assert.equal(out.ok, false, url);
+  }
+});
+
+test('rejects extra keys on a link entry', () => {
+  const out = validateRecord({
+    ...valid,
+    profile: { links: [{ label: 'x', url: 'https://a.com', icon: 'y' }] },
+  });
+  assert.equal(out.ok, false);
+});
+
+test('rejects more than 8 links, an empty array, and overlong labels', () => {
+  const links = Array.from({ length: 9 }, () => ({ label: 'x', url: 'https://a.com' }));
+  assert.equal(validateRecord({ ...valid, profile: { links } }).ok, false);
+  assert.equal(validateRecord({ ...valid, profile: { links: [] } }).ok, false);
+  assert.equal(
+    validateRecord({ ...valid, profile: { links: [{ label: 'x'.repeat(41), url: 'https://a.com' }] } }).ok,
+    false,
+  );
+});
+
 const valid = {
   name: 'lucas',
   owner: { github: 'zordhalo' },
@@ -320,4 +383,16 @@ test('the guard applies at the root too, not only under subdomains', () => {
   });
   assert.equal(out.ok, false);
   assert.ok(out.errors.some((e) => e.includes('truncated Vercel verification token')));
+});
+
+test('the JSON Schema mirror declares profile with the same field set', () => {
+  // Same drift-prevention contract as the name/owner mirrors above: the
+  // published schema is linked from the PR template, so it must not promise
+  // a shape the runtime validator rejects, or vice versa. `profile` is
+  // declared as a $ref into $defs, like `records` is.
+  const declared = mirror.properties.profile;
+  assert.equal(declared.$ref, '#/$defs/profile');
+  const def = mirror.$defs.profile;
+  assert.deepEqual(Object.keys(def.properties).sort(), ['bio', 'links', 'name']);
+  assert.equal(def.additionalProperties, false);
 });


### PR DESCRIPTION
Replaces #53 (same feature work, restructured per review: deploy fix split into #56, dns-check hardened below, docs example genericized).

## What's here

**1. `profile` block (schema + validator + JSON-schema mirror + drift tests + docs).** Optional `name` (max 60), `bio` (max 200), `links` (1-8 of `{label max 40, url absolute http(s)}`). Links render as rows on a trusted domain, so their URLs follow the `URL` record scheme rules (`javascript:`/`data:`/protocol-relative rejected).

**2. Link-in-bio card.** Field-by-field overrides over the GitHub data; `generateMetadata` merges the same way so the card and its meta tags can never disagree. Heading is the site link (underlined, signal blue on hover); a `manage` pill beside it goes to /manage; a `share` row under `claimedAt` exposes the banner links (absolute to the apex because this page renders on `<name>.runs-on.dev` hosts where a relative banner link gets proxy-rewritten and 404s).

**3. Manage wizard.** Profile editor fields, plus a **post-save "did it work?" panel**: polls `/api/dns-check` and shows live answers next to what was committed. The endpoint returns only public data, validates the name grammar, and reads the record through the same 30s revalidate window the card uses.

**4. Per-claim banner + social preview.** `/banner/<name>` (light, `?theme=dark` for GitHub READMEs) via `next/og`. The card's `og:image` points there so sharing a claimed name shows its own card.

**5. Anonymous-read Bearer fix.** Without CARD_TOKEN/REGISTRY_TOKEN, the card's profile fetch sent `Bearer undefined` (401). Same guard `lib/registry.js`'s `headers()` has always had.

## /api/dns-check hardening (per review)

- **Rate limit**: 10/minute per name via `lib/throttle.js`, same 429 + `Retry-After` pattern as the write routes.
- **SSRF guard**: the name's A records are resolved first; if any point at a private range (loopback, RFC 1918, link-local), the fetch is refused. The schema accepts any valid IPv4, but that doesn't mean this endpoint should fetch it.
- **No redirect following**: `redirect: 'manual'`. A URL-redirect name is still classified correctly because the registry's wildcard serves the 307 itself; the probe never follows wherever the record points.

## Testing

- 231/231 tests (6 new)
- Full `next build` green; exercised every surface against live DNS
- Satori remote-image fetching is runtime-dependent, so the banner avatar is fetched server-side and embedded as a data: URL