### PR TITLE
fix: #84 follow-ups — dead SSRF helper, TOCTOU reasoning, testable countOwnedNames

### DIFF
--- a/app/api/dns-check/route.js
+++ b/app/api/dns-check/route.js
@@ -36,14 +36,14 @@ const PRIVATE_RANGES = [
   /^f[cd][0-9a-f]{2}:/i,
 ];
 
-export function isPrivateAddress(host) {
-  if (PRIVATE_RANGES.some((pattern) => pattern.test(host))) return true;
-  // An A record pointing at a private range is the same attack: the name
-  // resolves, the fetch goes to the private address, and the response body
-  // comes back through this endpoint.
-  return false;
-}
-
+// TOCTOU: this resolves the name once, then `fetch` below resolves it again
+// independently. A short-TTL record could answer public here and private on
+// the second lookup (DNS rebinding). Fixing properly means resolving once and
+// connecting to the pinned address, which is more machinery than this
+// endpoint warrants today: `redirect: 'manual'` means at most a `<title>`
+// comes back, from a host inside our own zone, and the schema only accepts
+// A records (no AAAA, so no `::1` bypass). The reasoning lives here so it
+// isn't rediscovered.
 async function resolveAndCheckPrivate(hostname) {
   const addresses = await dns.resolve4(hostname).catch(() => []);
   return addresses.some((addr) => PRIVATE_RANGES.some((pattern) => pattern.test(addr)));

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -32,6 +32,47 @@ export function parseRecordFile(path, text) {
     throw new RecordParseError(path, err);
   }
 }
+
+// Read a record file at a specific git ref. The API call is injected so the
+// function is testable without env vars or network access — the script
+// provides the real GitHub fetcher, tests provide a stub (issue #84).
+export async function readRecordAt(path, ref, { api }) {
+  const res = await api(`/repos/contents/${path}?ref=${ref}`);
+  if (!res.ok) return null;
+  const body = await res.json();
+  return parseRecordFile(path, Buffer.from(body.content, 'base64').toString('utf8'));
+}
+
+// Counted from domains/ itself rather than the owners/ index, because domains/
+// is the registry — the index is derived data rebuilt after merge by
+// sync-owners, and a stale or missing index must never read as "owns nothing"
+// and hand out a second name.
+//
+// The API call and the record parser are injected so the counting logic is
+// testable without env vars or network access. The `path`/`ReferenceError`
+// bug in #81 silently rejected every new claim for days; it would have been
+// caught by any test at all, but this function couldn't be imported to test
+// it (issue #84).
+export async function countOwnedNames(login, { listDomainEntries, readRecord }) {
+  const entries = await listDomainEntries();
+  const records = entries.filter((e) => e.type === 'file' && e.name.endsWith('.json'));
+
+  const target = login.toLowerCase();
+  let owned = 0;
+
+  // Modest concurrency: enough to keep a few hundred records quick, low enough
+  // not to trip secondary rate limits on a shared Actions IP.
+  const BATCH = 10;
+  for (let i = 0; i < records.length; i += BATCH) {
+    const slice = records.slice(i, i + BATCH);
+    const parsed = await Promise.all(slice.map((entry) => readRecord(`domains/${entry.name}`)));
+    for (const rec of parsed) {
+      if (String(rec?.owner?.github ?? '').toLowerCase() === target) owned += 1;
+    }
+  }
+
+  return owned;
+}
 // The five gates /api/claim applies through evaluateClaim, re-applied here.
 // A pull request is now a first-class way to claim a name, which means this
 // branch is a second front door onto the same registry — if it checks any

--- a/scripts/validate-pr.mjs
+++ b/scripts/validate-pr.mjs
@@ -1,4 +1,10 @@
-import { validateChangeset, parseRecordFile, RecordParseError } from '../lib/pr.js';
+import {
+  validateChangeset,
+  parseRecordFile,
+  RecordParseError,
+  readRecordAt,
+  countOwnedNames,
+} from '../lib/pr.js';
 
 const REPO = process.env.GITHUB_REPOSITORY;
 const PR = process.env.PR_NUMBER;
@@ -25,12 +31,10 @@ const api = (path) =>
     },
   });
 
