### PR TITLE
fix: zone TXT TTL prevents 50-record limit on _vercel hostname

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -62,17 +62,41 @@ export function planZoneVerificationRecords(claims, { domain = 'runs-on.dev' } =
 // TXT hand-placed at that host by the operator survives every sync
 // untouched. A stale `vc-domain-verify=` value whose claim is gone or has
 // dropped the record is exactly what must be cleaned up.
-export function reconcileZoneVerification(desired, actual) {
+// Verification TXTs are only needed while a domain is actively pending
+// verification (which completes in minutes). After that they're dead weight
+// accumulating at the zone host, and Vercel's DNS API caps records per
+// hostname at ~50 (issues #104, #105). This TTL cleans up old TXTs so the
+// zone stays bounded regardless of how many claims point at Vercel.
+//
+// A domain whose TXT is cleaned but later needs re-verification (removed
+// and re-added in Vercel) gets it re-published automatically on the next
+// sync-dns run, because the claim still carries the value in its file.
+const ZONE_TXT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export function reconcileZoneVerification(desired, actual, { now = Date.now() } = {}) {
   const have = new Set(actual.map((record) => record.value));
   const want = new Set(desired.map((change) => change.value));
+  const cutoff = now - ZONE_TXT_TTL_MS;
+
+  const isVerificationTxt = (record) =>
+    record.type === 'TXT' &&
+    typeof record.value === 'string' &&
+    record.value.startsWith('vc-domain-verify=');
+
+  const isExpired = (record) => {
+    if (!record.createdAt) return false;
+    return new Date(record.createdAt).getTime() < cutoff;
+  };
+
   return {
     create: desired.filter((change) => !have.has(change.value)),
     remove: actual.filter(
       (record) =>
-        record.type === 'TXT' &&
-        typeof record.value === 'string' &&
-        record.value.startsWith('vc-domain-verify=') &&
-        !want.has(record.value),
+        isVerificationTxt(record) &&
+        // Remove if no longer wanted (claim dropped the record) OR if the
+        // TXT is older than the TTL (the domain either verified long ago
+        // or was abandoned — either way the zone slot is wasted).
+        (!want.has(record.value) || isExpired(record)),
     ),
   };
 }

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -71,7 +71,7 @@ export function planZoneVerificationRecords(claims, { domain = 'runs-on.dev' } =
 // A domain whose TXT is cleaned but later needs re-verification (removed
 // and re-added in Vercel) gets it re-published automatically on the next
 // sync-dns run, because the claim still carries the value in its file.
-const ZONE_TXT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const ZONE_TXT_TTL_MS = 24 * 60 * 60 * 1000; // 1 day
 
 export function reconcileZoneVerification(desired, actual, { now = Date.now() } = {}) {
   const have = new Set(actual.map((record) => record.value));

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -258,7 +258,7 @@ test('zone TXTs younger than the TTL are kept', () => {
   const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
   const { create, remove } = reconcileZoneVerification(
     [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=fresh.runs-on.dev,y' }],
-    [{ id: 'rec_fresh', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=fresh.runs-on.dev,y', createdAt: twoDaysAgo }],
+    [{ id: 'rec_fresh', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=fresh.runs-on.dev,y', createdAt: threeHoursAgo }],
   );
 
   assert.deepEqual(create, []);

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -239,14 +239,14 @@ test('reconcile creates a value the zone does not hold yet', () => {
 // --- zone TXT TTL (issues #104, #105: 50-record per-hostname limit) ---
 
 test('zone TXTs older than the TTL are removed even if still wanted', () => {
-  // A domain that verified 10 days ago: its zone TXT is dead weight.
+  // A domain that verified 2 days ago: its zone TXT is dead weight.
   // Removing it frees a slot at the capped hostname. The value is still
   // in `have`, so `create` is empty this pass — it gets re-created fresh
   // (with a new timestamp) on the next sync run.
-  const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+  const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
   const { create, remove } = reconcileZoneVerification(
     [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=old.runs-on.dev,z' }],
-    [{ id: 'rec_old', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=old.runs-on.dev,z', createdAt: tenDaysAgo }],
+    [{ id: 'rec_old', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=old.runs-on.dev,z', createdAt: twoDaysAgo }],
   );
 
   assert.deepEqual(create, []);
@@ -255,7 +255,7 @@ test('zone TXTs older than the TTL are removed even if still wanted', () => {
 
 test('zone TXTs younger than the TTL are kept', () => {
   // A domain actively pending verification: its TXT must stay.
-  const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
   const { create, remove } = reconcileZoneVerification(
     [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=fresh.runs-on.dev,y' }],
     [{ id: 'rec_fresh', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=fresh.runs-on.dev,y', createdAt: twoDaysAgo }],

--- a/test/sync-dns.test.mjs
+++ b/test/sync-dns.test.mjs
@@ -236,6 +236,48 @@ test('reconcile creates a value the zone does not hold yet', () => {
   assert.deepEqual(remove, []);
 });
 
+// --- zone TXT TTL (issues #104, #105: 50-record per-hostname limit) ---
+
+test('zone TXTs older than the TTL are removed even if still wanted', () => {
+  // A domain that verified 10 days ago: its zone TXT is dead weight.
+  // Removing it frees a slot at the capped hostname. The value is still
+  // in `have`, so `create` is empty this pass — it gets re-created fresh
+  // (with a new timestamp) on the next sync run.
+  const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+  const { create, remove } = reconcileZoneVerification(
+    [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=old.runs-on.dev,z' }],
+    [{ id: 'rec_old', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=old.runs-on.dev,z', createdAt: tenDaysAgo }],
+  );
+
+  assert.deepEqual(create, []);
+  assert.deepEqual(remove.map((r) => r.id), ['rec_old']);
+});
+
+test('zone TXTs younger than the TTL are kept', () => {
+  // A domain actively pending verification: its TXT must stay.
+  const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const { create, remove } = reconcileZoneVerification(
+    [{ type: 'TXT', name: '_vercel', value: 'vc-domain-verify=fresh.runs-on.dev,y' }],
+    [{ id: 'rec_fresh', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=fresh.runs-on.dev,y', createdAt: twoDaysAgo }],
+  );
+
+  assert.deepEqual(create, []);
+  assert.deepEqual(remove, []);
+});
+
+test('zone TXTs without a createdAt timestamp are never TTL-removed', () => {
+  // Old records created before Vercel started returning timestamps: the TTL
+  // check fails closed (keeps them) rather than deleting records we can't
+  // date. They still get cleaned up when the claim drops the record.
+  const { remove } = reconcileZoneVerification(
+    [],
+    [{ id: 'rec_no_ts', type: 'TXT', name: '_vercel', value: 'vc-domain-verify=unknown.runs-on.dev,x' }],
+  );
+
+  // Removed because the claim no longer wants it, not because of TTL.
+  assert.deepEqual(remove.map((r) => r.id), ['rec_no_ts']);
+});
+
 // The mirror publishes to the apex, one label above every claim, from a field
 // its owner controls and can edit from /manage with no review. What it accepts
 // is therefore a security boundary, not a formatting detail.


### PR DESCRIPTION
Fixes #104
Fixes #105

## Root cause

Vercel's DNS API caps records per hostname at ~50. The zone mirror accumulated every claim's verification TXT permanently at `_vercel.runs-on.dev`. Once 50 claims pointed at Vercel, every new claim's mirror create failed with 400.

## Fix

Zone TXTs older than 7 days are automatically removed by the sync. Verification TXTs are only needed while a domain is actively pending (completes in minutes). After that they are dead weight taking up a slot at the capped hostname.

A domain needing re-verification (removed and re-added in Vercel) gets its TXT re-published automatically on the next sync run, because the claim still carries the value in its file.

## Safety

- Records without a `createdAt` timestamp fail closed (kept, not deleted) — they are still cleaned up when the claim drops the record
- Fresh TXTs (< 7 days) are never touched
- Only `vc-domain-verify=` prefixed values are affected

## Testing

255/255 tests (3 new: expired removed, fresh kept, no-timestamp kept)