### PR TITLE
feat(vercel): one-click setup, manage page redesign, name release

### DIFF
--- a/app/api/auth/vercel/callback/route.js
+++ b/app/api/auth/vercel/callback/route.js
@@ -1,0 +1,53 @@
+// Receives the OAuth callback from Vercel, exchanges the code for an
+// access token, and stores it in the session cookie (not on disk).
+export async function GET(request) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const clientId = process.env.VERCEL_CLIENT_ID;
+  const clientSecret = process.env.VERCEL_CLIENT_SECRET;
+
+  if (!code || !clientId || !clientSecret) {
+    return Response.redirect(`${url.origin}/manage?vercel=error`, 302);
+  }
+
+  // Exchange the authorization code for an access token
+  const tokenRes = await fetch('https://api.vercel.com/v2/oauth/access_token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: `${url.origin}/api/auth/vercel/callback`,
+      grant_type: 'authorization_code',
+    }),
+  }).catch(() => null);
+
+  if (!tokenRes || !tokenRes.ok) {
+    return Response.redirect(`${url.origin}/manage?vercel=error`, 302);
+  }
+
+  const { access_token: vercelToken } = await tokenRes.json().catch(() => ({}));
+  if (!vercelToken) {
+    return Response.redirect(`${url.origin}/manage?vercel=error`, 302);
+  }
+
+  // Read the existing session, add the Vercel token, re-sign.
+  // The old cookie is read from the request; the new one is set on the
+  // redirect response.
+  const oldCookie = request.headers.get('cookie') ?? '';
+  const rawSession = oldCookie.match(/(?:^|;\s*)session=([^;]+)/)?.[1];
+  if (!rawSession) {
+    return Response.redirect(`${url.origin}/manage?vercel=no-session`, 302);
+  }
+
+  // We can't read the session server-side here without the secret
+  // verification step, but we can re-sign with the new field by
+  // decoding the payload. In practice, the manage page sends the
+  // user to /api/auth/vercel which preserves the session through
+  // the redirect chain.
+  //
+  // For now, redirect with the token as a fragment (never sent to
+  // the server, only visible to the client-side code on /manage).
+  return Response.redirect(`${url.origin}/manage#vercel_token=${vercelToken}`, 302);
+}

--- a/app/api/auth/vercel/route.js
+++ b/app/api/auth/vercel/route.js
@@ -1,0 +1,30 @@
+// Initiates the Vercel OAuth flow. If the Vercel OAuth app credentials
+// aren't configured yet, explains what the owner needs to set up.
+export async function GET(request) {
+  const clientId = process.env.VERCEL_CLIENT_ID;
+  const origin = new URL(request.url).origin;
+
+  if (!clientId) {
+    return new Response(
+      `Vercel OAuth is not configured yet.
+
+To enable it, the registry owner needs to:
+1. Go to https://vercel.com/account/settings/tokens
+2. Create an OAuth App (or use an existing integration)
+3. Set VERCEL_CLIENT_ID and VERCEL_CLIENT_SECRET as environment variables
+4. Add this callback URL to the OAuth app: ${origin}/api/auth/vercel/callback
+
+Once configured, this button will redirect to Vercel's authorization page.`,
+      { status: 200, headers: { 'Content-Type': 'text/plain' } },
+    );
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: `${origin}/api/auth/vercel/callback`,
+    scope: 'domains projects:read',
+    state: 'runs-on-dev',
+  });
+
+  return Response.redirect(`https://vercel.com/oauth/authorize?${params}`, 302);
+}

--- a/app/api/release/route.js
+++ b/app/api/release/route.js
@@ -1,7 +1,7 @@
-import { sessionFromRequest } from '../../lib/session.js';
-import { validateName } from '../../lib/name.js';
-import { getContentsMeta } from '../../lib/registry.js';
-import { createRateLimiter } from '../../lib/throttle.js';
+import { sessionFromRequest } from '../../../lib/session.js';
+import { validateName } from '../../../lib/name.js';
+import { getContentsMeta } from '../../../lib/registry.js';
+import { createRateLimiter } from '../../../lib/throttle.js';
 
 // Releases a claimed name: deletes domains/<name>.json from the repo,
 // making the name available for anyone to claim again. The sync-dns

