### PR TITLE
Remove shanu

### DIFF
--- a/domains/shanu.json
+++ b/domains/shanu.json
@@ -1,8 +1,0 @@
-{
-  "name": "shanu",
-  "owner": {
-    "github": "Shanu-Kumawat"
-  },
-  "claimedAt": "2026-09-03T06:25:53.209Z",
-  "records": {}
-}


### PR DESCRIPTION
Owner @Shanu-Kumawat releasing this name. Record is empty (`records: {}`), name freed for re-claim.