### PR TITLE
Point samanyu.runs-on.dev to Vercel via CNAME

### DIFF
--- a/domains/samanyu.json
+++ b/domains/samanyu.json
@@ -4,5 +4,7 @@
     "github": "Samanyu-dev"
   },
   "claimedAt": "2026-09-01T12:43:25.957Z",
-  "records": {}
+  "records": {
+    "CNAME": "cname.vercel-dns.com"
+  }
 }


### PR DESCRIPTION
## Summary
- Edits the existing `domains/samanyu.json` record (branched from up-to-date `main`) to add the Vercel CNAME, leaving `claimedAt` untouched as instructed on #3.

```json
"records": { "CNAME": "cname.vercel-dns.com" }
```

Follow-up to #3, which was closed since the name was already claimed and that branch would have recreated the record with a stale `claimedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiGPk2pV19Hwh6omC4xapJ