### PR TITLE
fix(sync-dns): log the Vercel API's actual error body, not just the status

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -99,6 +99,25 @@ export function removePath(domain, recordId) {
   return `/v2/domains/${domain}/records/${encodeURIComponent(recordId)}`;
 }
 
+// The sync script used to log a bare status code on a failed create or delete
+// (`failed to create TXT _vercel: 400`), which is why two independent zone
+// TXT-mirror failures (#104) couldn't be diagnosed by anyone reading the
+// Action log — the API's own reason for the 400 was fetched and then
+// discarded. This formats whatever the response body turns out to be into
+// one line, without assuming its shape, so the next failure explains itself.
+export function formatApiError(status, body) {
+  if (!body) return `${status}`;
+  try {
+    const parsed = JSON.parse(body);
+    const message = parsed?.error?.message ?? parsed?.error?.code;
+    if (message) return `${status} ${message}`;
+  } catch {
+    // Not JSON — fall through and log the raw body.
+  }
+  const trimmed = body.trim();
+  return trimmed ? `${status} ${trimmed}` : `${status}`;
+}
+
 // The diff that makes a sync safe: only the records that genuinely changed
 // are touched, and everything else survives untouched. The old flow —
 // delete every record for the name, then recreate them all — meant a single

--- a/scripts/sync-dns.mjs
+++ b/scripts/sync-dns.mjs
@@ -8,6 +8,7 @@ import {
   createPath,
   removePath,
   ZONE_VERIFICATION_LABEL,
+  formatApiError,
 } from '../lib/dns.js';
 
 const DOMAIN = 'runs-on.dev';
@@ -68,7 +69,8 @@ async function existingFor(name) {
 async function deleteRecord(stale) {
   const res = await vercel(removePath(DOMAIN, stale.id), { method: 'DELETE' });
   if (!res.ok) {
-    console.error(`sync-dns: failed to delete ${stale.type} ${stale.name}: ${res.status} ${res.statusText}`);
+    const detail = await res.text().catch(() => '');
+    console.error(`sync-dns: failed to delete ${stale.type} ${stale.name}: ${formatApiError(res.status, detail)}`);
     process.exit(1);
   }
   console.log(`deleted ${stale.type} ${stale.name}`);
@@ -84,7 +86,8 @@ async function createRecord(change) {
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    console.error(`failed to create ${change.type} ${change.name}: ${res.status}`);
+    const detail = await res.text().catch(() => '');
+    console.error(`failed to create ${change.type} ${change.name}: ${formatApiError(res.status, detail)}`);
     return false;
   }
   console.log(`created ${change.type} ${change.name} -> ${change.value}`);

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -8,6 +8,7 @@ import {
   listPath,
   createPath,
   removePath,
+  formatApiError,
 } from '../lib/dns.js';
 
 const base = { name: 'lucas', owner: { github: 'zordhalo' }, claimedAt: '2026-08-30T00:00:00Z' };
@@ -273,4 +274,26 @@ test('every real _vercel claim still mirrors', () => {
     subdomains: { _vercel: { TXT: [`vc-domain-verify=${name}.runs-on.dev,tok`] } },
   }));
   assert.equal(planZoneVerificationRecords(claims).length, 4);
+});
+
+// A bare status code is what #104 and its duplicate both got stuck on: the
+// API's own reason for the 400 was fetched by the script and never logged,
+// so neither report could say why the create failed.
+test('an API error body with a message is folded into the log line', () => {
+  const body = JSON.stringify({ error: { code: 'conflicting_record', message: 'Value already exists' } });
+  assert.equal(formatApiError(400, body), '400 Value already exists');
+});
+
+test('an API error body with only a code falls back to the code', () => {
+  const body = JSON.stringify({ error: { code: 'conflicting_record' } });
+  assert.equal(formatApiError(400, body), '400 conflicting_record');
+});
+
+test('a non-JSON error body is still logged, not swallowed', () => {
+  assert.equal(formatApiError(502, 'upstream timeout'), '502 upstream timeout');
+});
+
+test('an empty error body falls back to the bare status', () => {
+  assert.equal(formatApiError(500, ''), '500');
+  assert.equal(formatApiError(500, '   '), '500');
 });


### PR DESCRIPTION
Related to #104. Resubmission of #108, which I closed myself to gather more
concrete evidence before reopening — this adds that evidence.

## What this changes

Same diagnostic fix as #108: `createRecord` and `deleteRecord` in
`scripts/sync-dns.mjs` only ever logged the bare HTTP status on failure
(`failed to create TXT _vercel: 400`). Neither #104 nor the duplicate report
in its comments could say *why* Vercel rejected the create, because the
response body was fetched by `fetch()` and then discarded without being read.

- `formatApiError(status, body)` in `lib/dns.js` (pure, tested): folds
  whatever the body turns out to be — a Vercel `{ error: { code, message } }`
  object, plain text, or nothing — into one log line.
- `createRecord` and `deleteRecord` now read `res.text()` on failure and pass
  it through `formatApiError` instead of logging `res.status` alone.

## New since #108: a concrete hypothesis to check against the real error body

`_vercel.runs-on.dev` currently holds **exactly 50** `vc-domain-verify=`
values (checked directly via `dns.resolveTxt` against 8.8.8.8 just now). Every
`sync-dns` run for a *new* claim's zone-mirror (mine included — 5 consecutive
failed runs on 2026-09-06) fails identically at `createRecord` for the
zone-level TXT, while the claim's own nested `_vercel.<name>` TXT and its
CNAME both create successfully in the same run.

A round number sitting exactly at the point new zone-level creates started
failing is consistent with Vercel enforcing a cap on records sharing one
type+name (as opposed to a total-bytes RRset limit, which wouldn't produce
such a clean number) — i.e. the mirror may simply have filled its 50 slots.
I can't confirm this without a live Vercel token for the zone, which is
exactly what this PR's logging would surface on the next run: it would print
the real `code`/`message` Vercel sends back instead of a bare `400`.

If the cap theory is right, the actual fix is presumably collapsing the
mirror's multiple single-value TXT records into fewer multi-string records
(Vercel's API may accept an array of strings per record) rather than one
record per claim — happy to take a pass at that once the real error confirms
it's a count limit and not something else.

## What this does *not* do

Still diagnostic only — no change to sync behavior on success, and no claim
to have fixed the underlying 400 itself.

## Testing

- 256/256 tests green, 4 covering `formatApiError` (a Vercel-shaped error
  body with a message, one with only a code, a non-JSON body, an empty body).
- `node --check` on both changed files.
