### PR TITLE
Remove viberoulette

### DIFF
--- a/domains/viberoulette.json
+++ b/domains/viberoulette.json
@@ -1,8 +1,0 @@
-{
-  "name": "viberoulette",
-  "owner": {
-    "github": "Kxrbx"
-  },
-  "claimedAt": "2026-09-03T15:03:17.636Z",
-  "records": {}
-}


### PR DESCRIPTION
Release the name `viberoulette` as requested by its owner, @Kxrbx.