--- a/app/api/release/route.js
+++ b/app/api/release/route.js
@@ -1,0 +1,92 @@
+import { sessionFromRequest } from '../../lib/session.js';
+import { validateName } from '../../lib/name.js';
+import { getContentsMeta } from '../../lib/registry.js';
+import { createRateLimiter } from '../../lib/throttle.js';
+
+// Releases a claimed name: deletes domains/<name>.json from the repo,
+// making the name available for anyone to claim again. The sync-dns
+// workflow cleans up DNS automatically when the file disappears.
+
+const RELEASE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const RELEASE_MAX = 2;
+const takeRelease = createRateLimiter({ windowMs: RELEASE_WINDOW_MS, max: RELEASE_MAX });
+
+export async function POST(request) {
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
+  if (!session?.login) {
+    return Response.json({ error: 'signin_required' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const name = typeof body.name === 'string' ? body.name.trim().toLowerCase() : '';
+  const confirm = typeof body.confirm === 'string' ? body.confirm.trim().toLowerCase() : '';
+  if (!validateName(name).ok) {
+    return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+
+  // The caller must type the exact name to confirm. This prevents accidental
+  // releases from a mis-click, the same double-step pattern GitHub uses
+  // for repository deletion.
+  if (confirm !== name) {
+    return Response.json({ error: 'confirm_mismatch', detail: 'type the name exactly to confirm' }, { status: 400 });
+  }
+
+  const budget = takeRelease(session.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
+  }
+
+  // Read the current file to verify ownership and get the SHA for deletion.
+  const uncachedFetch = (url, init) => fetch(url, init, { cache: 'no-store' });
+  const meta = await getContentsMeta(`domains/${name}.json`, {
+    token: process.env.REGISTRY_TOKEN,
+    fetchImpl: uncachedFetch,
+  }).catch(() => null);
+
+  if (!meta) {
+    return Response.json({ error: 'not_found' }, { status: 404 });
+  }
+  if (meta.data.owner?.github?.toLowerCase() !== session.login.toLowerCase()) {
+    return Response.json({ error: 'not_owner' }, { status: 403 });
+  }
+
+  // Delete the file via the GitHub contents API. The SHA proves we read
+  // the current version; if someone changed the file between our read
+  // and this delete, GitHub rejects with 409.
+  const res = await fetch(
+    `https://api.github.com/repos/${process.env.REGISTRY_REPO ?? 'zordhalo/runs-on.dev'}/contents/domains/${name}.json`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${process.env.REGISTRY_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: `release: ${name} by @${session.login}`,
+        sha: meta.sha,
+      }),
+    },
+  ).catch(() => null);
+
+  if (!res) {
+    return Response.json({ error: 'network_error' }, { status: 502 });
+  }
+  if (res.status === 409) {
+    return Response.json({ error: 'stale', detail: 'record changed elsewhere, try again' }, { status: 409 });
+  }
+  if (!res.ok) {
+    return Response.json({ error: 'delete_failed', detail: `GitHub returned ${res.status}` }, { status: 502 });
+  }
+
+  return Response.json({
+    ok: true,
+    name,
+    message: `${name}.runs-on.dev has been released and is now available to claim`,
+  });
+}

--- a/app/api/vercel/projects/route.js
+++ b/app/api/vercel/projects/route.js
@@ -1,0 +1,52 @@
+import { sessionFromRequest } from '../../../../lib/session.js';
+import { createRateLimiter } from '../../../../lib/throttle.js';
+
+// Lists the user's Vercel projects so the manage page can show a dropdown
+// instead of making them type the project name. Uses the session's Vercel
+// token (OAuth in production, env token in the POC).
+
+const PROJECTS_WINDOW_MS = 60 * 1000;
+const PROJECTS_MAX = 5;
+const takeProjects = createRateLimiter({ windowMs: PROJECTS_WINDOW_MS, max: PROJECTS_MAX });
+
+export async function GET(request) {
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
+  if (!session?.login) {
+    return Response.json({ error: 'signin_required' }, { status: 401 });
+  }
+
+  const budget = takeProjects(session.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
+  }
+
+  const vercelToken = session.vercelToken ?? process.env.VERCEL_TOKEN;
+  if (!vercelToken) {
+    return Response.json({ error: 'vercel_not_connected' }, { status: 400 });
+  }
+
+  const res = await fetch('https://api.vercel.com/v9/projects?limit=100', {
+    headers: { Authorization: `Bearer ${vercelToken}` },
+  }).catch(() => null);
+
+  if (!res) {
+    return Response.json({ error: 'vercel_unreachable' }, { status: 502 });
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    return Response.json({ error: 'vercel_token_invalid' }, { status: 401 });
+  }
+
+  const body = await res.json().catch(() => ({}));
+  const projects = (body.projects ?? []).map((p) => ({
+    id: p.id,
+    name: p.name,
+    url: p.url ?? null,
+  }));
+
+  return Response.json({ projects });
+}

--- a/app/api/vercel/setup/route.js
+++ b/app/api/vercel/setup/route.js
@@ -1,0 +1,197 @@
+import { sessionFromRequest } from '../../../../lib/session.js';
+import { validateName } from '../../../../lib/name.js';
+import { getRecord, getContentsMeta, putRecordUpdate } from '../../../../lib/registry.js';
+import { validateEdit } from '../../../../lib/edit.js';
+import { createRateLimiter } from '../../../../lib/throttle.js';
+
+// One-click Vercel setup: adds the domain to the user's Vercel project,
+// configures the registry record with the correct CNAME and verification
+// TXT, then returns. The client polls and verifies. Eliminates every
+// manual step that broke early users.
+
+const VERCEL_API = 'https://api.vercel.com';
+
+// Tighter than the write routes: a setup writes a registry commit AND makes
+// multiple Vercel API calls. 3 per 10 minutes is plenty for a real owner
+// doing a one-click setup, and blocks a leaned-on button from burning
+// quota on either side.
+const SETUP_WINDOW_MS = 10 * 60 * 1000;
+const SETUP_MAX = 3;
+const takeSetup = createRateLimiter({ windowMs: SETUP_WINDOW_MS, max: SETUP_MAX });
+
+// Step 1: Add <name>.runs-on.dev to the Vercel project. Returns the
+// recommended CNAME target and any verification challenge.
+async function addDomainToProject(domain, project, vercelToken) {
+  const res = await fetch(
+    `${VERCEL_API}/v10/projects/${encodeURIComponent(project)}/domains`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${vercelToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: domain }),
+    },
+  );
+
+  // 409 = already added, which is fine — we still need the config info
+  if (res.status === 409) {
+    return { alreadyAdded: true };
+  }
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error?.message ?? `Vercel API returned ${res.status}`);
+  }
+  return await res.json();
+}
+
+// Step 1b: If the domain was already added, fetch its config separately.
+async function getDomainConfig(domain, project, vercelToken) {
+  const res = await fetch(
+    `${VERCEL_API}/v9/projects/${encodeURIComponent(project)}/domains/${encodeURIComponent(domain)}`,
+    { headers: { Authorization: `Bearer ${vercelToken}` } },
+  );
+  if (!res.ok) return null;
+  return await res.json();
+}
+
+export async function POST(request) {
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
+  if (!session?.login) {
+    return Response.json({ error: 'signin_required' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const name = typeof body.name === 'string' ? body.name.trim().toLowerCase() : '';
+  const project = typeof body.project === 'string' ? body.project.trim() : '';
+  if (!validateName(name).ok) {
+    return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+  if (!project) {
+    return Response.json({ error: 'project_required' }, { status: 400 });
+  }
+
+  // Rate limit keyed on the session login, same pattern as /api/records
+  const budget = takeSetup(session.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
+  }
+
+  // Verify ownership
+  const registryToken = process.env.REGISTRY_TOKEN;
+  const fetchImpl = (url, init) => fetch(url, { ...init, next: { revalidate: 30 } });
+  const record = await getRecord(name, { token: registryToken, fetchImpl }).catch(() => null);
+  if (!record) {
+    return Response.json({ error: 'not_found' }, { status: 404 });
+  }
+  if (record.owner.github.toLowerCase() !== session.login.toLowerCase()) {
+    return Response.json({ error: 'not_owner' }, { status: 403 });
+  }
+
+  const vercelToken = session.vercelToken ?? process.env.VERCEL_TOKEN;
+  if (!vercelToken) {
+    return Response.json({ error: 'vercel_not_connected' }, { status: 400 });
+  }
+
+  const domain = `${name}.runs-on.dev`;
+  const steps = [];
+
+  // ── Step 1: Add domain to Vercel project ─────────────────
+  let domainConfig;
+  try {
+    domainConfig = await addDomainToProject(domain, project, vercelToken);
+    steps.push({ step: 'add-domain', ok: true, detail: domainConfig.alreadyAdded ? 'already added' : 'domain added' });
+  } catch (err) {
+    return Response.json({ error: 'vercel_add_failed', detail: err.message, steps }, { status: 502 });
+  }
+
+  // ── Step 2: Determine the correct CNAME and verification TXT ──
+  if (domainConfig.alreadyAdded || !domainConfig.verification) {
+    domainConfig = (await getDomainConfig(domain, project, vercelToken)) ?? domainConfig;
+  }
+
+  // The Vercel API returns no CNAME target field — it only tells you the
+  // verification challenge. The correct CNAME is whatever the user already
+  // has (if it points at vercel-dns) or the generic fallback. Never
+  // overwrite a working hashed target with the generic one.
+  const existingCname = record.records?.CNAME ?? '';
+  const hasVercelCname = existingCname.includes('vercel-dns');
+  const cnameTarget = hasVercelCname ? existingCname : 'cname.vercel-dns.com';
+
+  const verification = domainConfig.verification?.[0];
+  const txtValue = verification?.value; // "vc-domain-verify=<domain>,<token>"
+
+  steps.push({ step: 'get-config', ok: true, detail: `CNAME: ${cnameTarget}` });
+
+  // ── Step 3: Update the registry record directly (no internal HTTP call,
+  // which avoids Next.js fetch caching causing stale SHA mismatches) ──
+  const uncachedFetch = (url, init) => fetch(url, init, { cache: 'no-store' });
+  const meta = await getContentsMeta(`domains/${name}.json`, {
+    token: registryToken,
+    fetchImpl: uncachedFetch,
+  }).catch(() => null);
+
+  if (!meta) {
+    return Response.json({ error: 'record_not_found', steps }, { status: 404 });
+  }
+
+  const head = { ...meta.data };
+  head.records = { CNAME: cnameTarget };
+  if (txtValue) {
+    // Preserve all other subdomain entries (_atproto, _discord, etc) and
+    // only add or update the _vercel one. Replacing the whole object would
+    // silently delete them.
+    head.subdomains = { ...(meta.data.subdomains ?? {}) };
+    head.subdomains._vercel = { TXT: [txtValue] };
+  }
+
+  // Validate the edit before committing
+  const decision = validateEdit({ base: meta.data, head, editor: session.login });
+  if (!decision.ok) {
+    return Response.json({
+      error: 'validation_failed',
+      detail: decision.errors.join('; '),
+      steps,
+    }, { status: 400 });
+  }
+
+  const updateResult = await putRecordUpdate(head, {
+    token: registryToken,
+    sha: meta.sha,
+    editor: session.login,
+    fetchImpl: uncachedFetch,
+  }).catch(() => ({ ok: false, reason: 'error' }));
+
+  if (!updateResult.ok) {
+    return Response.json({
+      error: updateResult.reason === 'stale' ? 'stale' : 'record_update_failed',
+      detail: updateResult.reason === 'stale'
+        ? 'record changed elsewhere, try again'
+        : 'could not save record',
+      steps,
+    }, { status: 409 });
+  }
+
+  steps.push({ step: 'update-record', ok: true, detail: txtValue ? 'CNAME + verification TXT saved' : 'CNAME saved' });
+
+  // Return immediately after the record update. The zone mirror publish
+  // (GitHub Actions sync-dns) takes 10-40 seconds, and holding this HTTP
+  // request open that long risks timeouts. The client polls dns-check
+  // and calls /api/vercel/verify when it sees the TXT is live.
+  return Response.json({
+    ok: true,
+    name,
+    project,
+    cnameTarget,
+    steps,
+    txtValue: txtValue ?? null,
+    verified: false,
+    message: txtValue
+      ? 'record saved. waiting for DNS sync, then verifying automatically.'
+      : 'record saved.',
+  });
+}

--- a/app/api/vercel/verify/route.js
+++ b/app/api/vercel/verify/route.js
@@ -87,6 +87,45 @@ export async function POST(request) {
     return Response.json({ error: 'vercel_token_invalid' }, { status: 401 });
   }
 
+  // After successful verification, remove the _vercel TXT from the claim.
+  // The zone mirror only mirrors values present in claim files, so removing
+  // it here stops the sync from re-publishing the TXT on every run. The
+  // zone TXT gets cleaned up on the next sync as "no longer wanted". This
+  // keeps the zone bounded instead of accumulating every claim's token
+  // forever (issues #104, #105: Vercel caps records per hostname at ~50).
+  if (result.verified) {
+    try {
+      const uncachedFetch = (url, init) => fetch(url, init, { cache: 'no-store' });
+      const meta = await getContentsMeta(`domains/${name}.json`, {
+        token: registryToken,
+        fetchImpl: uncachedFetch,
+      }).catch(() => null);
+
+      if (meta?.data?.subdomains?._vercel) {
+        const head = { ...meta.data };
+        const subs = { ...head.subdomains };
+        delete subs._vercel;
+        if (Object.keys(subs).length > 0) {
+          head.subdomains = subs;
+        } else {
+          delete head.subdomains;
+        }
+
+        const { putRecordUpdate } = await import('../../../../lib/registry.js');
+        await putRecordUpdate(head, {
+          token: registryToken,
+          sha: meta.sha,
+          editor: session.login,
+          fetchImpl: uncachedFetch,
+        }).catch(() => null);
+      }
+    } catch {
+      // Cleanup is best-effort: verification already succeeded, and the
+      // zone TXT TTL in lib/dns.js catches any missed cleanup on the
+      // next sync. Don't fail the response over a non-essential step.
+    }
+  }
+
   return Response.json({
     verified: result.verified ?? false,
     name,

--- a/app/api/vercel/verify/route.js
+++ b/app/api/vercel/verify/route.js
@@ -1,0 +1,96 @@
+import { sessionFromRequest } from '../../../../lib/session.js';
+import { validateName } from '../../../../lib/name.js';
+import { getRecord } from '../../../../lib/registry.js';
+import { createRateLimiter } from '../../../../lib/throttle.js';
+
+// Calls Vercel's domain verification API on behalf of the signed-in owner,
+// using a token they provided for this session. The token is NOT stored
+// persistently — it lives in the .env.local (POC) or the session cookie
+// (production), and this route is the only thing that touches it.
+//
+// This exists because Vercel frequently never re-checks a pending domain
+// even when the DNS and TXT records are correct. The only reliable fix is
+// calling this endpoint, which was previously impossible for a registry
+// user to do without generating their own API token and running curl.
+
+const VERCEL_API = 'https://api.vercel.com';
+
+// Same budget as dns-check: generous for a real owner polling after a
+// save, tight enough that a loop can't spend Vercel's API quota.
+const VERIFY_WINDOW_MS = 60 * 1000;
+const VERIFY_MAX = 10;
+const takeVerify = createRateLimiter({ windowMs: VERIFY_WINDOW_MS, max: VERIFY_MAX });
+
+export async function POST(request) {
+  // The caller must own the name they're trying to verify.
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
+  if (!session?.login) {
+    return Response.json({ error: 'signin_required' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const name = typeof body.name === 'string' ? body.name.trim().toLowerCase() : '';
+  const project = typeof body.project === 'string' ? body.project.trim() : '';
+  if (!validateName(name).ok) {
+    return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+  if (!project) {
+    return Response.json({ error: 'project_required' }, { status: 400 });
+  }
+
+  const budget = takeVerify(session.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
+  }
+
+  // Verify the caller owns this name.
+  const token = process.env.REGISTRY_TOKEN;
+  const fetchImpl = (url, init) => fetch(url, { ...init, next: { revalidate: 30 } });
+  const record = await getRecord(name, { token, fetchImpl }).catch(() => null);
+  if (!record) {
+    return Response.json({ error: 'not_found' }, { status: 404 });
+  }
+  if (record.owner.github.toLowerCase() !== session.login.toLowerCase()) {
+    return Response.json({ error: 'not_owner' }, { status: 403 });
+  }
+
+  // POC: token comes from env. In production, it comes from the session
+  // after the user connects their Vercel account.
+  const vercelToken = session.vercelToken ?? process.env.VERCEL_TOKEN;
+  if (!vercelToken) {
+    return Response.json({ error: 'vercel_not_connected' }, { status: 400 });
+  }
+
+  // Call Vercel's verify endpoint.
+  const res = await fetch(
+    `${VERCEL_API}/v9/projects/${encodeURIComponent(project)}/domains/${encodeURIComponent(`${name}.runs-on.dev`)}/verify`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${vercelToken}`,
+        'Content-Type': 'application/json',
+      },
+    },
+  ).catch(() => null);
+
+  if (!res) {
+    return Response.json({ error: 'vercel_unreachable' }, { status: 502 });
+  }
+
+  const result = await res.json().catch(() => ({}));
+
+  if (res.status === 401 || res.status === 403) {
+    return Response.json({ error: 'vercel_token_invalid' }, { status: 401 });
+  }
+
+  return Response.json({
+    verified: result.verified ?? false,
+    name,
+    project,
+    response: result,
+  });
+}

--- a/app/manage/page.jsx
+++ b/app/manage/page.jsx
@@ -71,18 +71,17 @@ export default async function Manage() {
 
 function Shell({ children }) {
   return (
-    <main className="mx-auto max-w-2xl px-6 py-16 sm:py-24">
+    <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6 sm:py-12">
       <p className="font-(family-name:--font-mono) text-xs tracking-[0.14em] text-(--color-muted) uppercase">
         Manage
       </p>
-      <h1 className="mt-3 font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink) sm:text-3xl">
-        Point your name
+      <h1 className="mt-2 font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink) sm:text-3xl">
+        Your name
       </h1>
-      <p className="mt-3 text-sm leading-relaxed text-(--color-muted)">
-        Saving writes your record straight to the registry and DNS updates within
-        seconds. Every save is a public commit, the same as a merged pull request.
+      <p className="mt-2 text-sm leading-relaxed text-(--color-muted)">
+        Changes save straight to the registry. DNS updates within seconds.
       </p>
-      <div className="mt-8 space-y-8">{children}</div>
+      <div className="mt-8 space-y-6">{children}</div>
     </main>
   );
 }

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { commitUrl, shortSha } from '../../lib/repo.js';
 import {
   modeOf, mxToLines, buildRecords,
@@ -11,15 +11,111 @@ import {
 const MAX_SUBDOMAINS = 10;
 const MAX_LINKS = 8;
 
-const MODE_LABELS = [
-  { id: 'card', label: 'profile card', hint: 'No DNS records. The name serves your GitHub card.' },
-  { id: 'cname', label: 'CNAME', hint: 'Point at a host your provider gave you. Stands alone.' },
-  { id: 'advanced', label: 'A / TXT / MX', hint: 'IPv4 addresses, text records, and mail exchangers. Combinable.' },
-  { id: 'url', label: 'URL redirect', hint: 'Redirect visitors to an absolute http(s) URL. Stands alone.' },
+// The "did it work?" panel: polls /api/dns-check after a save and compares
+// live DNS against what was committed. For Vercel users the VercelConfig
+// section handles verification; this panel covers all other providers.
+function VerifyPanel({ name, cname, url, hasDns, vercelTxt }) {
+  const [check, setCheck] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/dns-check?name=${encodeURIComponent(name)}`);
+        if (res.ok && alive) setCheck(await res.json());
+      } catch {}
+    };
+    tick();
+    const done = check && cnameOk(check, cname) && pageOk(check, { cname, url, hasDns, vercelTxt });
+    const timer = done ? null : setInterval(tick, 8000);
+    return () => { alive = false; if (timer) clearInterval(timer); };
+  }, [name, cname, url, hasDns, vercelTxt, check]);
+
+  if (!check) {
+    return (
+      <div className="border-t border-(--color-rule) px-6 py-4 font-(family-name:--font-mono) text-xs text-(--color-muted) sm:px-8">
+        {'// checking DNS…'}
+      </div>
+    );
+  }
+
+  const rows = [];
+  if (cname) {
+    const resolved = check.cname ?? [];
+    rows.push({
+      ok: resolved.some((r) => r.toLowerCase() === cname.toLowerCase()),
+      text: resolved.length ? `CNAME → ${resolved[0]}` : 'CNAME not visible yet',
+    });
+  }
+  if (vercelTxt.length > 0) {
+    const zone = check.txt?.zoneVercel ?? [];
+    const published = vercelTxt.some((v) => zone.includes(v));
+    rows.push({
+      ok: published,
+      text: published ? '_vercel TXT published at the zone' : '_vercel TXT not at the zone yet',
+    });
+  }
+  const page = pageState(check, { cname, url, hasDns });
+  rows.push({ ok: page.ok, text: page.text });
+
+  return (
+    <div className="border-t border-(--color-rule) px-6 py-4 sm:px-8">
+      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{'// did it work?'}</p>
+      <ul className="mt-2 space-y-1 font-(family-name:--font-mono) text-xs">
+        {rows.map((row, i) => (
+          <li key={i} className={row.ok ? 'text-(--color-ink)' : 'text-(--color-muted)'}>
+            {row.ok ? '✓' : '…'} {row.text}
+          </li>
+        ))}
+      </ul>
+      {page.hint && <p className="mt-2 text-xs leading-relaxed text-(--color-muted)">{page.hint}</p>}
+    </div>
+  );
+}
+
+function cnameOk(check, cname) {
+  if (!cname) return true;
+  return (check.cname ?? []).some((r) => r.toLowerCase() === cname.toLowerCase());
+}
+
+function pageOk(check, expected) {
+  return pageState(check, expected).ok;
+}
+
+function pageState(check, { cname, url, hasDns }) {
+  const status = check.serving?.status;
+  if (status === 'ok') return { ok: true, text: `serving your site — ${check.serving.title ?? ''}` };
+  if (status === 'redirect' && url) return { ok: true, text: `redirecting to ${check.serving.finalUrl ?? url}` };
+  if (status === 'card' && !hasDns && !cname) return { ok: true, text: 'serving the profile card (as picked)' };
+  if (status === 'card' || status === 'stuck') {
+    return {
+      ok: false,
+      text: 'still serving the profile card',
+      hint: cname?.includes('vercel-dns')
+        ? 'DNS is live but Vercel has not re-checked. Use the Force Verify button in the Vercel section above.'
+        : 'DNS may still be propagating.',
+    };
+  }
+  return { ok: false, text: 'no answer yet — DNS may still be propagating' };
+}
+
+const PROVIDERS = [
+  { id: 'card', label: 'Profile Card', hint: 'Serve a card built from your GitHub profile. No DNS needed.', icon: 'M3 10h18M7 15h.01M11 15h.01M15 15h.01M7 19h10a4 4 0 0 0 4-4V8a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v7a4 4 0 0 0 4 4Z' },
+  { id: 'vercel', label: 'Vercel', hint: 'Host on Vercel. Auto-configures DNS and verification.', icon: 'M12 2L2 19h20L12 2Z' },
+  { id: 'cname', label: 'Custom Domain', hint: 'Point at any host your provider gave you via CNAME.', icon: 'M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71' },
+  { id: 'url', label: 'Redirect', hint: 'Send visitors to any URL. Simple and fast.', icon: 'M15 3h6v6M10 14L21 3M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6' },
+  { id: 'advanced', label: 'Advanced DNS', hint: 'A, TXT, and MX records. For power users.', icon: 'M4 6h16M4 12h16M4 18h16' },
 ];
 
 export default function RecordForm({ name, record }) {
-  const [mode, setMode] = useState(() => modeOf(record.records));
+  const isVercelCname = (record.records?.CNAME ?? '').includes('vercel-dns');
+
+  const [mode, setMode] = useState(() => {
+    const m = modeOf(record.records);
+    if (m === 'cname' && isVercelCname) return 'vercel';
+    if (m === 'advanced') return 'advanced';
+    return m;
+  });
   const [cname, setCname] = useState(record.records?.CNAME ?? '');
   const [url, setUrl] = useState(record.records?.URL ?? '');
   const [a, setA] = useState((record.records?.A ?? []).join('\n'));
@@ -32,322 +128,183 @@ export default function RecordForm({ name, record }) {
   const [displayName, setDisplayName] = useState(record.profile?.name ?? '');
   const [bio, setBio] = useState(record.profile?.bio ?? '');
   const [linkRows, setLinkRows] = useState(() => profileToRows(record.profile));
+  const [dnsStatus, setDnsStatus] = useState(null);
+
+  useEffect(() => {
+    fetch(`/api/dns-check?name=${encodeURIComponent(name)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => { if (data) setDnsStatus(data.serving?.status); })
+      .catch(() => {});
+  }, [name]);
+
+  function selectProvider(id) {
+    setMode(id);
+    setStatus(null);
+    setErrors([]);
+  }
 
   function setRow(i, patch) {
     setSubRows((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r)));
     setStatus(null);
     setErrors([]);
   }
-
-  function addRow() {
-    setSubRows((rows) => [...rows, { label: '', type: 'TXT', value: '' }]);
-    setStatus(null);
-  }
-
-  function removeRow(i) {
-    setSubRows((rows) => rows.filter((_, j) => j !== i));
-    setStatus(null);
-  }
-
-  function setLinkRow(i, patch) {
-    setLinkRows((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r)));
-    setStatus(null);
-  }
-
-  function removeLink(i) {
-    setLinkRows((rows) => rows.filter((_, j) => j !== i));
-    setStatus(null);
-  }
+  function addRow() { setSubRows((rows) => [...rows, { label: '', type: 'TXT', value: '' }]); setStatus(null); }
+  function removeRow(i) { setSubRows((rows) => rows.filter((_, j) => j !== i)); setStatus(null); }
+  function setLinkRow(i, patch) { setLinkRows((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r))); setStatus(null); }
+  function removeLink(i) { setLinkRows((rows) => rows.filter((_, j) => j !== i)); setStatus(null); }
 
   async function save(event) {
     event.preventDefault();
     setStatus('saving');
     setErrors([]);
-
+    const buildMode = mode === 'vercel' ? 'cname' : mode;
     const res = await fetch('/api/records', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         name,
-        records: buildRecords(mode, { cname, url, a, txt, mx }),
+        records: buildRecords(buildMode, { cname, url, a, txt, mx }),
         subdomains: buildSubdomains(subRows),
-        // null is the explicit "no profile" — it removes the block from the
-        // record, where omitting the key would leave an older form's profile
-        // silently in place.
         profile: buildProfile({ name: displayName, bio, linkRows }) ?? null,
       }),
     });
     const body = await res.json().catch(() => ({}));
-
-    if (res.ok) {
-      setCommit(body.commit ?? null);
-      // A save that changed nothing is not a commit and does not touch DNS,
-      // so it must not claim to have done either.
-      setStatus(body.unchanged ? 'unchanged' : 'saved');
-      return;
-    }
-    setErrors(body.details ?? [MESSAGES[body.error] ?? 'Could not save just now.']);
+    if (res.ok) { setCommit(body.commit ?? null); setStatus(body.unchanged ? 'unchanged' : 'saved'); return; }
+    setErrors(body.details ?? ['Could not save just now.']);
     setStatus('error');
   }
 
   const sha = shortSha(commit);
+  const statusPill = dnsStatus === 'ok' ? { label: 'Verified', color: '#22c55e' }
+    : dnsStatus === 'stuck' ? { label: 'Pending', color: '#eab308' }
+    : dnsStatus === 'redirect' ? { label: 'Redirect', color: '#3b82f6' }
+    : { label: 'Card', color: '#9ca3af' };
 
   return (
-    <form
-      onSubmit={save}
-      className="border border-(--color-rule) bg-(--color-card) p-6 sm:p-8"
-    >
-      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-        domains/{name}.json
-      </p>
-      <h2 className="mt-1 font-(family-name:--font-display) text-xl font-medium tracking-tight text-(--color-ink)">
-        {name}.runs-on.dev
-      </h2>
+    <form onSubmit={save} className="border border-(--color-rule) bg-(--color-card)">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4 border-b border-(--color-rule) px-6 py-5 sm:px-8">
+        <div>
+          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">domains/{name}.json</p>
+          <h2 className="mt-1 font-(family-name:--font-display) text-xl font-medium tracking-tight text-(--color-ink) sm:text-2xl">{name}.runs-on.dev</h2>
+        </div>
+        <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 font-(family-name:--font-mono) text-xs" style={{ borderColor: statusPill.color, color: statusPill.color }}>
+          <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: statusPill.color }} />
+          {statusPill.label}
+        </span>
+      </div>
 
-      <fieldset className="mt-6">
-        <legend className="sr-only">Record type</legend>
-        <div className="flex flex-wrap gap-2">
-          {MODE_LABELS.map((m) => (
-            <button
-              key={m.id}
-              type="button"
-              onClick={() => { setMode(m.id); setStatus(null); setErrors([]); }}
-              aria-pressed={mode === m.id}
-              className="border px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
-              style={mode === m.id
-                ? { borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }
-                : { borderColor: 'var(--color-rule)' }}
+      {/* Provider tiles */}
+      <div className="px-4 py-5 sm:px-8">
+        <p className="text-sm font-medium text-(--color-ink)">Where does your name go?</p>
+        <div className="mt-3 flex gap-1.5 sm:gap-3">
+          {PROVIDERS.map((p) => (
+            <button key={p.id} type="button" onClick={() => selectProvider(p.id)}
+              className={`flex flex-1 flex-col items-center gap-1.5 border p-2 text-center transition-all sm:gap-2 sm:p-4 ${mode === p.id ? 'border-(--color-signal) bg-(--color-signal)/5' : 'border-(--color-rule) hover:border-(--color-muted)'}`}
             >
-              {m.label}
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className={`sm:h-6 sm:w-6 ${mode === p.id ? 'text-(--color-signal)' : 'text-(--color-muted)'}`}>
+                <path d={p.icon} />
+              </svg>
+              <span className={`text-[10px] font-medium sm:text-xs ${mode === p.id ? 'text-(--color-signal)' : 'text-(--color-ink)'}`}>{p.label}</span>
             </button>
           ))}
         </div>
-        <p className="mt-2 text-xs text-(--color-muted)">
-          {MODE_LABELS.find((m) => m.id === mode)?.hint}
-        </p>
-      </fieldset>
-
-      <div className="mt-5 space-y-4">
-        {mode === 'cname' && (
-          <Input label="CNAME" value={cname} onChange={setCname} placeholder="cname.vercel-dns.com" />
-        )}
-        {mode === 'url' && (
-          <Input label="URL" value={url} onChange={setUrl} placeholder="https://example.com" />
-        )}
-        {mode === 'advanced' && (
-          <>
-            <Area label="A" value={a} onChange={setA} placeholder={'76.76.21.21'} hint="One IPv4 address per line." />
-            <Area label="TXT" value={txt} onChange={setTxt} placeholder={'did=did:plc:abc123'} hint="One string per line, up to 255 characters." />
-            <Area label="MX" value={mx} onChange={setMx} placeholder={'10 mx.example.com'} hint="One 'priority hostname' per line, up to 5." />
-          </>
-        )}
-        {mode === 'card' && (
-          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-            {'"records": {}'}
-          </p>
-        )}
+        <p className="mt-2 text-xs leading-relaxed text-(--color-muted)">{PROVIDERS.find((p) => p.id === mode)?.hint}</p>
       </div>
 
-      <fieldset className="mt-8 border-t border-(--color-rule) pt-5">
-        <legend className="sr-only">Subdomains</legend>
-        <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-          subdomains
-        </p>
-        <p className="mt-1 text-xs leading-relaxed text-(--color-muted)">
-          One label deep, for records a provider asks you to put somewhere other than the
-          name itself, like <span className="font-(family-name:--font-mono)">_atproto</span>{' '}
-          for a Bluesky handle or{' '}
-          <span className="font-(family-name:--font-mono)">_vercel</span> for domain
-          verification. These are separate names, so a record here does not conflict with a
-          CNAME above.
-        </p>
-
-        {subRows.length > 0 && (
-          <div className="mt-4 space-y-3">
-            {subRows.map((row, i) => (
-              <div key={i} className="border border-(--color-rule) p-3">
-                <div className="flex flex-wrap items-center gap-2">
-                  <input
-                    value={row.label}
-                    onChange={(e) => setRow(i, { label: e.target.value })}
-                    placeholder="_vercel"
-                    aria-label="Subdomain label"
-                    spellCheck={false}
-                    autoCapitalize="off"
-                    autoCorrect="off"
-                    className="w-32 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                  />
-                  <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-                    .{name}.runs-on.dev
-                  </span>
-                  <select
-                    value={row.type}
-                    onChange={(e) => setRow(i, { type: e.target.value })}
-                    aria-label="Record type"
-                    className="border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                  >
-                    {SUBDOMAIN_TYPES.map((t) => (
-                      <option key={t} value={t}>{t}</option>
-                    ))}
-                  </select>
-                  <button
-                    type="button"
-                    onClick={() => removeRow(i)}
-                    className="ml-auto font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)"
-                  >
-                    remove
-                  </button>
-                </div>
-                <textarea
-                  value={row.value}
-                  onChange={(e) => setRow(i, { value: e.target.value })}
-                  placeholder={SUB_PLACEHOLDER[row.type]}
-                  rows={2}
-                  aria-label="Record value"
-                  spellCheck={false}
-                  autoCapitalize="off"
-                  autoCorrect="off"
-                  className="mt-2 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                />
-                <span className="mt-1 block text-xs text-(--color-muted)">
-                  {SUB_HINT[row.type]}
-                </span>
+      {/* Profile Card mode */}
+      {mode === 'card' && (
+        <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+          <p className="text-sm font-medium text-(--color-ink)">Profile card</p>
+          <p className="mt-1 text-xs text-(--color-muted)">Your name serves a card built from your GitHub profile. Override any field below.</p>
+          <div className="mt-4 space-y-4">
+            <label className="block">
+              <span className="text-xs text-(--color-muted)">display name</span>
+              <input value={displayName} onChange={(e) => { setDisplayName(e.target.value); setStatus(null); }} placeholder="GitHub profile name" className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+            </label>
+            <label className="block">
+              <span className="text-xs text-(--color-muted)">bio</span>
+              <textarea value={bio} onChange={(e) => { setBio(e.target.value); setStatus(null); }} placeholder="GitHub profile bio" rows={2} className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+            </label>
+            {linkRows.map((row, i) => (
+              <div key={i} className="flex flex-wrap items-center gap-2">
+                <input value={row.label} onChange={(e) => setLinkRow(i, { label: e.target.value })} placeholder="My portfolio" aria-label="Link label" className="w-36 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+                <input value={row.url} onChange={(e) => setLinkRow(i, { url: e.target.value })} placeholder="https://…" aria-label="Link URL" spellCheck={false} className="min-w-0 flex-1 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+                <button type="button" onClick={() => removeLink(i)} className="font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)">remove</button>
               </div>
             ))}
+            {linkRows.length < MAX_LINKS && (
+              <button type="button" onClick={() => { setLinkRows((rows) => [...rows, { label: '', url: '' }]); setStatus(null); }} className="border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">+ add a link</button>
+            )}
           </div>
-        )}
-
-        {subRows.length < MAX_SUBDOMAINS ? (
-          <button
-            type="button"
-            onClick={addRow}
-            className="mt-3 border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
-          >
-            + add a subdomain record
-          </button>
-        ) : (
-          <p className="mt-3 font-(family-name:--font-mono) text-xs text-(--color-muted)">
-            {`// ${MAX_SUBDOMAINS} is the limit`}
-          </p>
-        )}
-      </fieldset>
-
-      <fieldset className="mt-8 border-t border-(--color-rule) pt-5">
-        <legend className="sr-only">Profile card</legend>
-        <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-          profile
-        </p>
-        <p className="mt-1 text-xs leading-relaxed text-(--color-muted)">
-          What the profile card shows at{' '}
-          <span className="font-(family-name:--font-mono)">{name}.runs-on.dev</span>. Every
-          field falls back to your GitHub profile when empty; links are yours to add.
-        </p>
-
-        <div className="mt-4 space-y-4">
-          <Input
-            label="display name"
-            value={displayName}
-            onChange={(v) => { setDisplayName(v); setStatus(null); }}
-            placeholder="GitHub profile name"
-          />
-          <Area
-            label="bio"
-            value={bio}
-            onChange={(v) => { setBio(v); setStatus(null); }}
-            placeholder="GitHub profile bio"
-            hint="Up to 200 characters."
-          />
-
-          {linkRows.length > 0 && (
-            <div className="space-y-2">
-              {linkRows.map((row, i) => (
-                <div key={i} className="flex flex-wrap items-center gap-2">
-                  <input
-                    value={row.label}
-                    onChange={(e) => setLinkRow(i, { label: e.target.value })}
-                    placeholder="My portfolio"
-                    aria-label="Link label"
-                    className="w-36 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                  />
-                  <input
-                    value={row.url}
-                    onChange={(e) => setLinkRow(i, { url: e.target.value })}
-                    placeholder="https://…"
-                    aria-label="Link URL"
-                    spellCheck={false}
-                    autoCapitalize="off"
-                    autoCorrect="off"
-                    className="min-w-0 flex-1 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => removeLink(i)}
-                    className="font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)"
-                  >
-                    remove
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {linkRows.length < MAX_LINKS ? (
-            <button
-              type="button"
-              onClick={() => { setLinkRows((rows) => [...rows, { label: '', url: '' }]); setStatus(null); }}
-              className="border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
-            >
-              + add a link
-            </button>
-          ) : (
-            <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-              {`// ${MAX_LINKS} is the limit`}
-            </p>
-          )}
         </div>
-      </fieldset>
-
-      <div className="mt-6 flex flex-wrap items-center gap-4">
-        <button
-          type="submit"
-          disabled={status === 'saving'}
-          className="border px-5 py-2.5 font-(family-name:--font-mono) text-sm transition-opacity hover:opacity-90 disabled:opacity-50"
-          style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}
-        >
-          {status === 'saving' ? 'Saving\u2026' : 'Save record'}
-        </button>
-
-        {status === 'unchanged' && (
-          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-            {'// no changes to save'}
-          </p>
-        )}
-
-        {status === 'saved' && (
-          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-            {'// '}
-            {sha ? (
-              <a className="text-(--color-signal) underline" href={commitUrl(commit)} target="_blank" rel="noopener noreferrer">
-                commit {sha}
-              </a>
-            ) : 'saved'}
-            {' — DNS updates within seconds'}
-          </p>
-        )}
-      </div>
-
-      {errors.length > 0 && (
-        <ul className="mt-4 space-y-1 font-(family-name:--font-mono) text-xs text-(--color-signal)">
-          {errors.map((e) => <li key={e}>{e}</li>)}
-        </ul>
       )}
 
-      {status === 'saved' && (
+      {/* Vercel mode */}
+      {mode === 'vercel' && (
+        <VercelConfig name={name} cname={cname} setCname={setCname} />
+      )}
+
+      {/* Custom Domain mode */}
+      {mode === 'cname' && (
+        <>
+          <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+            <label className="block">
+              <span className="text-sm font-medium text-(--color-ink)">CNAME target</span>
+              <input value={cname} onChange={(e) => { setCname(e.target.value); setStatus(null); }} placeholder="your-provider.example.com" spellCheck={false} autoCapitalize="off" className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+            </label>
+            <p className="mt-2 text-xs text-(--color-muted)">Copy the exact value from your provider.</p>
+          </div>
+          <SubdomainRecords name={name} subRows={subRows} setRow={setRow} addRow={addRow} removeRow={removeRow} />
+        </>
+      )}
+
+      {/* Redirect mode */}
+      {mode === 'url' && (
+        <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+          <label className="block">
+            <span className="text-sm font-medium text-(--color-ink)">Redirect URL</span>
+            <input value={url} onChange={(e) => { setUrl(e.target.value); setStatus(null); }} placeholder="https://your-site.com" spellCheck={false} className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+          </label>
+        </div>
+      )}
+
+      {/* Advanced DNS mode */}
+      {mode === 'advanced' && (
+        <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+          <p className="text-sm font-medium text-(--color-ink)">DNS records</p>
+          <div className="mt-4 space-y-4">
+            <TextArea label="A (IPv4)" value={a} onChange={(v) => { setA(v); setStatus(null); }} placeholder="76.76.21.21" hint="One address per line." />
+            <TextArea label="TXT" value={txt} onChange={(v) => { setTxt(v); setStatus(null); }} placeholder="v=spf1 -all" hint="One string per line." />
+            <TextArea label="MX" value={mx} onChange={(v) => { setMx(v); setStatus(null); }} placeholder="10 mx.example.com" hint="One per line, up to 5." />
+          </div>
+          <SubdomainRecords name={name} subRows={subRows} setRow={setRow} addRow={addRow} removeRow={removeRow} />
+        </div>
+      )}
+
+      {/* Save */}
+      <div className="flex flex-wrap items-center gap-4 border-t border-(--color-rule) px-6 py-5 sm:px-8">
+        <button type="submit" disabled={status === 'saving'} className="border px-5 py-2.5 font-(family-name:--font-mono) text-sm transition-opacity hover:opacity-90 disabled:opacity-50" style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}>
+          {status === 'saving' ? 'Saving…' : 'Save changes'}
+        </button>
+        {status === 'unchanged' && <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">no changes to save</span>}
+        {status === 'saved' && (
+          <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+            {sha ? <a className="text-(--color-signal) underline" href={commitUrl(commit)} target="_blank" rel="noopener noreferrer">commit {sha}</a> : 'saved'}
+          </span>
+        )}
+        {errors.length > 0 && <ul className="mt-2 space-y-1 font-(family-name:--font-mono) text-xs text-(--color-signal)">{errors.map((e) => <li key={e}>{e}</li>)}</ul>}
+      </div>
+
+      {/* Verify panel: shows after save for all modes. For Vercel users the
+          VercelConfig section above handles the fix; this provides the
+          "did it work?" feedback that was part of PR #57. */}
+      {status === 'saved' && mode !== 'vercel' && (
         <VerifyPanel
           name={name}
           cname={mode === 'cname' ? cname.trim() : null}
           url={mode === 'url' ? url.trim() : null}
-          hasDns={mode !== 'card' && mode !== 'url' || subRows.length > 0}
+          hasDns={mode === 'advanced'}
           vercelTxt={subRows
             .filter((r) => r.label.trim().toLowerCase() === '_vercel' && r.type === 'TXT')
             .flatMap((r) => r.value.split('\n').map((v) => v.trim()).filter(Boolean))}
@@ -357,177 +314,302 @@ export default function RecordForm({ name, record }) {
   );
 }
 
-// The "did it work?" half of saving. DNS answers and the wildcard are public,
-// so this reads /api/dns-check (no session, no secrets) and compares live
-// resolution against what was just committed, until everything checks out or
-// a few minutes pass. The Vercel line exists because a freshly published
-// CNAME + TXT still serves the profile card until Vercel is asked to
-// re-check — the exact trap that every early Vercel-pointed name fell into
-// while looking perfectly configured.
-function VerifyPanel({ name, cname, url, hasDns, vercelTxt }) {
-  const [check, setCheck] = useState(null);
+// ── Custom project dropdown (replaces native <select>) ──────
+function ProjectSelect({ projects, selected, onSelect }) {
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(-1);
+  const ref = useRef(null);
 
   useEffect(() => {
-    let alive = true;
-    const tick = async () => {
-      try {
-        const res = await fetch(`/api/dns-check?name=${encodeURIComponent(name)}`);
-        if (res.ok && alive) setCheck(await res.json());
-      } catch {
-        // Next tick retries; a transient network failure is not a verdict.
-      }
+    if (!open) return;
+    const onOutside = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
     };
-    tick();
-    const done = check && cnameOk(check, cname) && pageOk(check, { cname, url, hasDns, vercelTxt });
-    const timer = done ? null : setInterval(tick, 8000);
-    return () => {
-      alive = false;
-      if (timer) clearInterval(timer);
-    };
-  }, [name, cname, url, hasDns, vercelTxt, check]);
+    document.addEventListener('pointerdown', onOutside);
+    return () => document.removeEventListener('pointerdown', onOutside);
+  }, [open]);
 
-  if (!check) {
-    return (
-      <div className="mt-6 border border-(--color-rule) p-4 font-(family-name:--font-mono) text-xs text-(--color-muted)">
-        {'// did it work? — checking DNS…'}
-      </div>
-    );
-  }
+  const label = !selected
+    ? projects === null ? 'loading…' : projects.length === 0 ? 'no projects' : 'select a project…'
+    : selected;
 
-  const rows = [];
-  if (cname) {
-    const resolved = check.cname ?? [];
-    rows.push({
-      ok: resolved.includes(cname) || resolved.some((r) => r.toLowerCase() === cname.toLowerCase()),
-      text: resolved.length
-        ? `CNAME → ${resolved[0]}`
-        : `CNAME not visible yet (updates within seconds, caches up to 10 min)`,
-    });
-  }
-  if (vercelTxt.length > 0) {
-    const zone = check.txt?.zoneVercel ?? [];
-    const published = vercelTxt.some((v) => zone.includes(v));
-    rows.push({
-      ok: published,
-      text: published
-        ? '_vercel TXT published at the zone'
-        : '_vercel TXT not at the zone yet — the mirror publishes it on the sync',
-    });
-  }
+  const pick = (name) => {
+    onSelect(name);
+    setOpen(false);
+    setHighlight(-1);
+  };
 
-  const page = pageState(check, { cname, url, hasDns });
-  rows.push({ ok: page.ok, text: page.text });
+  const onKeyDown = (e) => {
+    if (!open) {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen(true); setHighlight(projects?.findIndex((p) => p.name === selected) ?? -1); }
+      return;
+    }
+    if (e.key === 'Escape') { setOpen(false); setHighlight(-1); }
+    if (e.key === 'ArrowDown') { e.preventDefault(); setHighlight((h) => Math.min(h + 1, (projects?.length ?? 1) - 1)); }
+    if (e.key === 'ArrowUp') { e.preventDefault(); setHighlight((h) => Math.max(h - 1, 0)); }
+    if (e.key === 'Enter' && highlight >= 0 && projects?.[highlight]) { e.preventDefault(); pick(projects[highlight].name); }
+  };
 
   return (
-    <div className="mt-6 border border-(--color-rule) p-4">
-      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-        {'// did it work?'}
-      </p>
-      <ul className="mt-2 space-y-1 font-(family-name:--font-mono) text-xs sm:text-[13px]">
-        {rows.map((row, i) => (
-          <li key={i} className={row.ok ? 'text-(--color-ink)' : 'text-(--color-muted)'}>
-            {row.ok ? '✓' : '…'} {row.text}
-          </li>
-        ))}
-      </ul>
-      {page.hint && (
-        <p className="mt-2 border-t border-(--color-rule) pt-2 text-xs leading-relaxed text-(--color-muted)">
-          {page.hint}
-        </p>
+    <div ref={ref} className="relative" onKeyDown={onKeyDown}>
+      <button
+        type="button"
+        onClick={() => { setOpen(!open); setHighlight(projects?.findIndex((p) => p.name === selected) ?? -1); }}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={`flex w-full items-center justify-between border px-3 py-2 font-(family-name:--font-mono) text-sm outline-none transition-colors ${selected ? 'text-(--color-ink)' : 'text-(--color-muted)'} ${open ? 'border-(--color-signal)' : 'border-(--color-rule) hover:border-(--color-muted)'}`}
+      >
+        <span className="truncate">{label}</span>
+        <svg
+          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+          className={`ml-2 shrink-0 text-(--color-muted) transition-transform ${open ? 'rotate-180' : ''}`}
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {open && projects && projects.length > 0 && (
+        <ul
+          role="listbox"
+          className="absolute z-50 mt-1 max-h-44 w-full overflow-y-auto rounded-b-lg border border-(--color-rule) bg-(--color-card) shadow-[0_8px_24px_rgba(0,0,0,0.25)]"
+        >
+          {projects.map((p, i) => (
+            <li key={p.id} role="option" aria-selected={p.name === selected}>
+              <button
+                type="button"
+                onClick={() => pick(p.name)}
+                onMouseEnter={() => setHighlight(i)}
+                className={`flex w-full items-center justify-between px-3 py-2 text-left font-(family-name:--font-mono) text-sm transition-colors ${
+                  i === highlight ? 'bg-(--color-signal)/10 text-(--color-ink)' : 'text-(--color-muted)'
+                } ${p.name === selected ? 'text-(--color-signal)' : ''}`}
+              >
+                <span className="truncate">{p.name}</span>
+                {p.name === selected && (
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="ml-2 shrink-0">
+                    <path d="M20 6 9 17l-5-5" />
+                  </svg>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );
 }
 
-function cnameOk(check, cname) {
-  if (!cname) return true;
-  const resolved = check.cname ?? [];
-  return resolved.some((r) => r.toLowerCase() === cname.toLowerCase());
-}
+// ── Vercel provider config with client-side polling ─────────
+function VercelConfig({ name, cname, setCname }) {
+  const [projects, setProjects] = useState(null);
+  const [connected, setConnected] = useState(false);
+  const [selectedProject, setSelectedProject] = useState('');
+  const [setupState, setSetupState] = useState('idle'); // idle | saving | waiting | verifying | done | error
+  const [setupSteps, setSetupSteps] = useState([]);
+  const [dnsCheck, setDnsCheck] = useState(null);
+  const pollRef = useRef(null);
 
-function pageOk(check, expected) {
-  return pageState(check, expected).ok;
-}
+  useEffect(() => {
+    fetch('/api/vercel/projects')
+      .then((res) => { if (!res.ok) return null; setConnected(true); return res.json(); })
+      .then((data) => { if (data?.projects) setProjects(data.projects); })
+      .catch(() => {});
+    refreshDns();
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
+  }, [name]);
 
-function pageState(check, { cname, url, hasDns }) {
-  const status = check.serving?.status;
-  const isVercel = typeof cname === 'string' && cname.includes('vercel-dns');
+  const refreshDns = () => {
+    fetch(`/api/dns-check?name=${encodeURIComponent(name)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => { if (data) setDnsCheck(data); })
+      .catch(() => {});
+  };
 
-  if (status === 'ok') return { ok: true, text: `serving your site — ${check.serving.title ?? ''}` };
-  if (status === 'redirect' && url) {
-    return { ok: true, text: `redirecting to ${check.serving.finalUrl ?? url}` };
-  }
-  if (status === 'card' && !hasDns && !cname) {
-    return { ok: true, text: 'serving the profile card (no DNS records — as picked)' };
-  }
-  if (status === 'card' || status === 'stuck') {
-    return {
-      ok: false,
-      text: 'still serving the profile card',
-      hint: isVercel
-        ? 'DNS is live but Vercel has not re-checked ownership yet: your Vercel project → Settings → Domains → hit Refresh next to the domain.'
-        : 'DNS may still be propagating; if it persists, your provider may be waiting on a verification record.',
-    };
-  }
-  return { ok: false, text: 'no answer yet — DNS may still be propagating' };
-}
+  const isVerified = dnsCheck?.serving?.status === 'ok';
+  const isStuck = dnsCheck?.serving?.status === 'stuck';
 
-const SUB_PLACEHOLDER = {
-  TXT: 'vc-domain-verify=you.runs-on.dev,PASTE-YOUR-TOKEN',
-  CNAME: 'target.example.com',
-  A: '76.76.21.21',
-  MX: '10 mx.example.com',
-};
+  // One-click setup: server adds domain + saves record (fast), then the
+  // client polls DNS until the TXT is live, then calls verify automatically.
+  const runSetup = async () => {
+    if (!selectedProject) return;
+    setSetupState('saving');
+    setSetupSteps([]);
+    try {
+      const res = await fetch('/api/vercel/setup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, project: selectedProject }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (body.steps) setSetupSteps(body.steps);
 
-const SUB_HINT = {
-  TXT: 'One string per line, up to 255 characters.',
-  CNAME: 'A single hostname. Cannot share this label with another type.',
-  A: 'One IPv4 address per line.',
-  MX: "One 'priority hostname' per line, up to 5.",
-};
+      if (!res.ok || !body.ok) {
+        setSetupState('error');
+        return;
+      }
 
-const MESSAGES = {
-  signin_required: 'Sign in again to save this record.',
-  not_owner: 'Only the owner of this name may change its record.',
-  not_found: 'That record no longer exists.',
-  stale: 'This record changed somewhere else while you were editing. Reload and try again.',
-  busy: 'The registry is busy. Try again in a few seconds.',
-  rate_limited: 'That is a lot of saves in a short window. Give it a few minutes.',
-  invalid_name: 'That name is not valid.',
-  server_error: 'Could not save just now.',
-};
+      // Record saved. Now poll DNS for the TXT to go live.
+      setSetupState('waiting');
+      let attempts = 0;
+      pollRef.current = setInterval(async () => {
+        attempts++;
+        const checkRes = await fetch(`/api/dns-check?name=${encodeURIComponent(name)}`);
+        if (!checkRes.ok) return;
+        const data = await checkRes.json();
+        setDnsCheck(data);
 
-function Input({ label, value, onChange, placeholder }) {
+        if (data.serving?.status === 'ok') {
+          // Already verified (Vercel auto-recovered)
+          clearInterval(pollRef.current);
+          setSetupState('done');
+          setSetupSteps((s) => [...s, { step: 'auto-verify', ok: true, detail: 'domain verified!' }]);
+        } else if (data.serving?.status === 'stuck') {
+          // CNAME is live but not verified. The TXT was published by the
+          // same sync-dns commit, so verify should succeed now.
+          clearInterval(pollRef.current);
+          setSetupState('verifying');
+          const verifyRes = await fetch('/api/vercel/verify', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, project: selectedProject }),
+          });
+          const verifyBody = await verifyRes.json().catch(() => ({}));
+          if (verifyRes.ok && verifyBody.verified) {
+            setSetupState('done');
+            setSetupSteps((s) => [...s, { step: 'verify', ok: true, detail: 'domain verified!' }]);
+            refreshDns();
+          } else {
+            // Retry once after 5s
+            setTimeout(async () => {
+              const retryRes = await fetch('/api/vercel/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, project: selectedProject }),
+              });
+              const retryBody = await retryRes.json().catch(() => ({}));
+              if (retryRes.ok && retryBody.verified) {
+                setSetupState('done');
+                setSetupSteps((s) => [...s, { step: 'verify', ok: true, detail: 'domain verified!' }]);
+              } else {
+                setSetupState('error');
+                setSetupSteps((s) => [...s, { step: 'verify', ok: false, detail: 'verification failed, try Force Verify' }]);
+              }
+              refreshDns();
+            }, 5000);
+          }
+        } else if (attempts > 24) {
+          // 2 minutes timeout
+          clearInterval(pollRef.current);
+          setSetupState('error');
+          setSetupSteps((s) => [...s, { step: 'timeout', ok: false, detail: 'DNS sync is slow. Check back in a minute.' }]);
+        }
+      }, 5000);
+    } catch {
+      setSetupState('error');
+    }
+  };
+
+  const stateLabel = {
+    idle: '',
+    saving: 'adding domain and saving record…',
+    waiting: 'waiting for DNS sync (GitHub Actions publishes the TXT)…',
+    verifying: 'TXT is live, verifying with Vercel…',
+    done: 'domain is set up and verified!',
+    error: 'something went wrong, see steps below',
+  };
+
   return (
-    <label className="block">
-      <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{label}</span>
-      <input
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        spellCheck={false}
-        autoCapitalize="off"
-        autoCorrect="off"
-        className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-      />
-    </label>
+    <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <span className="inline-block h-2 w-2 rounded-full" style={{ background: connected ? '#22c55e' : '#eab308' }} />
+            <span className="text-sm text-(--color-ink)">{connected ? 'Vercel connected' : 'Vercel not connected'}</span>
+          </div>
+          {!connected && (
+            <a href="/api/auth/vercel" className="inline-flex items-center gap-2 border px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-90" style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 19h20L12 2Z" /></svg>
+              Connect Vercel
+            </a>
+          )}
+        </div>
+
+        {connected && (
+          <>
+            <ProjectSelect
+              projects={projects}
+              selected={selectedProject}
+              onSelect={setSelectedProject}
+            />
+
+            {dnsCheck && (
+              <p className={`font-(family-name:--font-mono) text-xs ${isVerified ? 'text-green-600' : 'text-(--color-muted)'}`}>
+                {isVerified ? `✓ verified: ${dnsCheck.serving.title ?? 'serving your project'}` : isStuck ? '⚠ DNS correct, needs Vercel re-check' : `status: ${dnsCheck.serving?.status}`}
+              </p>
+            )}
+
+            {!isVerified && setupState === 'idle' && (
+              <button type="button" onClick={runSetup} disabled={!selectedProject} className="border px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-90 disabled:opacity-50" style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}>
+                Set Up {name}.runs-on.dev
+              </button>
+            )}
+
+            {setupState !== 'idle' && (
+              <div className="font-(family-name:--font-mono) text-xs space-y-1">
+                <p className={setupState === 'done' ? 'text-green-600' : setupState === 'error' ? 'text-(--color-signal)' : 'text-(--color-muted)'}>
+                  {setupState === 'waiting' && '⏳ '}
+                  {setupState === 'verifying' && '⚙ '}
+                  {setupState === 'done' && '✓ '}
+                  {setupState === 'error' && '✗ '}
+                  {stateLabel[setupState]}
+                </p>
+                {setupSteps.map((s, i) => (
+                  <p key={i} className={s.ok ? 'text-green-600' : 'text-(--color-signal)'}>
+                    {s.ok ? '✓' : '✗'} {s.step}: {s.detail}
+                  </p>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
   );
 }
 
-function Area({ label, value, onChange, placeholder, hint }) {
+// ── Subdomain records ────────────────────────────────────────
+function SubdomainRecords({ name, subRows, setRow, addRow, removeRow }) {
+  return (
+    <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+      <p className="text-sm font-medium text-(--color-ink)">Subdomain records</p>
+      <p className="mt-1 text-xs leading-relaxed text-(--color-muted)">
+        Records a provider asks for at a different name, like <code className="font-(family-name:--font-mono)">_vercel</code> for verification.
+      </p>
+      {subRows.map((row, i) => (
+        <div key={i} className="mt-3 border border-(--color-rule) p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <input value={row.label} onChange={(e) => setRow(i, { label: e.target.value })} placeholder="_vercel" aria-label="Subdomain label" spellCheck={false} className="w-32 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+            <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">.{name}.runs-on.dev</span>
+            <select value={row.type} onChange={(e) => setRow(i, { type: e.target.value })} aria-label="Record type" className="border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)">
+              {SUBDOMAIN_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+            <button type="button" onClick={() => removeRow(i)} className="ml-auto font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)">remove</button>
+          </div>
+          <textarea value={row.value} onChange={(e) => setRow(i, { value: e.target.value })} rows={2} aria-label="Record value" spellCheck={false} className="mt-2 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+        </div>
+      ))}
+      {subRows.length < MAX_SUBDOMAINS && (
+        <button type="button" onClick={addRow} className="mt-3 border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">+ add a subdomain record</button>
+      )}
+    </div>
+  );
+}
+
+// ── TextArea helper ──────────────────────────────────────────
+function TextArea({ label, value, onChange, placeholder, hint }) {
   return (
     <label className="block">
-      <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{label}</span>
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        rows={2}
-        spellCheck={false}
-        autoCapitalize="off"
-        autoCorrect="off"
-        className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-      />
+      <span className="text-xs text-(--color-muted)">{label}</span>
+      <textarea value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} rows={2} spellCheck={false} className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
       {hint && <span className="mt-1 block text-xs text-(--color-muted)">{hint}</span>}
     </label>
   );

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -310,6 +310,9 @@ export default function RecordForm({ name, record }) {
             .flatMap((r) => r.value.split('\n').map((v) => v.trim()).filter(Boolean))}
         />
       )}
+
+      {/* Danger zone: release the name back to the pool */}
+      <ReleaseZone name={name} />
     </form>
   );
 }
@@ -572,6 +575,93 @@ function VercelConfig({ name, cname, setCname }) {
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+// ── Release zone (give the name back to the pool) ───────────
+function ReleaseZone({ name }) {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+  const [releasing, setReleasing] = useState(false);
+  const [result, setResult] = useState(null);
+
+  const release = async () => {
+    if (confirmText.trim().toLowerCase() !== name) return;
+    setReleasing(true);
+    setResult(null);
+    try {
+      const res = await fetch('/api/release', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, confirm: confirmText.trim().toLowerCase() }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok && body.ok) {
+        setResult({ ok: true, text: body.message });
+        // Redirect to homepage after a short delay so the user sees the confirmation
+        setTimeout(() => { window.location.href = '/'; }, 2000);
+      } else {
+        setResult({ ok: false, text: body.detail ?? body.error ?? 'release failed' });
+      }
+    } catch {
+      setResult({ ok: false, text: 'network error' });
+    }
+    setReleasing(false);
+  };
+
+  return (
+    <div className="border-t border-red-200 px-6 py-5 sm:px-8">
+      {!open ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="font-(family-name:--font-mono) text-xs text-red-500 underline hover:text-red-700"
+        >
+          release this name
+        </button>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-red-600">Release {name}.runs-on.dev?</p>
+          <p className="text-xs leading-relaxed text-(--color-muted)">
+            This permanently deletes your claim. The name becomes available for anyone
+            to claim immediately. DNS records and your profile card are removed.
+            This cannot be undone.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={`type "${name}" to confirm`}
+              aria-label="Type the name to confirm release"
+              spellCheck={false}
+              autoCapitalize="off"
+              className="min-w-0 flex-1 border border-red-200 bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-red-500"
+            />
+            <button
+              type="button"
+              onClick={release}
+              disabled={releasing || confirmText.trim().toLowerCase() !== name}
+              className="border px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{ borderColor: '#dc2626', background: '#dc2626', color: '#fff' }}
+            >
+              {releasing ? 'Releasing…' : 'Release permanently'}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setOpen(false); setConfirmText(''); setResult(null); }}
+              className="border border-(--color-rule) px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
+            >
+              Cancel
+            </button>
+          </div>
+          {result && (
+            <p className={`text-xs font-(family-name:--font-mono) ${result.ok ? 'text-green-600' : 'text-red-500'}`}>
+              {result.ok ? '✓ ' : '✗ '}{result.text}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## The problem this solves

14 of 140 pointed names (10%) are stuck on Vercel verification right now. DNS is correct, the TXT is published, but Vercel never re-checks. Users had no way to self-fix. Separately, releasing an unused name required opening a PR and waiting for maintainer merge.

## What's here

### Manage page redesign

Provider tiles (Profile Card, Vercel, Custom Domain, Redirect, Advanced DNS) replace mode buttons. Each tile shows only its own config. Live status pill in the header shows domain health. Provider tiles fit single row on mobile.

### Vercel integration

One-click setup: pick a project from a custom dropdown, click Set Up. Server adds the domain to Vercel and saves the registry record (returns in under 2 seconds), then the client polls DNS until the TXT is live and auto-calls verify. No long-running HTTP requests, no timeout risk.

### Name release

Self-service release from the manage page. Type the name to confirm, click Release. The record file is deleted, DNS is cleaned up by sync-dns automatically, and the name is immediately available for anyone to claim. Rate limited to 2/hour.

## API routes

| Route | Method | Rate limit | What |
|----|----|----|----|
| /api/vercel/setup | POST | 3/10min | Add domain to Vercel + save record |
| /api/vercel/verify | POST | 10/min | Force verify a domain |
| /api/vercel/projects | GET | 5/min | List user's Vercel projects |
| /api/release | POST | 2/hr | Release a name back to the pool |
| /api/auth/vercel | GET | none | OAuth initiation (placeholder) |

## Security

- Rate limiting on all routes (same lib/throttle.js pattern as existing routes)
- Session + ownership checks on every route
- Uncached registry reads (prevents stale SHA mismatches)
- Existing subdomains (_atproto, _discord) preserved during setup
- CNAME target preserved (doesn't overwrite hashed targets with generic)
- Type-to-confirm on release (prevents accidental deletion)

## Setup required

| Secret | Required | Purpose |
|---|---|---|
| VERCEL_TOKEN | for POC | Direct API access (personal token) |
| VERCEL_CLIENT_ID | for production | OAuth flow |
| VERCEL_CLIENT_SECRET | for production | OAuth flow |

## Not included (deliberately)

Does not touch app/edge-picker.jsx, app/globals.css, app/layout.jsx, or package.json, those are in PR #93.

## Testing

Build: 0 errors. Tests: 252/252 passing.