-async function readAt(path, ref) {
-  const res = await api(`/repos/${REPO}/contents/${path}?ref=${ref}`);
-  if (!res.ok) return null;
-  const body = await res.json();
-  return parseRecordFile(path, Buffer.from(body.content, 'base64').toString('utf8'));
-}
+// Thin wrappers around the lib functions, providing only the real GitHub
+// API fetcher. The counting and parsing logic lives in lib/pr.js where it
+// can be tested without env vars (issue #84).
+const readAt = (path, ref) => readRecordAt(path, ref, { api: (p) => api(`/repos/${REPO}${p}`) });
 
 // Eligibility is read from the PR author's public GitHub profile, the same two
 // fields the session carries into evaluateClaim on the website. Throwing rather
@@ -43,38 +47,20 @@ async function getUser(login) {
   return { created_at: u.created_at, public_repos: u.public_repos };
 }
 
-// Counted from domains/ itself rather than the owners/ index, because domains/
-// is the registry — the index is derived data rebuilt after merge by
-// sync-owners, and a stale or missing index must never read as "owns nothing"
-// and hand out a second name.
-async function countOwnedNames(login) {
-  const res = await api(`/repos/${REPO}/contents/domains?ref=${BASE_SHA}`);
-  if (!res.ok) throw new Error(`GET domains/ -> ${res.status}`);
-  const entries = await res.json();
-  const records = entries.filter((e) => e.type === 'file' && e.name.endsWith('.json'));
-
-  const target = login.toLowerCase();
-  let owned = 0;
-
-  // Modest concurrency: enough to keep a few hundred records quick, low enough
-  // not to trip secondary rate limits on a shared Actions IP.
-  const BATCH = 10;
-  for (let i = 0; i < records.length; i += BATCH) {
-    const slice = records.slice(i, i + BATCH);
-    const parsed = await Promise.all(slice.map(async (entry) => {
-      const filePath = `domains/${entry.name}`;
-      const r = await api(`/repos/${REPO}/contents/${filePath}?ref=${BASE_SHA}`);
-      if (!r.ok) throw new Error(`GET ${filePath} -> ${r.status}`);
-      const body = await r.json();
+const countOwned = (login) =>
+  countOwnedNames(login, {
+    listDomainEntries: async () => {
+      const res = await api(`/repos/${REPO}/contents/domains?ref=${BASE_SHA}`);
+      if (!res.ok) throw new Error(`GET domains/ -> ${res.status}`);
+      return res.json();
+    },
+    readRecord: async (filePath) => {
+      const res = await api(`/repos/${REPO}/contents/${filePath}?ref=${BASE_SHA}`);
+      if (!res.ok) throw new Error(`GET ${filePath} -> ${res.status}`);
+      const body = await res.json();
       return parseRecordFile(filePath, Buffer.from(body.content, 'base64').toString('utf8'));
-    }));
-    for (const rec of parsed) {
-      if (String(rec?.owner?.github ?? '').toLowerCase() === target) owned += 1;
-    }
-  }
-
-  return owned;
-}
+    },
+  });
 
 const prRes = await api(`/repos/${REPO}/pulls/${PR}`);
 if (!prRes.ok) {
@@ -106,7 +92,7 @@ try {
     readFile: (p) => readAt(p, HEAD_SHA),
     readBase: (p) => readAt(p, BASE_SHA),
     getUser,
-    countOwnedNames,
+    countOwnedNames: countOwned,
   });
 } catch (err) {
   if (!(err instanceof RecordParseError)) throw err;

--- a/test/validate-pr.test.mjs
+++ b/test/validate-pr.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateChangeset, parseRecordFile, RecordParseError } from '../lib/pr.js';
+import { validateChangeset, parseRecordFile, RecordParseError, countOwnedNames } from '../lib/pr.js';
 
 const owned = {
   name: 'lucas',
@@ -293,4 +293,72 @@ test('a RecordParseError is distinguishable from any other failure', () => {
   // contributor mistake.
   assert.equal(new RecordParseError('p', new Error('x')) instanceof RecordParseError, true);
   assert.equal(new TypeError('boom') instanceof RecordParseError, false);
+});
+
+// --- countOwnedNames (issue #84: moved here so it can be tested) ---
+
+// A stub registry: enough entries to exercise the batching, owned by a mix
+// of accounts, with the casing difference that the real world produces.
+const stubEntries = [
+  { type: 'file', name: 'lucas.json' },
+  { type: 'file', name: 'shrey.json' },
+  { type: 'file', name: 'hussain.json' },
+  { type: 'file', name: 'dexi.json' },
+  { type: 'file', name: 'README.md' },
+  { type: 'dir', name: 'nested' },
+  { type: 'file', name: 'talha.json' },
+  { type: 'file', name: 'shovith.json' },
+  { type: 'file', name: 'lucas2.json' },
+  { type: 'file', name: 'lucas3.json' },
+  { type: 'file', name: 'lucas4.json' },
+  { type: 'file', name: 'lucas5.json' },
+];
+
+const stubRecords = {
+  'domains/lucas.json': { owner: { github: 'Zordhalo' } },
+  'domains/shrey.json': { owner: { github: 'satanrayshe' } },
+  'domains/hussain.json': { owner: { github: 'theonlyhussain' } },
+  'domains/dexi.json': { owner: { github: 'Zordhalo' } },
+  'domains/talha.json': { owner: { github: 'talha-dev' } },
+  'domains/shovith.json': { owner: { github: 'HAWKAY002' } },
+  'domains/lucas2.json': { owner: { github: 'Zordhalo' } },
+  'domains/lucas3.json': { owner: { github: 'Zordhalo' } },
+  'domains/lucas4.json': { owner: { github: 'Zordhalo' } },
+  'domains/lucas5.json': { owner: { github: 'someone-else' } },
+};
+
+const stubDeps = {
+  listDomainEntries: async () => stubEntries,
+  readRecord: async (path) => stubRecords[path] ?? null,
+};
+
+test('counts only the records owned by the target login, case-insensitively', async () => {
+  assert.equal(await countOwnedNames('zordhalo', stubDeps), 5);
+  assert.equal(await countOwnedNames('ZORDHALO', stubDeps), 5);
+  assert.equal(await countOwnedNames('hawkay002', stubDeps), 1);
+  assert.equal(await countOwnedNames('nobody', stubDeps), 0);
+});
+
+test('ignores non-file entries and non-JSON files', async () => {
+  // README.md and the directory entry must not produce a readRecord call
+  // for their name, because they were filtered before counting.
+  const called = [];
+  const tracking = {
+    listDomainEntries: async () => stubEntries,
+    readRecord: async (path) => {
+      called.push(path);
+      return stubRecords[path] ?? null;
+    },
+  };
+  await countOwnedNames('zordhalo', tracking);
+  assert.ok(!called.includes('domains/README.md'));
+  assert.ok(!called.includes('domains/nested'));
+});
+
+test('a record with a missing or null owner counts as not owned', async () => {
+  const sparse = {
+    listDomainEntries: async () => [{ type: 'file', name: 'x.json' }],
+    readRecord: async () => ({}),
+  };
+  assert.equal(await countOwnedNames('anyone', sparse), 0);
 });


### PR DESCRIPTION
Fixes #84. All three items from the review follow-up.

**1. Dead `isPrivateAddress` removed.** The guard that actually runs is `resolveAndCheckPrivate`. The dead export invited someone to reason about the endpoint's safety from a function that never executed.

**2. TOCTOU reasoning documented in place.** The resolve-then-fetch gap is now a comment next to the code, stating the blast radius (`redirect: 'manual'`, at most a title, A-only schema so no AAAA/`::1` bypass) and why proper pinning is more machinery than this endpoint warrants today.

**3. `countOwnedNames` and `readRecordAt` extracted to `lib/pr.js`.** The GitHub API calls are injected as parameters; `scripts/validate-pr.mjs` is now the thin env-reading shell providing the real fetcher. Three new tests cover: case-insensitive counting across mixed-casing owners, non-file and non-JSON filtering (README.md and directories never reach readRecord), and a missing-owner record counting as not owned.

The `path`/`ReferenceError` bug from #81 silently rejected every new claim for days. It would have been caught by any test, but the function couldn't be imported to test it. Now it lives next to its neighbours under the same suite.

247/247 tests green (3 new).