### PR TITLE
fix(validate): repair undefined `path` that gated every new claim

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,9 +17,16 @@ jobs:
       # of lib/pr.js and scripts/validate-pr.mjs — a PR that rewrites validateChangeset to
       # return { ok: true } would approve itself. The validator reads the PR's files over
       # the API, so it never needs the PR's working tree.
+      #
+      # `base.ref` (the branch tip) rather than `base.sha` (the branch as of the last PR
+      # event): both are trusted content, but base.sha is frozen in the stored event payload,
+      # so a re-run of an old PR keeps executing the validator as it was when the PR opened.
+      # A fix to the validator would then never reach the already-open PRs it was written for.
+      # BASE_SHA below stays base.sha — "what does the registry look like under this PR" is
+      # a question about the PR, and must not drift while the PR is being reviewed.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'

--- a/scripts/validate-pr.mjs
+++ b/scripts/validate-pr.mjs
@@ -62,10 +62,11 @@ async function countOwnedNames(login) {
   for (let i = 0; i < records.length; i += BATCH) {
     const slice = records.slice(i, i + BATCH);
     const parsed = await Promise.all(slice.map(async (entry) => {
-      const r = await api(`/repos/${REPO}/contents/domains/${entry.name}?ref=${BASE_SHA}`);
-      if (!r.ok) throw new Error(`GET domains/${entry.name} -> ${r.status}`);
+      const filePath = `domains/${entry.name}`;
+      const r = await api(`/repos/${REPO}/contents/${filePath}?ref=${BASE_SHA}`);
+      if (!r.ok) throw new Error(`GET ${filePath} -> ${r.status}`);
       const body = await r.json();
-      return parseRecordFile(path, Buffer.from(body.content, 'base64').toString('utf8'));
+      return parseRecordFile(filePath, Buffer.from(body.content, 'base64').toString('utf8'));
     }));
     for (const rec of parsed) {
       if (String(rec?.owner?.github ?? '').toLowerCase() === target) owned += 1;


### PR DESCRIPTION
## The bug

`countOwnedNames` in `scripts/validate-pr.mjs` referenced `path` — a parameter of the *other* function, `readAt(path, ref)` — from inside its own batch loop. ESM is strict mode, so that is a `ReferenceError` on the first record it reads.

`validateChangeset` treats a throw from `countOwnedNames` as "could not check" and **fails closed**. That is the right call: assuming "owns nothing" would hand out a second name. But it turned a typo into a silent gate — every *new claim* PR failed with `could not check how many names you already own, try re-running this check`, while *edits* to existing records passed, because only `validateNewClaim` calls `countOwnedNames`.

Currently blocking: #80, #79, #61 and others.

## The workflow change

`validate.yml` checked out `github.event.pull_request.base.sha`. That SHA is frozen in the stored event payload, so re-running an already-open PR re-runs the validator *as it was the day that PR opened* — this fix would land on main and never reach the PRs it was written for.

Switched to `base.ref`. Same trust boundary — still base-branch content, never the PR's own copy of the validator, so the self-approving-PR attack the original comment describes stays closed. `BASE_SHA` still passes `base.sha`, because "what does the registry look like under this PR" must not drift mid-review.

## Testing

225 existing tests pass. Not covered by a regression test: `countOwnedNames` is defined inline in a top-level-await script that reads required env vars at import, so it cannot be imported by the suite. Extracting it into `lib/` alongside the other PR logic would make it testable and is worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUmByKm84VhDGXnBMxUhcM