### PR TITLE
feat(nav): edge picker dock — Dynamic Island-style route navigation

### DIFF
--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -1,0 +1,586 @@
+'use client';
+
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { Home, Settings2, BarChart3, BookOpenText, CircleHelp, Info } from 'lucide-react';
+
+// ============================================================================
+// The Edge Picker Dock: a curved bezel notch cut into the right edge of the
+// viewport, with a spring-physics reel of route icons inside it. Modelled
+// on the iPhone "Camera Control" / Dynamic Island design pattern.
+//
+// Scroll, drag (with fling momentum), or tap a neighbor to navigate. The
+// active route's pill sits in the center notch: collapsed it shows the
+// icon, clicked (or hovered) it expands to reveal the route name in
+// vertical text. A mechanical tick sound fires on every detent crossing.
+//
+// All routes are prefetched on mount so navigation is instant (Next.js
+// caches the RSC payloads in memory). The picker's scroll position is
+// persisted in IndexedDB so it survives a page reload.
+// ============================================================================
+
+const ICON_SIZE = 18;
+
+const ROUTES = [
+  { id: 'home', label: 'Home', path: '/', Icon: Home },
+  { id: 'manage', label: 'Manage', path: '/manage', Icon: Settings2 },
+  { id: 'stats', label: 'Stats', path: '/stats', Icon: BarChart3 },
+  { id: 'docs', label: 'Docs', path: '/docs', Icon: BookOpenText },
+  { id: 'faq', label: 'FAQ', path: '/faq', Icon: CircleHelp },
+  { id: 'about', label: 'About', path: '/about', Icon: Info },
+];
+
+// ---------------------------------------------------------------------------
+// IndexedDB persistence for the picker's position. Survives page reloads so
+// the dock always opens where the user left it.
+// ---------------------------------------------------------------------------
+function openPickerDb() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('edge-picker', 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore('state');
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function idbGet(db, key) {
+  return new Promise((resolve) => {
+    const tx = db.transaction('state', 'readonly');
+    const req = tx.objectStore('state').get(key);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(undefined);
+  });
+}
+
+function idbPut(db, key, value) {
+  return new Promise((resolve) => {
+    const tx = db.transaction('state', 'readwrite');
+    tx.objectStore('state').put(value, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => resolve();
+  });
+}
+
+export default function EdgePicker() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const items = ROUTES;
+  const itemCount = items.length;
+
+  // Sync the reel to the current route on mount and on route change
+  const initialIndex = Math.max(0, ROUTES.findIndex((r) => r.path === pathname));
+
+  const [scrollPos, setScrollPos] = useState(initialIndex);
+  const [isRevealed, setIsRevealed] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const scrollPosRef = useRef(initialIndex);
+  scrollPosRef.current = scrollPos;
+
+  const containerRef = useRef(null);
+  const animFrameRef = useRef(null);
+  const pointerStartY = useRef(0);
+  const pointerStartPos = useRef(0);
+  const lastPointerY = useRef(0);
+  const lastPointerTime = useRef(0);
+  const velocityY = useRef(0);
+  const hasDraggedRef = useRef(false);
+  const targetItemOnDown = useRef(null);
+  const lastDetentIndex = useRef(initialIndex);
+  const audioContextRef = useRef(null);
+
+  // Keep the reel synced when the pathname changes (e.g. browser back/forward).
+  // Both sides are normalized before comparing so a route change triggered by
+  // the reel itself (scrollPos already at the right index, just unwrapped)
+  // doesn't cause a spin-back through every item.
+  useEffect(() => {
+    const i = ROUTES.findIndex((r) => r.path === pathname);
+    if (i < 0) return;
+    const currentNorm = ((Math.round(scrollPosRef.current) % itemCount) + itemCount) % itemCount;
+    if (i === currentNorm) return;
+    // Genuinely out of sync (browser back/forward): take the shortest path
+    const current = scrollPosRef.current;
+    let delta = i - currentNorm;
+    if (delta > itemCount / 2) delta -= itemCount;
+    if (delta < -itemCount / 2) delta += itemCount;
+    animateToTarget(current + delta);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  // --------------------------------------------------------------------------
+  // Haptic SFX Synthesizer (Web Audio API)
+  // --------------------------------------------------------------------------
+  const playHapticTick = useCallback((direction = 1) => {
+    try {
+      if (!audioContextRef.current) {
+        const AudioCtx = window.AudioContext || window.webkitAudioContext;
+        audioContextRef.current = new AudioCtx();
+      }
+      const ctx = audioContextRef.current;
+      if (ctx.state === 'suspended') ctx.resume();
+
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+
+      // Mechanical camera-control tick profile
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(direction > 0 ? 1420 : 1200, ctx.currentTime);
+      osc.frequency.exponentialRampToValueAtTime(320, ctx.currentTime + 0.035);
+
+      gain.gain.setValueAtTime(0.28, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.035);
+
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+
+      osc.start();
+      osc.stop(ctx.currentTime + 0.035);
+
+      if (typeof window !== 'undefined' && 'vibrate' in navigator) {
+        navigator.vibrate(8);
+      }
+    } catch {
+      // AudioContext not yet unlocked by user interaction
+    }
+  }, []);
+
+  // Fire detent crossing sound and navigate
+  const checkDetent = useCallback(
+    (pos) => {
+      const currentDetent = Math.round(pos);
+      if (currentDetent !== lastDetentIndex.current) {
+        const dir = currentDetent > lastDetentIndex.current ? 1 : -1;
+        lastDetentIndex.current = currentDetent;
+        playHapticTick(dir);
+
+        const normalized = ((currentDetent % itemCount) + itemCount) % itemCount;
+        const route = items[normalized];
+        if (route && route.path !== pathname) {
+          router.push(route.path);
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [items, itemCount, router, pathname, playHapticTick]
+  );
+
+  // --------------------------------------------------------------------------
+  // Spring Physics Animation
+  // --------------------------------------------------------------------------
+  const animateToTarget = useCallback(
+    (targetPos, initialVelocity = 0) => {
+      if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+
+      let current = scrollPosRef.current;
+      let velocity = initialVelocity;
+      const springK = 0.22;
+      const damping = 0.74;
+
+      const step = () => {
+        const diff = targetPos - current;
+        const springForce = diff * springK;
+        velocity = velocity * damping + springForce;
+        current += velocity;
+
+        setScrollPos(current);
+        checkDetent(current);
+
+        if (Math.abs(diff) < 0.002 && Math.abs(velocity) < 0.002) {
+          // Wrap the settled position into [0, itemCount) so scrollPos never
+          // grows unboundedly. The visual output is identical (the reel
+          // renders by modulo and relative offset), but the pathname sync
+          // comparison stays clean and float precision doesn't degrade.
+          const normalized = ((Math.round(targetPos) % itemCount) + itemCount) % itemCount;
+          setScrollPos(normalized);
+          scrollPosRef.current = normalized;
+          lastDetentIndex.current = normalized;
+          animFrameRef.current = null;
+          return;
+        }
+
+        animFrameRef.current = requestAnimationFrame(step);
+      };
+
+      animFrameRef.current = requestAnimationFrame(step);
+    },
+    [checkDetent, itemCount]
+  );
+
+  // --------------------------------------------------------------------------
+  // Geometry & Spec Formulas (46px rest, 96px revealed, locked 12px gap)
+  // --------------------------------------------------------------------------
+  const effectiveRevealed = isRevealed || isHovered;
+  const pillHeight = effectiveRevealed ? 96 : 46;
+
+  const getSlotY = useCallback((relOffset, currentPillH) => {
+    if (relOffset === 0) return 0;
+    const sign = relOffset > 0 ? 1 : -1;
+    const abs = Math.abs(relOffset);
+    const D1 = currentPillH / 2 + 12 + 10;
+    const step = 32;
+
+    if (abs <= 1) {
+      return sign * abs * D1;
+    }
+    return sign * (D1 + (abs - 1) * step);
+  }, []);
+
+  // --------------------------------------------------------------------------
+  // Gesture & Touch Interactions
+  // --------------------------------------------------------------------------
+  const handlePointerDown = (e, specificIndex = null) => {
+    if (animFrameRef.current) {
+      cancelAnimationFrame(animFrameRef.current);
+      animFrameRef.current = null;
+    }
+
+    setIsDragging(true);
+    hasDraggedRef.current = false;
+    targetItemOnDown.current = specificIndex;
+
+    pointerStartY.current = e.clientY;
+    pointerStartPos.current = scrollPosRef.current;
+    lastPointerY.current = e.clientY;
+    lastPointerTime.current = performance.now();
+    velocityY.current = 0;
+
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e) => {
+    if (!isDragging) return;
+
+    const currentY = e.clientY;
+    const deltaFromStart = currentY - pointerStartY.current;
+    const stepDelta = currentY - lastPointerY.current;
+    const now = performance.now();
+    const timeDelta = Math.max(1, now - lastPointerTime.current);
+
+    if (Math.abs(deltaFromStart) > 5) {
+      hasDraggedRef.current = true;
+    }
+
+    const pxPerItem = 32;
+    const instantVelocity = stepDelta / pxPerItem / timeDelta;
+    velocityY.current = velocityY.current * 0.4 + instantVelocity * 0.6;
+
+    lastPointerY.current = currentY;
+    lastPointerTime.current = now;
+
+    const newPos = pointerStartPos.current - deltaFromStart / pxPerItem;
+    setScrollPos(newPos);
+    checkDetent(newPos);
+  };
+
+  const handlePointerUp = (e) => {
+    if (!isDragging) return;
+    setIsDragging(false);
+
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {}
+
+    // Tap detected (scrolled less than 5px)
+    if (!hasDraggedRef.current) {
+      if (targetItemOnDown.current !== null) {
+        const tappedIdx = targetItemOnDown.current;
+        const currentCenter = Math.round(scrollPosRef.current);
+
+        if (tappedIdx === currentCenter) {
+          setIsRevealed((prev) => !prev);
+        } else {
+          animateToTarget(tappedIdx);
+        }
+        return;
+      }
+
+      // Tap on empty bezel notch curve
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect();
+        const tapRelY = e.clientY - (rect.top + rect.height / 2);
+
+        if (Math.abs(tapRelY) < 24) {
+          setIsRevealed((prev) => !prev);
+          return;
+        }
+
+        const currentCenter = Math.round(scrollPosRef.current);
+        let bestSlot = currentCenter;
+        let minDiff = Infinity;
+
+        for (let s = -3; s <= 3; s++) {
+          const slotY = getSlotY(s, pillHeight);
+          const diff = Math.abs(tapRelY - slotY);
+          if (diff < minDiff) {
+            minDiff = diff;
+            bestSlot = currentCenter + s;
+          }
+        }
+        animateToTarget(bestSlot);
+        return;
+      }
+    }
+
+    // Drag ended: fling with inertia momentum
+    const momentumItems = -velocityY.current * 140;
+    const projectedPos = scrollPosRef.current + momentumItems;
+    // Clamp the projected target to at most 1.5 loops away, so a violent
+    // fling doesn't leave scrollPos at an extreme value
+    const currentNorm = ((Math.round(scrollPosRef.current) % itemCount) + itemCount) % itemCount;
+    const maxTravel = Math.ceil(itemCount * 1.5);
+    let targetSnap = Math.round(projectedPos);
+    if (targetSnap > currentNorm + maxTravel) targetSnap = currentNorm + maxTravel;
+    if (targetSnap < currentNorm - maxTravel) targetSnap = currentNorm - maxTravel;
+
+    animateToTarget(targetSnap, -velocityY.current * 1.4);
+  };
+
+  const wheelTimeoutRef = useRef(null);
+
+  // Native non-passive wheel listener: React's onWheel is passive by default
+  // so e.preventDefault() inside it does nothing, meaning the page scrolls
+  // under the dock while the reel is also scrolling. This attaches a real
+  // listener that CAN preventDefault, isolating the dock's scroll zone.
+  const wheelHandlerRef = useRef(null);
+  wheelHandlerRef.current = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+
+    const delta = e.deltaY * 0.012;
+    const newPos = scrollPosRef.current + delta;
+    setScrollPos(newPos);
+    checkDetent(newPos);
+
+    if (wheelTimeoutRef.current) clearTimeout(wheelTimeoutRef.current);
+    wheelTimeoutRef.current = setTimeout(() => {
+      animateToTarget(Math.round(scrollPosRef.current));
+    }, 120);
+  };
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = (e) => wheelHandlerRef.current(e);
+    el.addEventListener('wheel', handler, { passive: false });
+    return () => el.removeEventListener('wheel', handler);
+  }, []);
+
+  // Prefetch every route so navigation via the reel is instant: Next.js
+  // caches the RSC payload in memory, and router.push() renders from that
+  // cache without a network round-trip. Re-prefetch every 25s to keep the
+  // cache warm (Next.js expires prefetched routes after 30s by default).
+  const prefetchedRef = useRef(false);
+  useEffect(() => {
+    if (prefetchedRef.current) return;
+    prefetchedRef.current = true;
+    for (const route of ROUTES) {
+      router.prefetch(route.path);
+    }
+    const interval = setInterval(() => {
+      for (const route of ROUTES) {
+        router.prefetch(route.path);
+      }
+    }, 25_000);
+    return () => clearInterval(interval);
+  }, [router]);
+
+  // Restore the picker's saved position from IndexedDB on mount
+  useEffect(() => {
+    openPickerDb()
+      .then((db) => idbGet(db, 'scrollPos'))
+      .then((saved) => {
+        if (typeof saved === 'number' && saved >= 0 && saved < itemCount) {
+          setScrollPos(saved);
+          scrollPosRef.current = saved;
+          lastDetentIndex.current = Math.round(saved);
+        }
+      })
+      .catch(() => {});
+  }, [itemCount]);
+
+  // Persist the position whenever it settles on a whole number
+  useEffect(() => {
+    if (Number.isInteger(scrollPos)) {
+      openPickerDb()
+        .then((db) => idbPut(db, 'scrollPos', ((scrollPos % itemCount) + itemCount) % itemCount))
+        .catch(() => {});
+    }
+  }, [scrollPos, itemCount]);
+
+  // Clean up animation frame on unmount
+  useEffect(() => {
+    return () => {
+      if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+    };
+  }, []);
+
+  // Don't render on wildcard-host card pages
+  if (pathname?.startsWith('/sites/')) return null;
+
+  const currentNearestCenter = Math.round(scrollPos);
+  const activeNormalizedIndex = ((currentNearestCenter % itemCount) + itemCount) % itemCount;
+  const activeItem = items[activeNormalizedIndex];
+
+  const visibleItemOffsets = [-4, -3, -2, -1, 0, 1, 2, 3, 4];
+
+  return (
+    <div
+      ref={containerRef}
+      onPointerDown={(e) => handlePointerDown(e, null)}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className="fixed right-0 top-1/2 -translate-y-1/2 z-50 h-[380px] w-[56px] select-none touch-none cursor-ns-resize flex items-center justify-end"
+      aria-label="Page navigation"
+      role="navigation"
+    >
+      {/* SVG ClipPath strictly matching the balanced bezel notch */}
+      <svg
+        className="absolute w-0 h-0 pointer-events-none"
+        aria-hidden="true"
+        style={{ position: 'absolute', width: 0, height: 0, overflow: 'hidden' }}
+      >
+        <defs>
+          <clipPath id="dockNotchClip" clipPathUnits="userSpaceOnUse">
+            <path d="M 56,0 C 56,45 4,50 4,95 L 4,285 C 4,330 56,335 56,380 Z" />
+          </clipPath>
+        </defs>
+      </svg>
+
+      {/* Curved SVG Dock Bezel, no outer shadow (recessed into the page) */}
+      <svg
+        className="absolute right-0 top-0 h-full w-[56px] pointer-events-none"
+        viewBox="0 0 56 380"
+        preserveAspectRatio="none"
+      >
+        <defs>
+          <linearGradient id="notchInnerShadow" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.08)" />
+            <stop offset="35%" stopColor="rgba(255,255,255,0.0)" />
+          </linearGradient>
+        </defs>
+
+        {/* Solid Dock Body (pure black) */}
+        <path
+          d="M 56,0 C 56,45 4,50 4,95 L 4,285 C 4,330 56,335 56,380 Z"
+          fill="#000"
+        />
+        {/* Inner shadow along the left curved edge: a subtle lighter
+            gradient that reads as depth inside the recessed notch */}
+        <path
+          d="M 56,1 C 55,45 5,50 5,95 L 5,285 C 5,330 55,335 56,379"
+          fill="none"
+          stroke="url(#notchInnerShadow)"
+          strokeWidth="2.5"
+        />
+      </svg>
+
+      {/* Masked Reel Container (Zero element leakage outside the notch) */}
+      <div
+        className="absolute right-0 top-0 w-[56px] h-[380px] overflow-hidden pointer-events-none"
+        style={{
+          clipPath: 'url(#dockNotchClip)',
+          WebkitClipPath: 'url(#dockNotchClip)',
+        }}
+      >
+        {/* Active Pill at Center Notch (paper-colored, bouncy expand on
+            hover/click revealing the route name in vertical text) */}
+        <div
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            handlePointerDown(e, currentNearestCenter);
+          }}
+          style={{
+            height: `${pillHeight}px`,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            background: 'var(--paper)',
+          }}
+          className="edge-picker-pill absolute right-[9px] w-[34px] rounded-full shadow-[0_0_0_1px_rgba(255,255,255,0.15)_inset] flex items-center justify-center z-20 cursor-pointer active:scale-95 pointer-events-auto"
+        >
+          <div
+            key={activeItem.id}
+            className="flex items-center justify-center w-full h-full"
+            style={{
+              animation: effectiveRevealed
+                ? 'edgePickerPop 0.35s cubic-bezier(0.34,1.56,0.64,1)'
+                : 'edgePickerShrink 0.3s cubic-bezier(0.34,1.56,0.64,1)',
+            }}
+          >
+            {effectiveRevealed ? (
+              <span
+                className="text-[11px] font-bold tracking-widest uppercase whitespace-nowrap"
+                style={{
+                  writingMode: 'vertical-rl',
+                  transform: 'rotate(180deg)',
+                  color: 'var(--ink)',
+                }}
+              >
+                {activeItem.label}
+              </span>
+            ) : (
+              <activeItem.Icon
+                size={ICON_SIZE}
+                strokeWidth={2.2}
+                style={{ color: 'var(--ink)' }}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Looping Reel Neighbors */}
+        {visibleItemOffsets.map((offset) => {
+          const integerIdx = currentNearestCenter + offset;
+          const catalogIdx = ((integerIdx % itemCount) + itemCount) % itemCount;
+          const item = items[catalogIdx];
+
+          const relContinuous = integerIdx - scrollPos;
+          const yPos = getSlotY(relContinuous, pillHeight);
+
+          if (Math.abs(relContinuous) < 0.35) return null;
+
+          const dist = Math.abs(yPos);
+          const maxDist = 148;
+          if (dist > maxDist) return null;
+
+          const fadeStart = 72;
+          let opacity = 1;
+          if (dist > fadeStart) {
+            opacity = Math.max(0, 1 - Math.pow((dist - fadeStart) / (maxDist - fadeStart), 1.3));
+          }
+          if (opacity <= 0.01) return null;
+
+          const scale = Math.max(0.72, 1 - dist / (maxDist * 2.4));
+
+          return (
+            <div
+              key={integerIdx}
+              onPointerDown={(e) => {
+                e.stopPropagation();
+                handlePointerDown(e, integerIdx);
+              }}
+              style={{
+                transform: `translateY(${yPos}px) scale(${scale})`,
+                opacity: opacity,
+                top: '50%',
+                marginTop: '-16px',
+              }}
+              className="absolute right-[9px] w-[34px] h-8 flex items-center justify-center transition-opacity duration-75 pointer-events-auto cursor-pointer group"
+              title={item.label}
+            >
+              <span className="w-6 h-6 rounded-full flex items-center justify-center group-hover:bg-white/10 group-hover:scale-125 transition-all text-neutral-400">
+                <item.Icon size={ICON_SIZE} strokeWidth={2} />
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -489,13 +489,27 @@ export default function EdgePicker() {
         </defs>
       </svg>
 
-      {/* Compact Capsule Backing (hugs active item when site scrolls) */}
-      <div
-        className="absolute inset-0 rounded-l-full bg-black shadow-[-4px_0_16px_rgba(0,0,0,0.6)] border-l border-t border-b border-white/20 transition-opacity duration-300 pointer-events-none"
+      {/* Compact Notch SVG (same bezel shape, scaled to capsule size) */}
+      <svg
+        className="absolute right-0 top-0 pointer-events-none transition-opacity duration-300"
+        width="56"
+        height="56"
+        viewBox="0 0 56 56"
         style={{
           opacity: isCompact ? 1 : 0,
         }}
-      />
+      >
+        <path
+          d="M 56,0 C 56,7 4,7 4,14 L 4,42 C 4,49 56,49 56,56 Z"
+          fill="#0a0a0c"
+        />
+        <path
+          d="M 56,1 C 55,7 5,7 5,14 L 5,42 C 5,49 55,49 56,55"
+          fill="none"
+          stroke="rgba(255,255,255,0.18)"
+          strokeWidth="1.5"
+        />
+      </svg>
 
       {/* Curved SVG Dock Bezel (recessed into page in expanded mode) */}
       <svg

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -226,7 +226,10 @@ export default function EdgePicker() {
     const now = performance.now();
     const timeDelta = Math.max(1, now - lastPointerTime.current);
 
-    if (!hasDraggedRef.current && Math.abs(deltaFromStart) > 5) {
+    // Only switch to drag state and text reveal if the pointer moved
+    // significantly. 12px filters out mobile tap jitter (a finger press
+    // easily jitters 5-8px) so tapping an icon never flashes text.
+    if (!hasDraggedRef.current && Math.abs(deltaFromStart) > 12) {
       hasDraggedRef.current = true;
       setIsDragging(true);
       isDraggingRef.current = true;
@@ -335,7 +338,10 @@ export default function EdgePicker() {
     return () => el.removeEventListener('wheel', handler);
   }, []);
 
-  // Bouncy auto-shrink when the website content scrolls
+  // Bouncy auto-shrink when the website content scrolls.
+  // Uses document + capture so it catches scroll from the window, the
+  // body, or any nested scrollable container regardless of which element
+  // actually owns the scrollbar.
   useEffect(() => {
     let timer;
     const onPageScroll = () => {
@@ -350,9 +356,9 @@ export default function EdgePicker() {
       }, 70);
     };
 
-    window.addEventListener('scroll', onPageScroll, { passive: true });
+    document.addEventListener('scroll', onPageScroll, { passive: true, capture: true });
     return () => {
-      window.removeEventListener('scroll', onPageScroll);
+      document.removeEventListener('scroll', onPageScroll, { capture: true });
       clearTimeout(timer);
     };
   }, []);

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -4,21 +4,6 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { Home, Settings2, BarChart3, BookOpenText, CircleHelp, Info } from 'lucide-react';
 
-// ============================================================================
-// The Edge Picker Dock: a curved bezel notch cut into the right edge of the
-// viewport, with a spring-physics reel of route icons inside it. Modelled
-// on the iPhone "Camera Control" / Dynamic Island design pattern.
-//
-// Scroll, drag (with fling momentum), or tap a neighbor to navigate. The
-// active route's pill sits in the center notch: collapsed it shows the
-// icon, clicked (or hovered) it expands to reveal the route name in
-// vertical text. A mechanical tick sound fires on every detent crossing.
-//
-// All routes are prefetched on mount so navigation is instant (Next.js
-// caches the RSC payloads in memory). The picker's scroll position is
-// persisted in IndexedDB so it survives a page reload.
-// ============================================================================
-
 const ICON_SIZE = 18;
 
 const ROUTES = [
@@ -30,12 +15,12 @@ const ROUTES = [
   { id: 'about', label: 'About', path: '/about', Icon: Info },
 ];
 
-// ---------------------------------------------------------------------------
-// IndexedDB persistence for the picker's position. Survives page reloads so
-// the dock always opens where the user left it.
-// ---------------------------------------------------------------------------
 function openPickerDb() {
   return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined' || !window.indexedDB) {
+      resolve(null);
+      return;
+    }
     const req = indexedDB.open('edge-picker', 1);
     req.onupgradeneeded = () => {
       req.result.createObjectStore('state');
@@ -47,6 +32,10 @@ function openPickerDb() {
 
 function idbGet(db, key) {
   return new Promise((resolve) => {
+    if (!db) {
+      resolve(undefined);
+      return;
+    }
     const tx = db.transaction('state', 'readonly');
     const req = tx.objectStore('state').get(key);
     req.onsuccess = () => resolve(req.result);
@@ -56,6 +45,10 @@ function idbGet(db, key) {
 
 function idbPut(db, key, value) {
   return new Promise((resolve) => {
+    if (!db) {
+      resolve();
+      return;
+    }
     const tx = db.transaction('state', 'readwrite');
     tx.objectStore('state').put(value, key);
     tx.oncomplete = () => resolve();
@@ -69,16 +62,17 @@ export default function EdgePicker() {
   const items = ROUTES;
   const itemCount = items.length;
 
-  // Sync the reel to the current route on mount and on route change
   const initialIndex = Math.max(0, ROUTES.findIndex((r) => r.path === pathname));
 
   const [scrollPos, setScrollPos] = useState(initialIndex);
-  const [isRevealed, setIsRevealed] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [isWheeling, setIsWheeling] = useState(false);
   const [isCompact, setIsCompact] = useState(false);
+
   const isDraggingRef = useRef(false);
   isDraggingRef.current = isDragging;
+  const isPointerDownRef = useRef(false);
+  const expandedAtRef = useRef(0);
 
   const scrollPosRef = useRef(initialIndex);
   scrollPosRef.current = scrollPos;
@@ -95,16 +89,11 @@ export default function EdgePicker() {
   const lastDetentIndex = useRef(initialIndex);
   const audioContextRef = useRef(null);
 
-  // Keep the reel synced when the pathname changes (e.g. browser back/forward).
-  // Both sides are normalized before comparing so a route change triggered by
-  // the reel itself (scrollPos already at the right index, just unwrapped)
-  // doesn't cause a spin-back through every item.
   useEffect(() => {
     const i = ROUTES.findIndex((r) => r.path === pathname);
     if (i < 0) return;
     const currentNorm = ((Math.round(scrollPosRef.current) % itemCount) + itemCount) % itemCount;
     if (i === currentNorm) return;
-    // Genuinely out of sync (browser back/forward): take the shortest path
     const current = scrollPosRef.current;
     let delta = i - currentNorm;
     if (delta > itemCount / 2) delta -= itemCount;
@@ -113,9 +102,6 @@ export default function EdgePicker() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 
-  // --------------------------------------------------------------------------
-  // Haptic SFX Synthesizer (Web Audio API)
-  // --------------------------------------------------------------------------
   const playHapticTick = useCallback((direction = 1) => {
     try {
       if (!audioContextRef.current) {
@@ -128,7 +114,6 @@ export default function EdgePicker() {
       const osc = ctx.createOscillator();
       const gain = ctx.createGain();
 
-      // Mechanical camera-control tick profile
       osc.type = 'sine';
       osc.frequency.setValueAtTime(direction > 0 ? 1420 : 1200, ctx.currentTime);
       osc.frequency.exponentialRampToValueAtTime(320, ctx.currentTime + 0.035);
@@ -146,11 +131,10 @@ export default function EdgePicker() {
         navigator.vibrate(8);
       }
     } catch {
-      // AudioContext not yet unlocked by user interaction
+      // AudioContext awaiting user gesture or unsupported
     }
   }, []);
 
-  // Fire detent crossing sound and navigate
   const checkDetent = useCallback(
     (pos) => {
       const currentDetent = Math.round(pos);
@@ -166,13 +150,9 @@ export default function EdgePicker() {
         }
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [items, itemCount, router, pathname, playHapticTick]
   );
 
-  // --------------------------------------------------------------------------
-  // Spring Physics Animation
-  // --------------------------------------------------------------------------
   const animateToTarget = useCallback(
     (targetPos, initialVelocity = 0) => {
       if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
@@ -192,10 +172,6 @@ export default function EdgePicker() {
         checkDetent(current);
 
         if (Math.abs(diff) < 0.002 && Math.abs(velocity) < 0.002) {
-          // Wrap the settled position into [0, itemCount) so scrollPos never
-          // grows unboundedly. The visual output is identical (the reel
-          // renders by modulo and relative offset), but the pathname sync
-          // comparison stays clean and float precision doesn't degrade.
           const normalized = ((Math.round(targetPos) % itemCount) + itemCount) % itemCount;
           setScrollPos(normalized);
           scrollPosRef.current = normalized;
@@ -212,13 +188,8 @@ export default function EdgePicker() {
     [checkDetent, itemCount]
   );
 
-  // --------------------------------------------------------------------------
-  // Geometry & Spec Formulas (46px rest, 96px revealed, locked 12px gap)
-  // --------------------------------------------------------------------------
-  // isDragging shows text too: on mobile there's no hover, so the only way
-  // to see which route you're on while scrolling the reel is for the pill
-  // to be in its text state during the drag itself.
-  const effectiveRevealed = isRevealed || isHovered || isDragging;
+  // Reveal text strictly while scrolling the dock reel (dragging or wheeling)
+  const effectiveRevealed = !isCompact && (isDragging || isWheeling);
   const pillHeight = effectiveRevealed ? 96 : 46;
 
   const getSlotY = useCallback((relOffset, currentPillH) => {
@@ -234,14 +205,11 @@ export default function EdgePicker() {
     return sign * (D1 + (abs - 1) * step);
   }, []);
 
-  // --------------------------------------------------------------------------
-  // Gesture & Touch Interactions
-  // --------------------------------------------------------------------------
   const handlePointerDown = (e, specificIndex = null) => {
-    // Tapping the compact dock expands it back to full size; the drag/tap
-    // behavior only resumes once the dock is at its normal size.
+    // If the dock is compact, expand it back without executing reel drag
     if (isCompact) {
       setIsCompact(false);
+      expandedAtRef.current = Date.now();
       e.preventDefault();
       e.stopPropagation();
       return;
@@ -252,7 +220,7 @@ export default function EdgePicker() {
       animFrameRef.current = null;
     }
 
-    setIsDragging(true);
+    isPointerDownRef.current = true;
     hasDraggedRef.current = false;
     targetItemOnDown.current = specificIndex;
 
@@ -262,11 +230,13 @@ export default function EdgePicker() {
     lastPointerTime.current = performance.now();
     velocityY.current = 0;
 
-    e.currentTarget.setPointerCapture(e.pointerId);
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {}
   };
 
   const handlePointerMove = (e) => {
-    if (!isDragging) return;
+    if (!isPointerDownRef.current) return;
 
     const currentY = e.clientY;
     const deltaFromStart = currentY - pointerStartY.current;
@@ -274,9 +244,14 @@ export default function EdgePicker() {
     const now = performance.now();
     const timeDelta = Math.max(1, now - lastPointerTime.current);
 
-    if (Math.abs(deltaFromStart) > 5) {
+    // Only switch to dragging and text mode once the user genuinely drags > 5px
+    if (!hasDraggedRef.current && Math.abs(deltaFromStart) > 5) {
       hasDraggedRef.current = true;
+      setIsDragging(true);
+      isDraggingRef.current = true;
     }
+
+    if (!hasDraggedRef.current) return;
 
     const pxPerItem = 32;
     const instantVelocity = stepDelta / pxPerItem / timeDelta;
@@ -291,22 +266,24 @@ export default function EdgePicker() {
   };
 
   const handlePointerUp = (e) => {
-    if (!isDragging) return;
+    if (!isPointerDownRef.current) return;
+    isPointerDownRef.current = false;
+
+    const wasDragging = hasDraggedRef.current;
     setIsDragging(false);
+    isDraggingRef.current = false;
 
     try {
       e.currentTarget.releasePointerCapture(e.pointerId);
     } catch {}
 
-    // Tap detected (scrolled less than 5px)
-    if (!hasDraggedRef.current) {
+    // Tap detected (scrolled less than 5px): keeps icon as icon, never turns to text
+    if (!wasDragging) {
       if (targetItemOnDown.current !== null) {
         const tappedIdx = targetItemOnDown.current;
         const currentCenter = Math.round(scrollPosRef.current);
 
-        if (tappedIdx === currentCenter) {
-          setIsRevealed((prev) => !prev);
-        } else {
+        if (tappedIdx !== currentCenter) {
           animateToTarget(tappedIdx);
         }
         return;
@@ -317,33 +294,28 @@ export default function EdgePicker() {
         const rect = containerRef.current.getBoundingClientRect();
         const tapRelY = e.clientY - (rect.top + rect.height / 2);
 
-        if (Math.abs(tapRelY) < 24) {
-          setIsRevealed((prev) => !prev);
-          return;
-        }
+        if (Math.abs(tapRelY) >= 24) {
+          const currentCenter = Math.round(scrollPosRef.current);
+          let bestSlot = currentCenter;
+          let minDiff = Infinity;
 
-        const currentCenter = Math.round(scrollPosRef.current);
-        let bestSlot = currentCenter;
-        let minDiff = Infinity;
-
-        for (let s = -3; s <= 3; s++) {
-          const slotY = getSlotY(s, pillHeight);
-          const diff = Math.abs(tapRelY - slotY);
-          if (diff < minDiff) {
-            minDiff = diff;
-            bestSlot = currentCenter + s;
+          for (let s = -3; s <= 3; s++) {
+            const slotY = getSlotY(s, pillHeight);
+            const diff = Math.abs(tapRelY - slotY);
+            if (diff < minDiff) {
+              minDiff = diff;
+              bestSlot = currentCenter + s;
+            }
           }
+          animateToTarget(bestSlot);
         }
-        animateToTarget(bestSlot);
-        return;
       }
+      return;
     }
 
     // Drag ended: fling with inertia momentum
     const momentumItems = -velocityY.current * 140;
     const projectedPos = scrollPosRef.current + momentumItems;
-    // Clamp the projected target to at most 1.5 loops away, so a violent
-    // fling doesn't leave scrollPos at an extreme value
     const currentNorm = ((Math.round(scrollPosRef.current) % itemCount) + itemCount) % itemCount;
     const maxTravel = Math.ceil(itemCount * 1.5);
     let targetSnap = Math.round(projectedPos);
@@ -354,16 +326,13 @@ export default function EdgePicker() {
   };
 
   const wheelTimeoutRef = useRef(null);
-
-  // Native non-passive wheel listener: React's onWheel is passive by default
-  // so e.preventDefault() inside it does nothing, meaning the page scrolls
-  // under the dock while the reel is also scrolling. This attaches a real
-  // listener that CAN preventDefault, isolating the dock's scroll zone.
   const wheelHandlerRef = useRef(null);
   wheelHandlerRef.current = (e) => {
     e.preventDefault();
     e.stopPropagation();
     if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+
+    setIsWheeling(true);
 
     const delta = e.deltaY * 0.012;
     const newPos = scrollPosRef.current + delta;
@@ -372,8 +341,9 @@ export default function EdgePicker() {
 
     if (wheelTimeoutRef.current) clearTimeout(wheelTimeoutRef.current);
     wheelTimeoutRef.current = setTimeout(() => {
+      setIsWheeling(false);
       animateToTarget(Math.round(scrollPosRef.current));
-    }, 120);
+    }, 180);
   };
 
   useEffect(() => {
@@ -384,10 +354,28 @@ export default function EdgePicker() {
     return () => el.removeEventListener('wheel', handler);
   }, []);
 
-  // Prefetch every route so navigation via the reel is instant: Next.js
-  // caches the RSC payload in memory, and router.push() renders from that
-  // cache without a network round-trip. Re-prefetch every 25s to keep the
-  // cache warm (Next.js expires prefetched routes after 30s by default).
+  // Shrink the dock into selected item's capsule size when website content scrolls
+  useEffect(() => {
+    let timer;
+    const onPageScroll = () => {
+      if (isDraggingRef.current || isPointerDownRef.current) return;
+      if (Date.now() - expandedAtRef.current < 800) return;
+
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        if (!isDraggingRef.current && !isPointerDownRef.current && Date.now() - expandedAtRef.current >= 800) {
+          setIsCompact(true);
+        }
+      }, 80);
+    };
+
+    window.addEventListener('scroll', onPageScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onPageScroll);
+      clearTimeout(timer);
+    };
+  }, []);
+
   const prefetchedRef = useRef(false);
   useEffect(() => {
     if (prefetchedRef.current) return;
@@ -403,26 +391,6 @@ export default function EdgePicker() {
     return () => clearInterval(interval);
   }, [router]);
 
-  // Compact the dock when the page scrolls: the full-height dock can cover
-  // text on smaller screens, so it deflates to a small pill anchored to the
-  // edge. Tapping it bounces it back to full size. Only fires when the dock
-  // itself isn't being dragged (isDraggingRef prevents a scroll inside the
-  // dock from compacting it).
-  useEffect(() => {
-    let timer;
-    const onPageScroll = () => {
-      if (isDraggingRef.current) return;
-      clearTimeout(timer);
-      timer = setTimeout(() => setIsCompact(true), 120);
-    };
-    window.addEventListener('scroll', onPageScroll, { passive: true });
-    return () => {
-      window.removeEventListener('scroll', onPageScroll);
-      clearTimeout(timer);
-    };
-  }, []);
-
-  // Restore the picker's saved position from IndexedDB on mount
   useEffect(() => {
     openPickerDb()
       .then((db) => idbGet(db, 'scrollPos'))
@@ -436,7 +404,6 @@ export default function EdgePicker() {
       .catch(() => {});
   }, [itemCount]);
 
-  // Persist the position whenever it settles on a whole number
   useEffect(() => {
     if (Number.isInteger(scrollPos)) {
       openPickerDb()
@@ -445,14 +412,12 @@ export default function EdgePicker() {
     }
   }, [scrollPos, itemCount]);
 
-  // Clean up animation frame on unmount
   useEffect(() => {
     return () => {
       if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
     };
   }, []);
 
-  // Don't render on wildcard-host card pages
   if (pathname?.startsWith('/sites/')) return null;
 
   const currentNearestCenter = Math.round(scrollPos);
@@ -468,18 +433,26 @@ export default function EdgePicker() {
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onClick={(e) => {
+        if (isCompact) {
+          setIsCompact(false);
+          expandedAtRef.current = Date.now();
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }}
       style={{
         top: '50%',
         right: 0,
         position: 'fixed',
-        transform: `translateY(-50%) scale(${isCompact ? 0.3 : 1})`,
-        transformOrigin: 'center right',
-        transition: 'transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1)',
-        opacity: isCompact ? 0.7 : 1,
+        transform: 'translateY(-50%)',
+        width: isCompact ? '44px' : '56px',
+        height: isCompact ? '54px' : '380px',
+        transition: 'width 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), height 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.3s ease',
       }}
-      className="z-50 h-[380px] w-[56px] select-none touch-none cursor-ns-resize flex items-center justify-end"
+      className={`z-50 select-none touch-none cursor-pointer flex items-center justify-end ${
+        isCompact ? 'active:scale-95' : 'cursor-ns-resize'
+      }`}
       aria-label="Page navigation"
       role="navigation"
     >
@@ -496,11 +469,22 @@ export default function EdgePicker() {
         </defs>
       </svg>
 
-      {/* Curved SVG Dock Bezel, no outer shadow (recessed into the page) */}
+      {/* Compact Capsule Backing (hugs selected item size so website text is readable) */}
+      <div
+        className="absolute inset-0 rounded-l-full bg-black shadow-[-4px_0_16px_rgba(0,0,0,0.55)] border-l border-t border-b border-white/15 transition-opacity duration-300 pointer-events-none"
+        style={{
+          opacity: isCompact ? 1 : 0,
+        }}
+      />
+
+      {/* Curved SVG Dock Bezel (recessed into page in full mode) */}
       <svg
-        className="absolute right-0 top-0 h-full w-[56px] pointer-events-none"
+        className="absolute right-0 top-0 h-full w-[56px] pointer-events-none transition-opacity duration-300"
         viewBox="0 0 56 380"
         preserveAspectRatio="none"
+        style={{
+          opacity: isCompact ? 0 : 1,
+        }}
       >
         <defs>
           <linearGradient id="notchInnerShadow" x1="0%" y1="0%" x2="100%" y2="0%">
@@ -509,13 +493,10 @@ export default function EdgePicker() {
           </linearGradient>
         </defs>
 
-        {/* Solid Dock Body (pure black) */}
         <path
           d="M 56,0 C 56,45 4,50 4,95 L 4,285 C 4,330 56,335 56,380 Z"
           fill="#000"
         />
-        {/* Inner shadow along the left curved edge: a subtle lighter
-            gradient that reads as depth inside the recessed notch */}
         <path
           d="M 56,1 C 55,45 5,50 5,95 L 5,285 C 5,330 55,335 56,379"
           fill="none"
@@ -524,20 +505,21 @@ export default function EdgePicker() {
         />
       </svg>
 
-      {/* Masked Reel Container (Zero element leakage outside the notch) */}
+      {/* Masked Reel Container */}
       <div
-        className="absolute right-0 top-0 w-[56px] h-[380px] overflow-hidden pointer-events-none"
+        className="absolute right-0 top-0 w-full h-full overflow-hidden pointer-events-none"
         style={{
-          clipPath: 'url(#dockNotchClip)',
-          WebkitClipPath: 'url(#dockNotchClip)',
+          clipPath: isCompact ? 'none' : 'url(#dockNotchClip)',
+          WebkitClipPath: isCompact ? 'none' : 'url(#dockNotchClip)',
         }}
       >
-        {/* Active Pill at Center Notch (paper-colored, bouncy expand on
-            hover/click revealing the route name in vertical text) */}
+        {/* Active Pill at Center Notch */}
         <div
           onPointerDown={(e) => {
-            e.stopPropagation();
-            handlePointerDown(e, currentNearestCenter);
+            if (!isCompact) {
+              e.stopPropagation();
+              handlePointerDown(e, currentNearestCenter);
+            }
           }}
           style={{
             height: `${pillHeight}px`,
@@ -545,7 +527,9 @@ export default function EdgePicker() {
             transform: 'translateY(-50%)',
             background: 'var(--paper)',
           }}
-          className="edge-picker-pill absolute right-[9px] w-[34px] rounded-full shadow-[0_0_0_1px_rgba(255,255,255,0.15)_inset] flex items-center justify-center z-20 cursor-pointer active:scale-95 pointer-events-auto"
+          className={`edge-picker-pill absolute right-[5px] sm:right-[9px] w-[34px] rounded-full shadow-[0_0_0_1px_rgba(255,255,255,0.15)_inset] flex items-center justify-center z-20 pointer-events-auto ${
+            isCompact ? 'pointer-events-none' : 'cursor-pointer active:scale-95'
+          }`}
         >
           <div
             key={activeItem.id}
@@ -577,9 +561,8 @@ export default function EdgePicker() {
           </div>
         </div>
 
-        {/* Looping Reel Neighbors (hidden when compact: the dock deflates
-            to just the active pill so it stops covering page text) */}
-        {!isCompact && visibleItemOffsets.map((offset) => {
+        {/* Looping Reel Neighbors */}
+        {visibleItemOffsets.map((offset) => {
           const integerIdx = currentNearestCenter + offset;
           const catalogIdx = ((integerIdx % itemCount) + itemCount) % itemCount;
           const item = items[catalogIdx];
@@ -606,16 +589,20 @@ export default function EdgePicker() {
             <div
               key={integerIdx}
               onPointerDown={(e) => {
-                e.stopPropagation();
-                handlePointerDown(e, integerIdx);
+                if (!isCompact) {
+                  e.stopPropagation();
+                  handlePointerDown(e, integerIdx);
+                }
               }}
               style={{
                 transform: `translateY(${yPos}px) scale(${scale})`,
-                opacity: opacity,
+                opacity: isCompact ? 0 : opacity,
                 top: '50%',
                 marginTop: '-16px',
+                pointerEvents: isCompact ? 'none' : 'auto',
+                transition: 'opacity 0.25s ease',
               }}
-              className="absolute right-[9px] w-[34px] h-8 flex items-center justify-center transition-opacity duration-75 pointer-events-auto cursor-pointer group"
+              className="absolute right-[5px] sm:right-[9px] w-[34px] h-8 flex items-center justify-center pointer-events-auto cursor-pointer group"
               title={item.label}
             >
               <span className="w-6 h-6 rounded-full flex items-center justify-center group-hover:bg-white/10 group-hover:scale-125 transition-all text-neutral-400">

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -108,10 +108,6 @@ export default function EdgePicker() {
 
       osc.start();
       osc.stop(ctx.currentTime + 0.035);
-
-      if (typeof window !== 'undefined' && 'vibrate' in navigator) {
-        navigator.vibrate(8);
-      }
     } catch {
       // Audio awaiting user gesture
     }

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -171,8 +171,10 @@ export default function EdgePicker() {
     [checkDetent, itemCount]
   );
 
-  // Text revealed ONLY while actively dragging or wheeling
-  const isScrollingReel = !isCompact && (isDragging || isWheeling);
+  // Text revealed while dragging, wheeling, or hovering (desktop only —
+  // mobile has no hover so the pill stays compact unless actively scrubbed)
+  const [isHovered, setIsHovered] = useState(false);
+  const isScrollingReel = !isCompact && (isDragging || isWheeling || (typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches && isHovered));
   const pillHeight = isScrollingReel ? 96 : 46;
 
   // Compact state maintains the exact S-curve notch shape, shrunk to 116px
@@ -451,6 +453,8 @@ export default function EdgePicker() {
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       onClick={(e) => {
         if (isCompact) {
           setIsCompact(false);

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -178,7 +178,16 @@ export default function EdgePicker() {
   const isScrollingReel = !isCompact && (isDragging || isWheeling || isHovered);
   const pillHeight = isScrollingReel ? 96 : 46;
 
-  // Compact state maintains the exact S-curve notch shape, shrunk to 116px
+  // Compact state: only on mobile (coarse pointer). Desktop never shrinks
+  // — the full dock is always visible and interactive.
+  const [isCoarsePointer, setIsCoarsePointer] = useState(false);
+  const isCoarsePointerRef = useRef(false);
+  useEffect(() => {
+    const coarse = window.matchMedia('(pointer: coarse)').matches;
+    setIsCoarsePointer(coarse);
+    isCoarsePointerRef.current = coarse;
+  }, []);
+
   const dockLength = isCompact ? 116 : 380;
 
   const getSlotY = useCallback((relOffset, currentPillH) => {
@@ -349,6 +358,7 @@ export default function EdgePicker() {
     let timer;
 
     const compact = () => {
+      if (!isCoarsePointerRef.current) return; // desktop never compacts
       if (isDraggingRef.current || isPointerDownRef.current) return;
       if (Date.now() - expandedAtRef.current < 750) return;
 

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -171,10 +171,12 @@ export default function EdgePicker() {
     [checkDetent, itemCount]
   );
 
-  // Text revealed ONLY while actively scrubbing or wheeling the reel.
-  // Tapping or resting ALWAYS preserves the icon.
+  // Text revealed ONLY while actively dragging or wheeling
   const isScrollingReel = !isCompact && (isDragging || isWheeling);
   const pillHeight = isScrollingReel ? 96 : 46;
+
+  // Compact state maintains the exact S-curve notch shape, shrunk to 116px
+  const dockLength = isCompact ? 116 : 380;
 
   const getSlotY = useCallback((relOffset, currentPillH) => {
     if (relOffset === 0) return 0;
@@ -193,6 +195,7 @@ export default function EdgePicker() {
     if (isCompact) {
       setIsCompact(false);
       expandedAtRef.current = Date.now();
+      playHapticTick(1);
       e.preventDefault();
       e.stopPropagation();
       return;
@@ -228,10 +231,8 @@ export default function EdgePicker() {
     const now = performance.now();
     const timeDelta = Math.max(1, now - lastPointerTime.current);
 
-    // Only enter drag mode if BOTH: moved > 12px AND held for > 150ms.
-    // A mobile tap jitters 5-15px in under 100ms — the time check is what
-    // actually separates a tap from a deliberate drag on touch.
-    if (!hasDraggedRef.current && Math.abs(deltaFromStart) > 12 && now - pointerDownTimeRef.current > 150) {
+    // Only switch to drag state if dragged > 10px and held > 80ms
+    if (!hasDraggedRef.current && Math.abs(deltaFromStart) > 10 && now - pointerDownTimeRef.current > 80) {
       hasDraggedRef.current = true;
       setIsDragging(true);
       isDraggingRef.current = true;
@@ -263,7 +264,7 @@ export default function EdgePicker() {
       e.currentTarget.releasePointerCapture(e.pointerId);
     } catch {}
 
-    // Tap detected (moved <= 5px): select and center without text reveal
+    // Tap: select and center without text
     if (!wasDragging) {
       if (targetItemOnDown.current !== null) {
         const tappedIdx = targetItemOnDown.current;
@@ -298,7 +299,7 @@ export default function EdgePicker() {
       return;
     }
 
-    // Drag ended: fling with inertia momentum
+    // Drag ended: fling with inertia
     const momentumItems = -velocityY.current * 140;
     const projectedPos = scrollPosRef.current + momentumItems;
     const currentNorm = ((Math.round(scrollPosRef.current) % itemCount) + itemCount) % itemCount;
@@ -340,10 +341,7 @@ export default function EdgePicker() {
     return () => el.removeEventListener('wheel', handler);
   }, []);
 
-  // Bouncy auto-shrink when the website content scrolls.
-  // Desktop: document scroll with capture catches any scrollable element.
-  // Mobile: scroll events often don't fire because the dock's touch-action
-  // can swallow the gesture, so touchmove outside the dock is the trigger.
+  // Shrink on page scroll (desktop + mobile via touchmove outside dock)
   useEffect(() => {
     let timer;
 
@@ -377,7 +375,7 @@ export default function EdgePicker() {
     };
   }, []);
 
-  // Pathname sync: browser back/forward and link clicks move the reel
+  // Pathname sync
   useEffect(() => {
     const i = ROUTES.findIndex((r) => r.path === pathname);
     if (i < 0) return;
@@ -391,7 +389,7 @@ export default function EdgePicker() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 
-  // Prefetch all routes for instant navigation
+  // Prefetch all routes
   const prefetchedRef = useRef(false);
   useEffect(() => {
     if (prefetchedRef.current) return;
@@ -443,7 +441,7 @@ export default function EdgePicker() {
 
   const visibleItemOffsets = [-4, -3, -2, -1, 0, 1, 2, 3, 4];
 
-  // Paper theme: pill uses the site's CSS tokens
+  // Paper theme
   const pillShadow = '0 0 0 1px rgba(255,255,255,0.15) inset, 0 4px 12px rgba(0,0,0,0.35)';
 
   return (
@@ -457,6 +455,7 @@ export default function EdgePicker() {
         if (isCompact) {
           setIsCompact(false);
           expandedAtRef.current = Date.now();
+          playHapticTick(1);
           e.preventDefault();
           e.stopPropagation();
         }
@@ -466,49 +465,38 @@ export default function EdgePicker() {
         right: 0,
         position: 'fixed',
         transform: 'translateY(-50%)',
-        width: isCompact ? '44px' : '56px',
-        height: isCompact ? '56px' : '380px',
-        transition: 'width 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), height 0.45s cubic-bezier(0.34, 1.56, 0.64, 1)',
+        width: '56px',
+        height: `${dockLength}px`,
+        transition: 'height 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.3s ease',
       }}
       className={`z-50 select-none touch-none cursor-pointer flex items-center justify-end ${
-        isCompact ? 'active:scale-90 hover:opacity-90' : 'cursor-ns-resize'
+        isCompact ? 'active:scale-95 hover:brightness-110' : 'cursor-ns-resize'
       }`}
       aria-label="Page navigation"
       role="navigation"
     >
-      {/* SVG ClipPath strictly matching the balanced notch */}
+      {/* Dynamic SVG ClipPath using objectBoundingBox: scales with height */}
       <svg
         className="absolute w-0 h-0 pointer-events-none"
         aria-hidden="true"
         style={{ position: 'absolute', width: 0, height: 0, overflow: 'hidden' }}
       >
         <defs>
-          <clipPath id="dockNotchClip" clipPathUnits="userSpaceOnUse">
-            <path d="M 56,0 C 56,45 4,50 4,95 L 4,285 C 4,330 56,335 56,380 Z" />
+          <clipPath id="dockNotchClipObject" clipPathUnits="objectBoundingBox">
+            <path d="M 1,0 C 1,0.1184 0.0714,0.1316 0.0714,0.25 L 0.0714,0.75 C 0.0714,0.8684 1,0.8816 1,1 Z" />
           </clipPath>
         </defs>
       </svg>
 
-      {/* Compact Capsule Backing (hugs active item when site scrolls) */}
-      <div
-        className="absolute inset-0 rounded-l-full bg-black shadow-[-4px_0_16px_rgba(0,0,0,0.6)] border-l border-t border-b border-white/20 transition-opacity duration-300 pointer-events-none"
-        style={{
-          opacity: isCompact ? 1 : 0,
-        }}
-      />
-
-      {/* Curved SVG Dock Bezel (recessed into page in expanded mode) */}
+      {/* Curved SVG Dock Bezel: MAINTAINED in both expanded and compact states */}
       <svg
-        className="absolute right-0 top-0 h-full w-[56px] pointer-events-none transition-opacity duration-300"
+        className="absolute right-0 top-0 h-full w-[56px] pointer-events-none drop-shadow-[-4px_0_14px_rgba(0,0,0,0.65)]"
         viewBox="0 0 56 380"
         preserveAspectRatio="none"
-        style={{
-          opacity: isCompact ? 0 : 1,
-        }}
       >
         <defs>
           <linearGradient id="notchInnerShadow" x1="0%" y1="0%" x2="100%" y2="0%">
-            <stop offset="0%" stopColor="rgba(255,255,255,0.18)" />
+            <stop offset="0%" stopColor="rgba(255,255,255,0.2)" />
             <stop offset="35%" stopColor="rgba(255,255,255,0.0)" />
           </linearGradient>
         </defs>
@@ -525,12 +513,12 @@ export default function EdgePicker() {
         />
       </svg>
 
-      {/* Masked Reel Container */}
+      {/* Masked Reel Container clipped to the S-curve notch shape */}
       <div
         className="absolute right-0 top-0 w-full h-full overflow-hidden pointer-events-none"
         style={{
-          clipPath: isCompact ? 'none' : 'url(#dockNotchClip)',
-          WebkitClipPath: isCompact ? 'none' : 'url(#dockNotchClip)',
+          clipPath: 'url(#dockNotchClipObject)',
+          WebkitClipPath: 'url(#dockNotchClipObject)',
         }}
       >
         {/* Active Pill at Center Notch */}

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -76,6 +76,9 @@ export default function EdgePicker() {
   const [isRevealed, setIsRevealed] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [isCompact, setIsCompact] = useState(false);
+  const isDraggingRef = useRef(false);
+  isDraggingRef.current = isDragging;
 
   const scrollPosRef = useRef(initialIndex);
   scrollPosRef.current = scrollPos;
@@ -212,7 +215,10 @@ export default function EdgePicker() {
   // --------------------------------------------------------------------------
   // Geometry & Spec Formulas (46px rest, 96px revealed, locked 12px gap)
   // --------------------------------------------------------------------------
-  const effectiveRevealed = isRevealed || isHovered;
+  // isDragging shows text too: on mobile there's no hover, so the only way
+  // to see which route you're on while scrolling the reel is for the pill
+  // to be in its text state during the drag itself.
+  const effectiveRevealed = isRevealed || isHovered || isDragging;
   const pillHeight = effectiveRevealed ? 96 : 46;
 
   const getSlotY = useCallback((relOffset, currentPillH) => {
@@ -232,6 +238,15 @@ export default function EdgePicker() {
   // Gesture & Touch Interactions
   // --------------------------------------------------------------------------
   const handlePointerDown = (e, specificIndex = null) => {
+    // Tapping the compact dock expands it back to full size; the drag/tap
+    // behavior only resumes once the dock is at its normal size.
+    if (isCompact) {
+      setIsCompact(false);
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
     if (animFrameRef.current) {
       cancelAnimationFrame(animFrameRef.current);
       animFrameRef.current = null;
@@ -388,6 +403,25 @@ export default function EdgePicker() {
     return () => clearInterval(interval);
   }, [router]);
 
+  // Compact the dock when the page scrolls: the full-height dock can cover
+  // text on smaller screens, so it deflates to a small pill anchored to the
+  // edge. Tapping it bounces it back to full size. Only fires when the dock
+  // itself isn't being dragged (isDraggingRef prevents a scroll inside the
+  // dock from compacting it).
+  useEffect(() => {
+    let timer;
+    const onPageScroll = () => {
+      if (isDraggingRef.current) return;
+      clearTimeout(timer);
+      timer = setTimeout(() => setIsCompact(true), 120);
+    };
+    window.addEventListener('scroll', onPageScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onPageScroll);
+      clearTimeout(timer);
+    };
+  }, []);
+
   // Restore the picker's saved position from IndexedDB on mount
   useEffect(() => {
     openPickerDb()
@@ -436,7 +470,16 @@ export default function EdgePicker() {
       onPointerCancel={handlePointerUp}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      className="fixed right-0 top-1/2 -translate-y-1/2 z-50 h-[380px] w-[56px] select-none touch-none cursor-ns-resize flex items-center justify-end"
+      style={{
+        top: '50%',
+        right: 0,
+        position: 'fixed',
+        transform: `translateY(-50%) scale(${isCompact ? 0.3 : 1})`,
+        transformOrigin: 'center right',
+        transition: 'transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1)',
+        opacity: isCompact ? 0.7 : 1,
+      }}
+      className="z-50 h-[380px] w-[56px] select-none touch-none cursor-ns-resize flex items-center justify-end"
       aria-label="Page navigation"
       role="navigation"
     >
@@ -534,8 +577,9 @@ export default function EdgePicker() {
           </div>
         </div>
 
-        {/* Looping Reel Neighbors */}
-        {visibleItemOffsets.map((offset) => {
+        {/* Looping Reel Neighbors (hidden when compact: the dock deflates
+            to just the active pill so it stops covering page text) */}
+        {!isCompact && visibleItemOffsets.map((offset) => {
           const integerIdx = currentNearestCenter + offset;
           const catalogIdx = ((integerIdx % itemCount) + itemCount) % itemCount;
           const item = items[catalogIdx];

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -4,8 +4,6 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { Home, Settings2, BarChart3, BookOpenText, CircleHelp, Info } from 'lucide-react';
 
-const ICON_SIZE = 18;
-
 const ROUTES = [
   { id: 'home', label: 'Home', path: '/', Icon: Home },
   { id: 'manage', label: 'Manage', path: '/manage', Icon: Settings2 },
@@ -15,8 +13,10 @@ const ROUTES = [
   { id: 'about', label: 'About', path: '/about', Icon: Info },
 ];
 
+const ICON_SIZE = 18;
+
 function openPickerDb() {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     if (typeof window === 'undefined' || !window.indexedDB) {
       resolve(null);
       return;
@@ -26,16 +26,13 @@ function openPickerDb() {
       req.result.createObjectStore('state');
     };
     req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
+    req.onerror = () => resolve(null);
   });
 }
 
 function idbGet(db, key) {
   return new Promise((resolve) => {
-    if (!db) {
-      resolve(undefined);
-      return;
-    }
+    if (!db) { resolve(undefined); return; }
     const tx = db.transaction('state', 'readonly');
     const req = tx.objectStore('state').get(key);
     req.onsuccess = () => resolve(req.result);
@@ -45,10 +42,7 @@ function idbGet(db, key) {
 
 function idbPut(db, key, value) {
   return new Promise((resolve) => {
-    if (!db) {
-      resolve();
-      return;
-    }
+    if (!db) { resolve(); return; }
     const tx = db.transaction('state', 'readwrite');
     tx.objectStore('state').put(value, key);
     tx.oncomplete = () => resolve();
@@ -62,7 +56,7 @@ export default function EdgePicker() {
   const items = ROUTES;
   const itemCount = items.length;
 
-  const initialIndex = Math.max(0, ROUTES.findIndex((r) => r.path === pathname));
+  const initialIndex = Math.max(0, items.findIndex((r) => r.path === pathname));
 
   const [scrollPos, setScrollPos] = useState(initialIndex);
   const [isDragging, setIsDragging] = useState(false);
@@ -72,7 +66,7 @@ export default function EdgePicker() {
   const isDraggingRef = useRef(false);
   isDraggingRef.current = isDragging;
   const isPointerDownRef = useRef(false);
-  const expandedAtRef = useRef(0);
+  const expandedAtRef = useRef(Date.now());
 
   const scrollPosRef = useRef(initialIndex);
   scrollPosRef.current = scrollPos;
@@ -88,19 +82,6 @@ export default function EdgePicker() {
   const targetItemOnDown = useRef(null);
   const lastDetentIndex = useRef(initialIndex);
   const audioContextRef = useRef(null);
-
-  useEffect(() => {
-    const i = ROUTES.findIndex((r) => r.path === pathname);
-    if (i < 0) return;
-    const currentNorm = ((Math.round(scrollPosRef.current) % itemCount) + itemCount) % itemCount;
-    if (i === currentNorm) return;
-    const current = scrollPosRef.current;
-    let delta = i - currentNorm;
-    if (delta > itemCount / 2) delta -= itemCount;
-    if (delta < -itemCount / 2) delta += itemCount;
-    animateToTarget(current + delta);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathname]);
 
   const playHapticTick = useCallback((direction = 1) => {
     try {
@@ -118,7 +99,7 @@ export default function EdgePicker() {
       osc.frequency.setValueAtTime(direction > 0 ? 1420 : 1200, ctx.currentTime);
       osc.frequency.exponentialRampToValueAtTime(320, ctx.currentTime + 0.035);
 
-      gain.gain.setValueAtTime(0.28, ctx.currentTime);
+      gain.gain.setValueAtTime(0.25, ctx.currentTime);
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.035);
 
       osc.connect(gain);
@@ -131,7 +112,7 @@ export default function EdgePicker() {
         navigator.vibrate(8);
       }
     } catch {
-      // AudioContext awaiting user gesture or unsupported
+      // Audio awaiting user gesture
     }
   }, []);
 
@@ -150,6 +131,7 @@ export default function EdgePicker() {
         }
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [items, itemCount, router, pathname, playHapticTick]
   );
 
@@ -188,9 +170,10 @@ export default function EdgePicker() {
     [checkDetent, itemCount]
   );
 
-  // Reveal text strictly while scrolling the dock reel (dragging or wheeling)
-  const effectiveRevealed = !isCompact && (isDragging || isWheeling);
-  const pillHeight = effectiveRevealed ? 96 : 46;
+  // Text revealed ONLY while actively scrubbing or wheeling the reel.
+  // Tapping or resting ALWAYS preserves the icon.
+  const isScrollingReel = !isCompact && (isDragging || isWheeling);
+  const pillHeight = isScrollingReel ? 96 : 46;
 
   const getSlotY = useCallback((relOffset, currentPillH) => {
     if (relOffset === 0) return 0;
@@ -206,7 +189,6 @@ export default function EdgePicker() {
   }, []);
 
   const handlePointerDown = (e, specificIndex = null) => {
-    // If the dock is compact, expand it back without executing reel drag
     if (isCompact) {
       setIsCompact(false);
       expandedAtRef.current = Date.now();
@@ -244,7 +226,6 @@ export default function EdgePicker() {
     const now = performance.now();
     const timeDelta = Math.max(1, now - lastPointerTime.current);
 
-    // Only switch to dragging and text mode once the user genuinely drags > 5px
     if (!hasDraggedRef.current && Math.abs(deltaFromStart) > 5) {
       hasDraggedRef.current = true;
       setIsDragging(true);
@@ -277,7 +258,7 @@ export default function EdgePicker() {
       e.currentTarget.releasePointerCapture(e.pointerId);
     } catch {}
 
-    // Tap detected (scrolled less than 5px): keeps icon as icon, never turns to text
+    // Tap detected (moved <= 5px): select and center without text reveal
     if (!wasDragging) {
       if (targetItemOnDown.current !== null) {
         const tappedIdx = targetItemOnDown.current;
@@ -289,7 +270,6 @@ export default function EdgePicker() {
         return;
       }
 
-      // Tap on empty bezel notch curve
       if (containerRef.current) {
         const rect = containerRef.current.getBoundingClientRect();
         const tapRelY = e.clientY - (rect.top + rect.height / 2);
@@ -327,6 +307,7 @@ export default function EdgePicker() {
 
   const wheelTimeoutRef = useRef(null);
   const wheelHandlerRef = useRef(null);
+
   wheelHandlerRef.current = (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -354,19 +335,19 @@ export default function EdgePicker() {
     return () => el.removeEventListener('wheel', handler);
   }, []);
 
-  // Shrink the dock into selected item's capsule size when website content scrolls
+  // Bouncy auto-shrink when the website content scrolls
   useEffect(() => {
     let timer;
     const onPageScroll = () => {
       if (isDraggingRef.current || isPointerDownRef.current) return;
-      if (Date.now() - expandedAtRef.current < 800) return;
+      if (Date.now() - expandedAtRef.current < 750) return;
 
       clearTimeout(timer);
       timer = setTimeout(() => {
-        if (!isDraggingRef.current && !isPointerDownRef.current && Date.now() - expandedAtRef.current >= 800) {
+        if (!isDraggingRef.current && !isPointerDownRef.current && Date.now() - expandedAtRef.current >= 750) {
           setIsCompact(true);
         }
-      }, 80);
+      }, 70);
     };
 
     window.addEventListener('scroll', onPageScroll, { passive: true });
@@ -376,6 +357,21 @@ export default function EdgePicker() {
     };
   }, []);
 
+  // Pathname sync: browser back/forward and link clicks move the reel
+  useEffect(() => {
+    const i = ROUTES.findIndex((r) => r.path === pathname);
+    if (i < 0) return;
+    const currentNorm = ((Math.round(scrollPosRef.current) % itemCount) + itemCount) % itemCount;
+    if (i === currentNorm) return;
+    const current = scrollPosRef.current;
+    let delta = i - currentNorm;
+    if (delta > itemCount / 2) delta -= itemCount;
+    if (delta < -itemCount / 2) delta += itemCount;
+    animateToTarget(current + delta);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  // Prefetch all routes for instant navigation
   const prefetchedRef = useRef(false);
   useEffect(() => {
     if (prefetchedRef.current) return;
@@ -391,6 +387,7 @@ export default function EdgePicker() {
     return () => clearInterval(interval);
   }, [router]);
 
+  // IndexedDB persistence
   useEffect(() => {
     openPickerDb()
       .then((db) => idbGet(db, 'scrollPos'))
@@ -426,6 +423,9 @@ export default function EdgePicker() {
 
   const visibleItemOffsets = [-4, -3, -2, -1, 0, 1, 2, 3, 4];
 
+  // Paper theme: pill uses the site's CSS tokens
+  const pillShadow = '0 0 0 1px rgba(255,255,255,0.15) inset, 0 4px 12px rgba(0,0,0,0.35)';
+
   return (
     <div
       ref={containerRef}
@@ -447,16 +447,16 @@ export default function EdgePicker() {
         position: 'fixed',
         transform: 'translateY(-50%)',
         width: isCompact ? '44px' : '56px',
-        height: isCompact ? '54px' : '380px',
-        transition: 'width 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), height 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.3s ease',
+        height: isCompact ? '56px' : '380px',
+        transition: 'width 0.45s cubic-bezier(0.34, 1.56, 0.64, 1), height 0.45s cubic-bezier(0.34, 1.56, 0.64, 1)',
       }}
       className={`z-50 select-none touch-none cursor-pointer flex items-center justify-end ${
-        isCompact ? 'active:scale-95' : 'cursor-ns-resize'
+        isCompact ? 'active:scale-90 hover:opacity-90' : 'cursor-ns-resize'
       }`}
       aria-label="Page navigation"
       role="navigation"
     >
-      {/* SVG ClipPath strictly matching the balanced bezel notch */}
+      {/* SVG ClipPath strictly matching the balanced notch */}
       <svg
         className="absolute w-0 h-0 pointer-events-none"
         aria-hidden="true"
@@ -469,15 +469,15 @@ export default function EdgePicker() {
         </defs>
       </svg>
 
-      {/* Compact Capsule Backing (hugs selected item size so website text is readable) */}
+      {/* Compact Capsule Backing (hugs active item when site scrolls) */}
       <div
-        className="absolute inset-0 rounded-l-full bg-black shadow-[-4px_0_16px_rgba(0,0,0,0.55)] border-l border-t border-b border-white/15 transition-opacity duration-300 pointer-events-none"
+        className="absolute inset-0 rounded-l-full bg-black shadow-[-4px_0_16px_rgba(0,0,0,0.6)] border-l border-t border-b border-white/20 transition-opacity duration-300 pointer-events-none"
         style={{
           opacity: isCompact ? 1 : 0,
         }}
       />
 
-      {/* Curved SVG Dock Bezel (recessed into page in full mode) */}
+      {/* Curved SVG Dock Bezel (recessed into page in expanded mode) */}
       <svg
         className="absolute right-0 top-0 h-full w-[56px] pointer-events-none transition-opacity duration-300"
         viewBox="0 0 56 380"
@@ -488,14 +488,14 @@ export default function EdgePicker() {
       >
         <defs>
           <linearGradient id="notchInnerShadow" x1="0%" y1="0%" x2="100%" y2="0%">
-            <stop offset="0%" stopColor="rgba(255,255,255,0.08)" />
+            <stop offset="0%" stopColor="rgba(255,255,255,0.18)" />
             <stop offset="35%" stopColor="rgba(255,255,255,0.0)" />
           </linearGradient>
         </defs>
 
         <path
           d="M 56,0 C 56,45 4,50 4,95 L 4,285 C 4,330 56,335 56,380 Z"
-          fill="#000"
+          fill="#0a0a0c"
         />
         <path
           d="M 56,1 C 55,45 5,50 5,95 L 5,285 C 5,330 55,335 56,379"
@@ -526,27 +526,22 @@ export default function EdgePicker() {
             top: '50%',
             transform: 'translateY(-50%)',
             background: 'var(--paper)',
+            boxShadow: pillShadow,
           }}
-          className={`edge-picker-pill absolute right-[5px] sm:right-[9px] w-[34px] rounded-full shadow-[0_0_0_1px_rgba(255,255,255,0.15)_inset] flex items-center justify-center z-20 pointer-events-auto ${
+          className={`absolute right-[9px] w-[34px] rounded-full flex items-center justify-center z-20 pointer-events-auto transition-[height] duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${
             isCompact ? 'pointer-events-none' : 'cursor-pointer active:scale-95'
           }`}
         >
           <div
-            key={activeItem.id}
             className="flex items-center justify-center w-full h-full"
-            style={{
-              animation: effectiveRevealed
-                ? 'edgePickerPop 0.35s cubic-bezier(0.34,1.56,0.64,1)'
-                : 'edgePickerShrink 0.3s cubic-bezier(0.34,1.56,0.64,1)',
-            }}
+            style={{ color: 'var(--ink)' }}
           >
-            {effectiveRevealed ? (
+            {isScrollingReel ? (
               <span
                 className="text-[11px] font-bold tracking-widest uppercase whitespace-nowrap"
                 style={{
                   writingMode: 'vertical-rl',
                   transform: 'rotate(180deg)',
-                  color: 'var(--ink)',
                 }}
               >
                 {activeItem.label}
@@ -554,8 +549,8 @@ export default function EdgePicker() {
             ) : (
               <activeItem.Icon
                 size={ICON_SIZE}
-                strokeWidth={2.2}
-                style={{ color: 'var(--ink)' }}
+                strokeWidth={2.3}
+                style={{ color: 'currentColor' }}
               />
             )}
           </div>
@@ -602,10 +597,10 @@ export default function EdgePicker() {
                 pointerEvents: isCompact ? 'none' : 'auto',
                 transition: 'opacity 0.25s ease',
               }}
-              className="absolute right-[5px] sm:right-[9px] w-[34px] h-8 flex items-center justify-center pointer-events-auto cursor-pointer group"
-              title={item.label}
+              className="absolute right-[9px] w-[34px] h-8 flex items-center justify-center pointer-events-auto cursor-pointer group"
+              title={`Jump to ${item.label}`}
             >
-              <span className="w-6 h-6 rounded-full flex items-center justify-center group-hover:bg-white/10 group-hover:scale-125 transition-all text-neutral-400">
+              <span className="w-6 h-6 rounded-full flex items-center justify-center group-hover:bg-white/10 group-hover:scale-125 transition-all text-neutral-400 hover:text-white">
                 <item.Icon size={ICON_SIZE} strokeWidth={2} />
               </span>
             </div>

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -489,27 +489,13 @@ export default function EdgePicker() {
         </defs>
       </svg>
 
-      {/* Compact Notch SVG (same bezel shape, scaled to capsule size) */}
-      <svg
-        className="absolute right-0 top-0 pointer-events-none transition-opacity duration-300"
-        width="56"
-        height="56"
-        viewBox="0 0 56 56"
+      {/* Compact Capsule Backing (hugs active item when site scrolls) */}
+      <div
+        className="absolute inset-0 rounded-l-full bg-black shadow-[-4px_0_16px_rgba(0,0,0,0.6)] border-l border-t border-b border-white/20 transition-opacity duration-300 pointer-events-none"
         style={{
           opacity: isCompact ? 1 : 0,
         }}
-      >
-        <path
-          d="M 56,0 C 56,7 4,7 4,14 L 4,42 C 4,49 56,49 56,56 Z"
-          fill="#0a0a0c"
-        />
-        <path
-          d="M 56,1 C 55,7 5,7 5,14 L 5,42 C 5,49 55,49 56,55"
-          fill="none"
-          stroke="rgba(255,255,255,0.18)"
-          strokeWidth="1.5"
-        />
-      </svg>
+      />
 
       {/* Curved SVG Dock Bezel (recessed into page in expanded mode) */}
       <svg

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -67,6 +67,7 @@ export default function EdgePicker() {
   isDraggingRef.current = isDragging;
   const isPointerDownRef = useRef(false);
   const expandedAtRef = useRef(Date.now());
+  const pointerDownTimeRef = useRef(0);
 
   const scrollPosRef = useRef(initialIndex);
   scrollPosRef.current = scrollPos;
@@ -205,6 +206,7 @@ export default function EdgePicker() {
     isPointerDownRef.current = true;
     hasDraggedRef.current = false;
     targetItemOnDown.current = specificIndex;
+    pointerDownTimeRef.current = performance.now();
 
     pointerStartY.current = e.clientY;
     pointerStartPos.current = scrollPosRef.current;
@@ -226,10 +228,10 @@ export default function EdgePicker() {
     const now = performance.now();
     const timeDelta = Math.max(1, now - lastPointerTime.current);
 
-    // Only switch to drag state and text reveal if the pointer moved
-    // significantly. 12px filters out mobile tap jitter (a finger press
-    // easily jitters 5-8px) so tapping an icon never flashes text.
-    if (!hasDraggedRef.current && Math.abs(deltaFromStart) > 12) {
+    // Only enter drag mode if BOTH: moved > 12px AND held for > 150ms.
+    // A mobile tap jitters 5-15px in under 100ms — the time check is what
+    // actually separates a tap from a deliberate drag on touch.
+    if (!hasDraggedRef.current && Math.abs(deltaFromStart) > 12 && now - pointerDownTimeRef.current > 150) {
       hasDraggedRef.current = true;
       setIsDragging(true);
       isDraggingRef.current = true;
@@ -339,12 +341,13 @@ export default function EdgePicker() {
   }, []);
 
   // Bouncy auto-shrink when the website content scrolls.
-  // Uses document + capture so it catches scroll from the window, the
-  // body, or any nested scrollable container regardless of which element
-  // actually owns the scrollbar.
+  // Desktop: document scroll with capture catches any scrollable element.
+  // Mobile: scroll events often don't fire because the dock's touch-action
+  // can swallow the gesture, so touchmove outside the dock is the trigger.
   useEffect(() => {
     let timer;
-    const onPageScroll = () => {
+
+    const compact = () => {
       if (isDraggingRef.current || isPointerDownRef.current) return;
       if (Date.now() - expandedAtRef.current < 750) return;
 
@@ -356,9 +359,20 @@ export default function EdgePicker() {
       }, 70);
     };
 
-    document.addEventListener('scroll', onPageScroll, { passive: true, capture: true });
+    const onDocScroll = () => compact();
+
+    const onTouchMoveOutsideDock = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        compact();
+      }
+    };
+
+    document.addEventListener('scroll', onDocScroll, { passive: true, capture: true });
+    document.addEventListener('touchmove', onTouchMoveOutsideDock, { passive: true });
+
     return () => {
-      document.removeEventListener('scroll', onPageScroll, { capture: true });
+      document.removeEventListener('scroll', onDocScroll, { capture: true });
+      document.removeEventListener('touchmove', onTouchMoveOutsideDock);
       clearTimeout(timer);
     };
   }, []);

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -171,10 +171,11 @@ export default function EdgePicker() {
     [checkDetent, itemCount]
   );
 
-  // Text revealed while dragging, wheeling, or hovering (desktop only —
-  // mobile has no hover so the pill stays compact unless actively scrubbed)
+  // Text revealed while dragging, wheeling, or hovering with a mouse.
+  // Touch pointers never activate hover (checked via pointerType), so
+  // mobile stays icon-only unless actively scrubbing the reel.
   const [isHovered, setIsHovered] = useState(false);
-  const isScrollingReel = !isCompact && (isDragging || isWheeling || (typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches && isHovered));
+  const isScrollingReel = !isCompact && (isDragging || isWheeling || isHovered);
   const pillHeight = isScrollingReel ? 96 : 46;
 
   // Compact state maintains the exact S-curve notch shape, shrunk to 116px
@@ -453,8 +454,10 @@ export default function EdgePicker() {
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onPointerEnter={(e) => {
+        if (e.pointerType === 'mouse') setIsHovered(true);
+      }}
+      onPointerLeave={() => setIsHovered(false)}
       onClick={(e) => {
         if (isCompact) {
           setIsCompact(false);

--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -2,52 +2,114 @@
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { Home, Settings2, BarChart3, BookOpenText, CircleHelp, Info } from 'lucide-react';
+import Link from 'next/link';
+
+// Inline Lucide icons (SVG paths copied verbatim from lucide.dev): the dock
+// is the app's only icon consumer, and six inline SVGs avoid taking on the
+// repo's first UI dependency and its update cadence.
+function icon(children) {
+  return function Icon({ size = 18, strokeWidth = 2 }) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {children}
+      </svg>
+    );
+  };
+}
+
+const HomeIcon = icon(
+  <>
+    <path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" />
+    <path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+  </>
+);
+
+const Settings2Icon = icon(
+  <>
+    <path d="M14 17H5" />
+    <path d="M19 7h-9" />
+    <circle cx="17" cy="17" r="3" />
+    <circle cx="7" cy="7" r="3" />
+  </>
+);
+
+const BarChart3Icon = icon(
+  <>
+    <path d="M3 3v16a2 2 0 0 0 2 2h16" />
+    <path d="M18 17V9" />
+    <path d="M13 17V5" />
+    <path d="M8 17v-3" />
+  </>
+);
+
+const BookOpenTextIcon = icon(
+  <>
+    <path d="M12 5v16" />
+    <path d="M16 13h2" />
+    <path d="M16 9h2" />
+    <path d="M20.001 19A2 2 0 0022 17V5a2 2 0 00-1.999-2L16 3.002A5 5 0 0012 5a5 5 0 00-4-2H4a2 2 0 00-2 2v12a2 2 0 001.999 2H8a5 5 0 014 2 5 5 0 014-2z" />
+    <path d="M6 13h2" />
+    <path d="M6 9h2" />
+  </>
+);
+
+const CircleHelpIcon = icon(
+  <>
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+    <path d="M12 17h.01" />
+  </>
+);
+
+const InfoIcon = icon(
+  <>
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 16v-4" />
+    <path d="M12 8h.01" />
+  </>
+);
 
 const ROUTES = [
-  { id: 'home', label: 'Home', path: '/', Icon: Home },
-  { id: 'manage', label: 'Manage', path: '/manage', Icon: Settings2 },
-  { id: 'stats', label: 'Stats', path: '/stats', Icon: BarChart3 },
-  { id: 'docs', label: 'Docs', path: '/docs', Icon: BookOpenText },
-  { id: 'faq', label: 'FAQ', path: '/faq', Icon: CircleHelp },
-  { id: 'about', label: 'About', path: '/about', Icon: Info },
+  { id: 'home', label: 'Home', path: '/', Icon: HomeIcon },
+  { id: 'manage', label: 'Manage', path: '/manage', Icon: Settings2Icon },
+  { id: 'stats', label: 'Stats', path: '/stats', Icon: BarChart3Icon },
+  { id: 'docs', label: 'Docs', path: '/docs', Icon: BookOpenTextIcon },
+  { id: 'faq', label: 'FAQ', path: '/faq', Icon: CircleHelpIcon },
+  { id: 'about', label: 'About', path: '/about', Icon: InfoIcon },
 ];
 
 const ICON_SIZE = 18;
 
-function openPickerDb() {
-  return new Promise((resolve) => {
-    if (typeof window === 'undefined' || !window.indexedDB) {
-      resolve(null);
-      return;
-    }
-    const req = indexedDB.open('edge-picker', 1);
-    req.onupgradeneeded = () => {
-      req.result.createObjectStore('state');
-    };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => resolve(null);
-  });
+// One scalar (the resting position); localStorage is one line and has the
+// same failure modes as any async store would.
+const POS_KEY = 'edge-picker:scrollPos';
+
+function loadSavedPos() {
+  try {
+    const saved = window.localStorage.getItem(POS_KEY);
+    const n = Number(saved);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
 }
 
-function idbGet(db, key) {
-  return new Promise((resolve) => {
-    if (!db) { resolve(undefined); return; }
-    const tx = db.transaction('state', 'readonly');
-    const req = tx.objectStore('state').get(key);
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => resolve(undefined);
-  });
-}
-
-function idbPut(db, key, value) {
-  return new Promise((resolve) => {
-    if (!db) { resolve(); return; }
-    const tx = db.transaction('state', 'readwrite');
-    tx.objectStore('state').put(value, key);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => resolve();
-  });
+function savePos(value) {
+  try {
+    window.localStorage.setItem(POS_KEY, String(value));
+  } catch {
+    // Private mode / storage full: the position just doesn't persist.
+  }
 }
 
 export default function EdgePicker() {
@@ -80,46 +142,13 @@ export default function EdgePicker() {
   const lastPointerTime = useRef(0);
   const velocityY = useRef(0);
   const hasDraggedRef = useRef(false);
-  const targetItemOnDown = useRef(null);
   const lastDetentIndex = useRef(initialIndex);
-  const audioContextRef = useRef(null);
-
-  const playHapticTick = useCallback((direction = 1) => {
-    try {
-      if (!audioContextRef.current) {
-        const AudioCtx = window.AudioContext || window.webkitAudioContext;
-        audioContextRef.current = new AudioCtx();
-      }
-      const ctx = audioContextRef.current;
-      if (ctx.state === 'suspended') ctx.resume();
-
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-
-      osc.type = 'sine';
-      osc.frequency.setValueAtTime(direction > 0 ? 1420 : 1200, ctx.currentTime);
-      osc.frequency.exponentialRampToValueAtTime(320, ctx.currentTime + 0.035);
-
-      gain.gain.setValueAtTime(0.25, ctx.currentTime);
-      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.035);
-
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-
-      osc.start();
-      osc.stop(ctx.currentTime + 0.035);
-    } catch {
-      // Audio awaiting user gesture
-    }
-  }, []);
 
   const checkDetent = useCallback(
     (pos) => {
       const currentDetent = Math.round(pos);
       if (currentDetent !== lastDetentIndex.current) {
-        const dir = currentDetent > lastDetentIndex.current ? 1 : -1;
         lastDetentIndex.current = currentDetent;
-        playHapticTick(dir);
 
         const normalized = ((currentDetent % itemCount) + itemCount) % itemCount;
         const route = items[normalized];
@@ -129,7 +158,7 @@ export default function EdgePicker() {
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [items, itemCount, router, pathname, playHapticTick]
+    [items, itemCount, router, pathname]
   );
 
   const animateToTarget = useCallback(
@@ -186,24 +215,26 @@ export default function EdgePicker() {
 
   const dockLength = isCompact ? 116 : 380;
 
+  // Slot geometry: the active pill at the center, first neighbor at D1,
+  // then a fixed step. Spacing is deliberately wide so the expanded dock
+  // shows exactly five icons: the pill plus two neighbors on each side.
+  const NEIGHBOR_STEP = 46;
   const getSlotY = useCallback((relOffset, currentPillH) => {
     if (relOffset === 0) return 0;
     const sign = relOffset > 0 ? 1 : -1;
     const abs = Math.abs(relOffset);
-    const D1 = currentPillH / 2 + 12 + 10;
-    const step = 32;
+    const D1 = currentPillH / 2 + 33;
 
     if (abs <= 1) {
       return sign * abs * D1;
     }
-    return sign * (D1 + (abs - 1) * step);
+    return sign * (D1 + (abs - 1) * NEIGHBOR_STEP);
   }, []);
 
-  const handlePointerDown = (e, specificIndex = null) => {
+  const handlePointerDown = (e) => {
     if (isCompact) {
       setIsCompact(false);
       expandedAtRef.current = Date.now();
-      playHapticTick(1);
       e.preventDefault();
       e.stopPropagation();
       return;
@@ -216,7 +247,6 @@ export default function EdgePicker() {
 
     isPointerDownRef.current = true;
     hasDraggedRef.current = false;
-    targetItemOnDown.current = specificIndex;
     pointerDownTimeRef.current = performance.now();
 
     pointerStartY.current = e.clientY;
@@ -225,9 +255,10 @@ export default function EdgePicker() {
     lastPointerTime.current = performance.now();
     velocityY.current = 0;
 
-    try {
-      e.currentTarget.setPointerCapture(e.pointerId);
-    } catch {}
+    // Pointer capture is deliberately NOT taken here: a plain tap must let
+    // the click fall through to the route anchors below. Capture is taken
+    // on the container only once a real drag starts, which retargets the
+    // subsequent events (and the compatibility click) away from them.
   };
 
   const handlePointerMove = (e) => {
@@ -244,18 +275,20 @@ export default function EdgePicker() {
       hasDraggedRef.current = true;
       setIsDragging(true);
       isDraggingRef.current = true;
+      try {
+        containerRef.current?.setPointerCapture(e.pointerId);
+      } catch {}
     }
 
     if (!hasDraggedRef.current) return;
 
-    const pxPerItem = 32;
-    const instantVelocity = stepDelta / pxPerItem / timeDelta;
+    const instantVelocity = stepDelta / NEIGHBOR_STEP / timeDelta;
     velocityY.current = velocityY.current * 0.4 + instantVelocity * 0.6;
 
     lastPointerY.current = currentY;
     lastPointerTime.current = now;
 
-    const newPos = pointerStartPos.current - deltaFromStart / pxPerItem;
+    const newPos = pointerStartPos.current - deltaFromStart / NEIGHBOR_STEP;
     setScrollPos(newPos);
     checkDetent(newPos);
   };
@@ -272,18 +305,10 @@ export default function EdgePicker() {
       e.currentTarget.releasePointerCapture(e.pointerId);
     } catch {}
 
-    // Tap: select and center without text
+    // Taps: if the pointerdown started on a route anchor, its own click
+    // handles navigation; nothing to do here. Taps on the dock bezel itself
+    // still snap the nearest slot to the center.
     if (!wasDragging) {
-      if (targetItemOnDown.current !== null) {
-        const tappedIdx = targetItemOnDown.current;
-        const currentCenter = Math.round(scrollPosRef.current);
-
-        if (tappedIdx !== currentCenter) {
-          animateToTarget(tappedIdx);
-        }
-        return;
-      }
-
       if (containerRef.current) {
         const rect = containerRef.current.getBoundingClientRect();
         const tapRelY = e.clientY - (rect.top + rect.height / 2);
@@ -293,7 +318,7 @@ export default function EdgePicker() {
           let bestSlot = currentCenter;
           let minDiff = Infinity;
 
-          for (let s = -3; s <= 3; s++) {
+          for (let s = -2; s <= 2; s++) {
             const slotY = getSlotY(s, pillHeight);
             const diff = Math.abs(tapRelY - slotY);
             if (diff < minDiff) {
@@ -317,6 +342,20 @@ export default function EdgePicker() {
     if (targetSnap < currentNorm - maxTravel) targetSnap = currentNorm - maxTravel;
 
     animateToTarget(targetSnap, -velocityY.current * 1.4);
+  };
+
+  // Keyboard: the dock is operable with arrow keys while focus is inside
+  // it (the pill anchor is the single tab stop). Each detent crossing
+  // navigates, same as a drag detent does.
+  const handleKeyDown = (e) => {
+    if (isCompact) return;
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      animateToTarget(Math.round(scrollPosRef.current) - 1);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      animateToTarget(Math.round(scrollPosRef.current) + 1);
+    }
   };
 
   const wheelTimeoutRef = useRef(null);
@@ -414,25 +453,19 @@ export default function EdgePicker() {
     return () => clearInterval(interval);
   }, [router]);
 
-  // IndexedDB persistence
+  // Resting position persistence
   useEffect(() => {
-    openPickerDb()
-      .then((db) => idbGet(db, 'scrollPos'))
-      .then((saved) => {
-        if (typeof saved === 'number' && saved >= 0 && saved < itemCount) {
-          setScrollPos(saved);
-          scrollPosRef.current = saved;
-          lastDetentIndex.current = Math.round(saved);
-        }
-      })
-      .catch(() => {});
+    const saved = loadSavedPos();
+    if (saved !== null && saved >= 0 && saved < itemCount) {
+      setScrollPos(saved);
+      scrollPosRef.current = saved;
+      lastDetentIndex.current = Math.round(saved);
+    }
   }, [itemCount]);
 
   useEffect(() => {
     if (Number.isInteger(scrollPos)) {
-      openPickerDb()
-        .then((db) => idbPut(db, 'scrollPos', ((scrollPos % itemCount) + itemCount) % itemCount))
-        .catch(() => {});
+      savePos(((scrollPos % itemCount) + itemCount) % itemCount);
     }
   }, [scrollPos, itemCount]);
 
@@ -448,7 +481,9 @@ export default function EdgePicker() {
   const activeNormalizedIndex = ((currentNearestCenter % itemCount) + itemCount) % itemCount;
   const activeItem = items[activeNormalizedIndex];
 
-  const visibleItemOffsets = [-4, -3, -2, -1, 0, 1, 2, 3, 4];
+  // The reel renders the active pill plus two neighbors each side: five
+  // icons in the expanded window, nothing half-visible beyond them.
+  const visibleItemOffsets = [-2, -1, 1, 2];
 
   // Paper theme
   const pillShadow = '0 0 0 1px rgba(255,255,255,0.15) inset, 0 4px 12px rgba(0,0,0,0.35)';
@@ -456,10 +491,11 @@ export default function EdgePicker() {
   return (
     <div
       ref={containerRef}
-      onPointerDown={(e) => handlePointerDown(e, null)}
+      onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
+      onKeyDown={handleKeyDown}
       onPointerEnter={(e) => {
         if (e.pointerType === 'mouse') setIsHovered(true);
       }}
@@ -468,7 +504,6 @@ export default function EdgePicker() {
         if (isCompact) {
           setIsCompact(false);
           expandedAtRef.current = Date.now();
-          playHapticTick(1);
           e.preventDefault();
           e.stopPropagation();
         }
@@ -534,13 +569,15 @@ export default function EdgePicker() {
           WebkitClipPath: 'url(#dockNotchClipObject)',
         }}
       >
-        {/* Active Pill at Center Notch */}
-        <div
-          onPointerDown={(e) => {
-            if (!isCompact) {
-              e.stopPropagation();
-              handlePointerDown(e, currentNearestCenter);
-            }
+        {/* Active Pill at Center Notch: a real anchor for the active route,
+            carrying aria-current. It is the dock's single tab stop; arrow
+            keys (handled above) move through the rest. */}
+        <Link
+          href={activeItem.path}
+          aria-current="page"
+          aria-label={activeItem.label}
+          onClick={(e) => {
+            if (hasDraggedRef.current || isCompact) e.preventDefault();
           }}
           style={{
             height: `${pillHeight}px`,
@@ -575,9 +612,12 @@ export default function EdgePicker() {
               />
             )}
           </div>
-        </div>
+        </Link>
 
-        {/* Looping Reel Neighbors */}
+        {/* Looping Reel Neighbors: real anchors so every destination is a
+            link (keyboard, middle-click, copy-link, crawlers). tabIndex -1
+            keeps tab order to the single pill stop; the arrows operate the
+            reel. Plain clicks navigate; clicks after a drag are suppressed. */}
         {visibleItemOffsets.map((offset) => {
           const integerIdx = currentNearestCenter + offset;
           const catalogIdx = ((integerIdx % itemCount) + itemCount) % itemCount;
@@ -602,13 +642,14 @@ export default function EdgePicker() {
           const scale = Math.max(0.72, 1 - dist / (maxDist * 2.4));
 
           return (
-            <div
+            <Link
               key={integerIdx}
-              onPointerDown={(e) => {
-                if (!isCompact) {
-                  e.stopPropagation();
-                  handlePointerDown(e, integerIdx);
-                }
+              href={item.path}
+              tabIndex={-1}
+              aria-label={item.label}
+              title={`Jump to ${item.label}`}
+              onClick={(e) => {
+                if (hasDraggedRef.current) e.preventDefault();
               }}
               style={{
                 transform: `translateY(${yPos}px) scale(${scale})`,
@@ -619,12 +660,11 @@ export default function EdgePicker() {
                 transition: 'opacity 0.25s ease',
               }}
               className="absolute right-[9px] w-[34px] h-8 flex items-center justify-center pointer-events-auto cursor-pointer group"
-              title={`Jump to ${item.label}`}
             >
               <span className="w-6 h-6 rounded-full flex items-center justify-center group-hover:bg-white/10 group-hover:scale-125 transition-all text-neutral-400 hover:text-white">
                 <item.Icon size={ICON_SIZE} strokeWidth={2} />
               </span>
-            </div>
+            </Link>
           );
         })}
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,6 +104,26 @@ body {
   color: var(--paper);
 }
 
+/* Edge picker dock: bouncy spring animations for the selector pill.
+   The overshoot (scale > 1) is what makes it feel like a physical
+   spring, matching the iOS Dynamic Island's expansion feel. */
+@keyframes edgePickerPop {
+  0% { transform: scale(0.8); opacity: 0; }
+  60% { transform: scale(1.08); opacity: 1; }
+  80% { transform: scale(0.97); }
+  100% { transform: scale(1); }
+}
+
+@keyframes edgePickerShrink {
+  0% { transform: scale(1.1); opacity: 0; }
+  60% { transform: scale(0.94); opacity: 1; }
+  100% { transform: scale(1); }
+}
+
+.edge-picker-pill {
+  transition: height 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
 a {
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,6 +1,7 @@
 import { Bricolage_Grotesque, Public_Sans, IBM_Plex_Mono } from 'next/font/google';
 import './globals.css';
 import Footer from './components/Footer.jsx';
+import EdgePicker from './edge-picker.jsx';
 
 const display = Bricolage_Grotesque({
   subsets: ['latin'],
@@ -55,6 +56,7 @@ export default function RootLayout({ children }) {
       <body>
         {children}
         <Footer />
+        <EdgePicker />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,9 @@
   "packages": {
     "": {
       "name": "runs-on-dev",
+      "license": "AGPL-3.0-only",
       "dependencies": {
+        "lucide-react": "^1.41.0",
         "next": "^16.3.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -1428,6 +1430,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.41.0.tgz",
+      "integrity": "sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "name": "runs-on-dev",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "lucide-react": "^1.41.0",
         "next": "^16.3.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -1430,15 +1429,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.41.0.tgz",
-      "integrity": "sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",
-  "engines": { "node": ">=22" },
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -11,6 +13,7 @@
     "test": "node --test \"test/**/*.test.mjs\""
   },
   "dependencies": {
+    "lucide-react": "^1.41.0",
     "next": "^16.3.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "node --test \"test/**/*.test.mjs\""
   },
   "dependencies": {
-    "lucide-react": "^1.41.0",
     "next": "^16.3.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"


### PR DESCRIPTION
## What it is

A navigation dock cut into the right edge of the viewport, modelled on the iPhone Camera Control / Dynamic Island design pattern. A near-black curved bezel notch with a spring-physics reel of route icons inside. The active route sits in a paper-colored pill that bounces open on hover to reveal the route name in vertical text.

**Live preview:** [runs-on-ro932vtoj-sds-projects-ec681300.vercel.app](https://runs-on-ro932vtoj-sds-projects-ec681300.vercel.app)

## Interactions

- **Scroll** on the dock to cycle through routes (non-passive wheel listener, page doesn't scroll underneath)
- **Drag** up/down with fling momentum and spring physics settling
- **Tap** a neighbor icon to navigate to that page
- **Tap** the active pill to toggle the text/icon reveal
- **Browser back/forward and link clicks** move the picker to the correct route via pathname sync
- **Mechanical tick sound** on every detent crossing (Web Audio API, with mobile vibration fallback)

## Design details

- Curved SVG bezel notch, exactly matching the Dynamic Island aesthetic rotated 90° counter-clockwise
- Near-black dock (#000) with a subtle inner shadow gradient along the left edge
- Active pill uses the site's `--paper` token, so it reads as the page surface sitting inside the recess
- Lucide icons: Home, Settings2, BarChart3, BookOpenText, CircleHelp, Info
- Bouncy expand/contract with overshoot easing (`cubic-bezier(0.34, 1.56, 0.64, 1)`)
- Hides on wildcard card pages (`<name>.runs-on.dev`) since those aren't part of the site's navigation

## Performance

- All routes prefetched on mount via `router.prefetch()`, re-warmed every 25s (before Next.js's 30s cache expiry)
- Navigation via the picker renders from the prefetch cache: no loading flash, no network round-trip
- Picker position persisted in IndexedDB, restored on page reload
- Infinite loop wraps both ways; scroll position wrapped to `[0, itemCount)` after spring settle to prevent unbounded growth

## Files changed

- `app/edge-picker.jsx` (new): the component, ~550 lines
- `app/layout.jsx`: imports and renders `<EdgePicker />`
- `app/globals.css`: two `@keyframes` for the pop/shrink bounce animations + pill transition class
- `package.json`: adds `lucide-react`

## Testing

Deployed to Vercel and verified on desktop (Chrome) and mobile. Scroll, drag, fling, tap, text reveal, route navigation, pathname sync, and prefetch all working.