### PR TITLE
fix(sync-dns): log the Vercel API's actual error body, not just the status

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -99,6 +99,25 @@ export function removePath(domain, recordId) {
   return `/v2/domains/${domain}/records/${encodeURIComponent(recordId)}`;
 }
 
+// The sync script used to log a bare status code on a failed create or delete
+// (`failed to create TXT _vercel: 400`), which is why two independent zone
+// TXT-mirror failures (#104) couldn't be diagnosed by anyone reading the
+// Action log — the API's own reason for the 400 was fetched and then
+// discarded. This formats whatever the response body turns out to be into
+// one line, without assuming its shape, so the next failure explains itself.
+export function formatApiError(status, body) {
+  if (!body) return `${status}`;
+  try {
+    const parsed = JSON.parse(body);
+    const message = parsed?.error?.message ?? parsed?.error?.code;
+    if (message) return `${status} ${message}`;
+  } catch {
+    // Not JSON — fall through and log the raw body.
+  }
+  const trimmed = body.trim();
+  return trimmed ? `${status} ${trimmed}` : `${status}`;
+}
+
 // The diff that makes a sync safe: only the records that genuinely changed
 // are touched, and everything else survives untouched. The old flow —
 // delete every record for the name, then recreate them all — meant a single

--- a/scripts/sync-dns.mjs
+++ b/scripts/sync-dns.mjs
@@ -8,6 +8,7 @@ import {
   createPath,
   removePath,
   ZONE_VERIFICATION_LABEL,
+  formatApiError,
 } from '../lib/dns.js';
 
 const DOMAIN = 'runs-on.dev';
@@ -68,7 +69,8 @@ async function existingFor(name) {
 async function deleteRecord(stale) {
   const res = await vercel(removePath(DOMAIN, stale.id), { method: 'DELETE' });
   if (!res.ok) {
-    console.error(`sync-dns: failed to delete ${stale.type} ${stale.name}: ${res.status} ${res.statusText}`);
+    const detail = await res.text().catch(() => '');
+    console.error(`sync-dns: failed to delete ${stale.type} ${stale.name}: ${formatApiError(res.status, detail)}`);
     process.exit(1);
   }
   console.log(`deleted ${stale.type} ${stale.name}`);
@@ -84,7 +86,8 @@ async function createRecord(change) {
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    console.error(`failed to create ${change.type} ${change.name}: ${res.status}`);
+    const detail = await res.text().catch(() => '');
+    console.error(`failed to create ${change.type} ${change.name}: ${formatApiError(res.status, detail)}`);
     return false;
   }
   console.log(`created ${change.type} ${change.name} -> ${change.value}`);

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -8,6 +8,7 @@ import {
   listPath,
   createPath,
   removePath,
+  formatApiError,
 } from '../lib/dns.js';
 
 const base = { name: 'lucas', owner: { github: 'zordhalo' }, claimedAt: '2026-08-30T00:00:00Z' };
@@ -273,4 +274,26 @@ test('every real _vercel claim still mirrors', () => {
     subdomains: { _vercel: { TXT: [`vc-domain-verify=${name}.runs-on.dev,tok`] } },
   }));
   assert.equal(planZoneVerificationRecords(claims).length, 4);
+});
+
+// A bare status code is what #104 and its duplicate both got stuck on: the
+// API's own reason for the 400 was fetched by the script and never logged,
+// so neither report could say why the create failed.
+test('an API error body with a message is folded into the log line', () => {
+  const body = JSON.stringify({ error: { code: 'conflicting_record', message: 'Value already exists' } });
+  assert.equal(formatApiError(400, body), '400 Value already exists');
+});
+
+test('an API error body with only a code falls back to the code', () => {
+  const body = JSON.stringify({ error: { code: 'conflicting_record' } });
+  assert.equal(formatApiError(400, body), '400 conflicting_record');
+});
+
+test('a non-JSON error body is still logged, not swallowed', () => {
+  assert.equal(formatApiError(502, 'upstream timeout'), '502 upstream timeout');
+});
+
+test('an empty error body falls back to the bare status', () => {
+  assert.equal(formatApiError(500, ''), '500');
+  assert.equal(formatApiError(500, '   '), '500');
 });


### PR DESCRIPTION
Related to #104.

`createRecord` and `deleteRecord` in `scripts/sync-dns.mjs` only ever logged the bare HTTP status on failure (`failed to create TXT _vercel: 400`). Two independent reports of the zone-level `_vercel` mirror failing — #104 and a duplicate in its comments — got stuck on exactly this: neither reporter could tell what Vercel was actually rejecting, because the response body was fetched by `fetch()` and then discarded without ever being read.

## What this changes

- `formatApiError(status, body)` in `lib/dns.js` (pure, tested): folds whatever the body turns out to be — a Vercel `{ error: { code, message } }` object, plain text, or nothing — into one log line.
- `createRecord` and `deleteRecord` in `scripts/sync-dns.mjs` now read `res.text()` on failure and pass it through `formatApiError` instead of logging `res.status` alone.

## What this does *not* do

This is diagnostic only — it does not change sync behavior on success, and it does not claim to fix the underlying 400 in #104. I don't have a live Vercel token for this zone, so I can't reproduce the actual rejection reason. What I can say is that right now nobody can, either, from the Action logs alone — this PR's entire purpose is to remove that blocker so the next occurrence (or a re-run against #104's data) prints the real reason instead of a bare status code.

## Testing

- 256/256 tests green, 4 new covering `formatApiError`: a Vercel-shaped error body with a message, one with only a code, a non-JSON body, and an empty body.
- `node --check` on both changed files.