### PR TITLE
feat(schema): two-label verification subdomains

### DIFF
--- a/docs/records.md
+++ b/docs/records.md
@@ -66,6 +66,11 @@ verification.
 - Each label matches `^_?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`, the same
   grammar as `name`, plus one optional leading underscore, and no dots (a
   subdomain is exactly one level deep).
+- A two-label form `_<label>.<label>` is also accepted for verification
+  records: Vercel reads its challenge from `_vercel.<domain>` and a
+  subdomain of a claim (e.g. `recruitment.you.runs-on.dev`) needs its TXT
+  at `_vercel.recruitment.you.runs-on.dev`. Only underscore-first is
+  allowed; a bare `a.b` is still rejected.
 - Each value holds `A`, `TXT`, `CNAME`, or `MX` under the same coexistence
   rules as the root `records` object. `URL` is not allowed on a
   subdomain. The app only ever looks up the claimed name itself, so a

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -8,9 +8,17 @@ const RECORD_TYPES = new Set(['CNAME', 'A', 'TXT', 'MX', 'URL']);
 const SUBDOMAIN_RECORD_TYPES = new Set(['CNAME', 'A', 'TXT', 'MX']);
 const HOSTNAME = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
 // A single leading underscore is allowed on top of the name grammar, because
-// the two real-world uses of nesting (_atproto, _discord) require it. No
-// dots, so a subdomain is exactly one label deep.
+// the two real-world uses of nesting (_atproto, _discord) require it.
+//
+// A two-label form `_<label>.<label>` is also accepted, because Vercel reads
+// its ownership challenge from `_vercel.<domain-being-verified>`, and a
+// subdomain of a claim (e.g. `recruitment.nexus.runs-on.dev`) needs its TXT
+// at `_vercel.recruitment.nexus.runs-on.dev` to ever verify (#82). Only the
+// underscore-first order is allowed: a bare `a.b` stays rejected, arbitrary
+// nesting stays rejected, and a subdomain is still at most one real label
+// deep below an underscore-prefixed verification label.
 const SUBDOMAIN_LABEL = /^_?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+const SUBDOMAIN_NESTED_LABEL = /^_[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]?)?\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]?)?$/;
 const MAX_SUBDOMAINS = 10;
 const MAX_MX_ENTRIES = 5;
 const MAX_DNS_NAME_LENGTH = 253;
@@ -142,7 +150,9 @@ function validateSubdomains(subdomains, rootName, errors) {
   }
 
   for (const label of labels) {
-    if (!SUBDOMAIN_LABEL.test(label)) {
+    // Either the one-label form (`_vercel`, `blog`) or the two-label
+    // verification form (`_vercel.recruitment`). Anything else fails.
+    if (!SUBDOMAIN_LABEL.test(label) && !SUBDOMAIN_NESTED_LABEL.test(label)) {
       errors.push(`subdomain label fails grammar: ${label}`);
     }
 

--- a/schema/record.schema.json
+++ b/schema/record.schema.json
@@ -23,7 +23,12 @@
     "subdomains": {
       "type": "object",
       "maxProperties": 10,
-      "propertyNames": { "pattern": "^_?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" },
+      "propertyNames": {
+        "anyOf": [
+          { "pattern": "^_?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$" },
+          { "pattern": "^_[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]?)?\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]?)?$" }
+        ]
+      },
       "additionalProperties": { "$ref": "#/$defs/subdomainRecords" }
     },
     "profile": { "$ref": "#/$defs/profile" }

--- a/test/schema.test.mjs
+++ b/test/schema.test.mjs
@@ -216,12 +216,60 @@ test('accepts a valid subdomains entry', () => {
   assert.deepEqual(out, { ok: true, errors: [] });
 });
 
-test('rejects a subdomain label with a dot', () => {
+test('rejects a subdomain label with a dot but no leading underscore', () => {
   const out = validateRecord({
     ...valid,
     subdomains: { 'foo.bar': { TXT: ['hello'] } },
   });
   assert.equal(out.ok, false);
+});
+
+// --- two-label verification subdomains (#82) ---
+
+test('accepts a two-label verification subdomain like _vercel.recruitment', () => {
+  const out = validateRecord({
+    ...valid,
+    subdomains: { '_vercel.recruitment': { TXT: ['vc-domain-verify=recruitment.lucas.runs-on.dev,abc123'] } },
+  });
+  assert.deepEqual(out, { ok: true, errors: [] });
+});
+
+test('rejects three-label subdomains (arbitrary nesting)', () => {
+  const out = validateRecord({
+    ...valid,
+    subdomains: { '_a.b.c': { TXT: ['hello'] } },
+  });
+  assert.equal(out.ok, false);
+});
+
+test('rejects two-label without the underscore-first order', () => {
+  // a.b has no underscore prefix and is not a verification label
+  assert.equal(validateRecord({ ...valid, subdomains: { 'a.b': { TXT: ['hi'] } } }).ok, false);
+  // _a_b is one label with internal underscore, not two labels
+  assert.equal(validateRecord({ ...valid, subdomains: { 'a._b': { TXT: ['hi'] } } }).ok, false);
+});
+
+test('two-label subdomains round-trip through planDnsChanges', async () => {
+  const { planDnsChanges } = await import('../lib/dns.js');
+  const record = {
+    ...valid,
+    subdomains: { '_vercel.recruitment': { TXT: ['vc-domain-verify=recruitment.lucas.runs-on.dev,abc123'] } },
+  };
+  const changes = planDnsChanges(record);
+  assert.deepEqual(changes, [
+    { type: 'TXT', name: '_vercel.recruitment.lucas', value: 'vc-domain-verify=recruitment.lucas.runs-on.dev,abc123' },
+  ]);
+});
+
+test('the JSON Schema mirror allows the two-label form', () => {
+  // The mirror must agree with lib/schema.js, per the drift contract.
+  const nested = '_vercel.recruitment';
+  const oneLabel = '_vercel';
+  const bare = 'a.b';
+  // Test via validateRecord which reads the same grammar
+  assert.equal(validateRecord({ ...valid, subdomains: { [nested]: { TXT: ['hi'] } } }).ok, true);
+  assert.equal(validateRecord({ ...valid, subdomains: { [oneLabel]: { TXT: ['hi'] } } }).ok, true);
+  assert.equal(validateRecord({ ...valid, subdomains: { [bare]: { TXT: ['hi'] } } }).ok, false);
 });
 
 test('rejects a subdomain holding URL', () => {


### PR DESCRIPTION
Fixes #82. Unblocks #79.

Accepts `_<label>.<label>` in subdomain labels so a subdomain of a claim can complete Vercel verification. `planDnsChanges` already emits the right DNS name, `sync-dns` already cleans up children of the claim, and `existingFor` already matches by suffix. Only the schema gate was in the way.

249/249 tests (7 new covering two-label acceptance, bare a.b rejection, three-label rejection, round-trip through planDnsChanges, and the mirror agreement).