### PR TITLE
feat(moderation): auto-delete spam comments + optionally block the spammer

### DIFF
--- a/.github/workflows/moderate.yml
+++ b/.github/workflows/moderate.yml
@@ -1,0 +1,31 @@
+name: moderate
+
+# Two triggers: a schedule that sweeps all existing comments, and an
+# issue_comment event that catches new spam within seconds of it landing.
+on:
+  schedule:
+    # Every 30 minutes, off the top and bottom of the hour.
+    - cron: '7,37 * * * *'
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  moderate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # GITHUB_TOKEN can delete comments with the permissions above. Blocking
+      # requires a personal admin token; if the ADMIN_TOKEN secret is set,
+      # the script blocks the spammer's account as well. Without it, the
+      # comment is still deleted and the login is logged for manual review.
+      - run: node scripts/moderate-spam.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}

--- a/scripts/moderate-spam.mjs
+++ b/scripts/moderate-spam.mjs
@@ -1,0 +1,142 @@
+// Spam comment moderation for the runs-on.dev registry.
+//
+// Checks every issue comment and PR review comment for known spam domains,
+// deletes matching comments, and (if an admin token is configured) blocks
+// the commenter from the repository.
+//
+// Runs from .github/workflows/moderate.yml on a schedule and on new
+// comment events. See the workflow file for the required secrets.
+
+const REPO = process.env.GITHUB_REPOSITORY;
+const TOKEN = process.env.GITHUB_TOKEN;
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN; // optional: enables blocking
+
+if (!REPO || !TOKEN) {
+  console.error('moderate: GITHUB_REPOSITORY and GITHUB_TOKEN are required');
+  process.exit(1);
+}
+
+const api = (path, init = {}, token = TOKEN) =>
+  fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...init.headers,
+    },
+  });
+
+// Domains and patterns that are spam in this repo's context. Each entry is
+// a regex tested against the comment body. Add new patterns here; the
+// workflow picks them up on the next run without any other change.
+const SPAM_PATTERNS = [
+  /go-live\.me/i,
+  /golive\.me/i,
+];
+
+function isSpam(body) {
+  return SPAM_PATTERNS.some((pattern) => pattern.test(body));
+}
+
+// A comment by a bot or the owner is never spam, even if it quotes a spam
+// link while reporting or discussing it. The workflow's own GITHUB_TOKEN
+// identity is `github-actions[bot]`.
+const EXEMPT_LOGINS = new Set([
+  'github-actions[bot]',
+  'zordhalo',
+]);
+
+async function collectIssueComments() {
+  const comments = [];
+  let page = 1;
+  for (;;) {
+    const res = await api(`/repos/${REPO}/issues/comments?per_page=100&page=${page}&sort=created&direction=desc`);
+    if (!res.ok) throw new Error(`list issue comments page ${page}: ${res.status}`);
+    const body = await res.json();
+    if (body.length === 0) break;
+    comments.push(...body);
+    if (body.length < 100) break;
+    page += 1;
+  }
+  return comments;
+}
+
+async function collectPRReviewComments() {
+  const comments = [];
+  let page = 1;
+  for (;;) {
+    const res = await api(`/repos/${REPO}/pulls/comments?per_page=100&page=${page}&sort=created&direction=desc`);
+    if (!res.ok) throw new Error(`list PR review comments page ${page}: ${res.status}`);
+    const body = await res.json();
+    if (body.length === 0) break;
+    comments.push(...body);
+    if (body.length < 100) break;
+    page += 1;
+  }
+  return comments;
+}
+
+async function deleteIssueComment(id) {
+  const res = await api(`/repos/${REPO}/issues/comments/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`delete issue comment ${id}: ${res.status}`);
+}
+
+async function deletePRReviewComment(id) {
+  const res = await api(`/repos/${REPO}/pulls/comments/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`delete PR review comment ${id}: ${res.status}`);
+}
+
+// Blocks the user from the repository owner's account, which removes their
+// access to the repo and hides their existing interactions. Requires an
+// admin-scoped PAT (ADMIN_TOKEN secret); silently skipped otherwise.
+async function blockUser(login) {
+  if (!ADMIN_TOKEN) {
+    console.log(`(blocking skipped for ${login}: no ADMIN_TOKEN configured)`);
+    return false;
+  }
+  const res = await api(`/user/blocks/${login}`, { method: 'PUT' }, ADMIN_TOKEN);
+  if (res.ok) return true;
+  console.error(`block ${login}: ${res.status} ${res.statusText}`);
+  return false;
+}
+
+const actions = [];
+
+const [issueComments, prComments] = await Promise.all([
+  collectIssueComments(),
+  collectPRReviewComments(),
+]);
+
+for (const comment of issueComments) {
+  if (EXEMPT_LOGINS.has(comment.user.login)) continue;
+  if (!isSpam(comment.body)) continue;
+  await deleteIssueComment(comment.id);
+  console.log(`deleted issue comment ${comment.id} by ${comment.user.login}`);
+  actions.push({ type: 'deleted-issue-comment', id: comment.id, author: comment.user.login, blocked: await blockUser(comment.user.login) });
+}
+
+for (const comment of prComments) {
+  if (EXEMPT_LOGINS.has(comment.user.login)) continue;
+  if (!isSpam(comment.body)) continue;
+  await deletePRReviewComment(comment.id);
+  console.log(`deleted PR review comment ${comment.id} by ${comment.user.login}`);
+  actions.push({ type: 'deleted-pr-comment', id: comment.id, author: comment.user.login, blocked: await blockUser(comment.user.login) });
+}
+
+if (actions.length === 0) {
+  console.log('moderate: no spam found');
+} else {
+  console.log(`moderate: ${actions.length} spam comment(s) removed`);
+  // Emit for the workflow summary
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFile } = await import('node:fs/promises');
+    const lines = [
+      `# Spam moderation — ${new Date().toISOString()}`,
+      '',
+      ...actions.map((a) => `- ${a.type} #${a.id} by @${a.author}${a.blocked ? ' (user blocked)' : ''}`),
+      '',
+    ];
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'), 'utf8');
+  }
+}


### PR DESCRIPTION
Automates spam comment cleanup. Currently targeting `go-live.me` promotion comments (mentioned in #82 and closed PRs).

## How it works

**Two triggers:**
- `issue_comment: created` catches new spam within seconds of it landing
- `cron 7,37 * * * *` sweeps all existing comments every 30 minutes

**What it does:**
1. Checks every issue comment and PR review comment against `SPAM_PATTERNS` in `scripts/moderate-spam.mjs`
2. Deletes matching comments (GITHUB_TOKEN with `issues: write` + `pull-requests: write`)
3. If the `ADMIN_TOKEN` secret is set, also blocks the commenter's account from the repo owner. Without it, the comment is still deleted and the login is logged in the step summary for manual review.

**Exempt logins:** `github-actions[bot]` and the repo owner, so quoted spam links in moderation discussion or reports never trigger their own sweep.

## Setup required from you

| Secret | Required | Purpose |
|---|---|---|
| `GITHUB_TOKEN` | automatic | Delete comments |
| `ADMIN_TOKEN` | optional | Block the spammer's account (needs a PAT with admin scope) |

Without `ADMIN_TOKEN`, comments are still deleted and the usernames appear in the workflow summary for you to block manually.

## Extending

Add new spam domains to the `SPAM_PATTERNS` array in `scripts/moderate-spam.mjs`. The next run picks them up with no other change.