### PR TITLE
fix(validate): repo-relative contents path in readRecordAt

### DIFF
--- a/lib/pr.js
+++ b/lib/pr.js
@@ -37,7 +37,12 @@ export function parseRecordFile(path, text) {
 // function is testable without env vars or network access — the script
 // provides the real GitHub fetcher, tests provide a stub (issue #84).
 export async function readRecordAt(path, ref, { api }) {
-  const res = await api(`/repos/contents/${path}?ref=${ref}`);
+  // Path is relative to the repo: the injected `api` already carries the
+  // `/repos/{owner}/{repo}` prefix. Emitting `/repos/...` here too produced
+  // `/repos/{owner}/{repo}/repos/contents/...`, which 404s — and since a
+  // failed read returns null, validateChangeset reported every record PR as
+  // "could not read the changed file" and failed it closed.
+  const res = await api(`/contents/${path}?ref=${ref}`);
   if (!res.ok) return null;
   const body = await res.json();
   return parseRecordFile(path, Buffer.from(body.content, 'base64').toString('utf8'));

--- a/test/validate-pr.test.mjs
+++ b/test/validate-pr.test.mjs
@@ -1,6 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateChangeset, parseRecordFile, RecordParseError, countOwnedNames } from '../lib/pr.js';
+import {
+  validateChangeset,
+  parseRecordFile,
+  RecordParseError,
+  countOwnedNames,
+  readRecordAt,
+} from '../lib/pr.js';
 
 const owned = {
   name: 'lucas',
@@ -361,4 +367,30 @@ test('a record with a missing or null owner counts as not owned', async () => {
     readRecord: async () => ({}),
   };
   assert.equal(await countOwnedNames('anyone', sparse), 0);
+});
+
+// The path readRecordAt builds is relative to the repo, because the injected
+// api already carries the /repos/{owner}/{repo} prefix. A doubled prefix here
+// 404s, and since a failed read returns null every record PR is rejected as
+// "could not read the changed file" — so the shape is worth pinning.
+test('readRecordAt requests a repo-relative contents path', async () => {
+  const seen = [];
+  const rec = await readRecordAt('domains/lucas.json', 'abc123', {
+    api: async (path) => {
+      seen.push(path);
+      return {
+        ok: true,
+        json: async () => ({ content: Buffer.from(JSON.stringify(owned)).toString('base64') }),
+      };
+    },
+  });
+  assert.deepEqual(seen, ['/contents/domains/lucas.json?ref=abc123']);
+  assert.equal(rec.name, 'lucas');
+});
+
+test('readRecordAt returns null when the file is absent', async () => {
+  const rec = await readRecordAt('domains/nope.json', 'abc123', {
+    api: async () => ({ ok: false, status: 404 }),
+  });
+  assert.equal(rec, null);
 });


### PR DESCRIPTION
## The bug

`readRecordAt` builds `/repos/contents/{path}`, but its only caller — `scripts/validate-pr.mjs` — injects an `api` that already prefixes `/repos/{owner}/{repo}`. The request that actually goes out is:

```
/repos/zordhalo/runs-on.dev/repos/contents/domains/x.json  ->  404
```

`readRecordAt` returns `null` on a failed read, so `validateChangeset` sees a missing record and reports **"could not read the changed file"**, failing the PR closed. Every domain record PR opened since this seam was extracted has been rejected by it, regardless of content.

## Verification

Ran the real validator locally against all seven open record PRs, before and after:

| PR | before | after |
|---|---|---|
| #112 | could not read the changed file | **passed** |
| #101 | could not read the changed file | **passed** |
| #100 | could not read the changed file | **passed** |
| #79  | could not read the changed file | **passed** |
| #98  | could not read the changed file | `claimedAt cannot be changed` |
| #91  | must change exactly one file | `must change exactly one file` |
| #77  | could not read the changed file | `domains/vinit.json is not valid JSON` |

The three that still fail now fail on their real contributor errors instead of being masked by the transport bug.

## Tests

Same bug class as the `path`/ReferenceError in #81 — an untested seam in the injected-API layer. `countOwnedNames` got tests in #84; `readRecordAt` did not. Adds two: one pinning the exact path shape, one covering the absent-file `null` path. Full suite: 254 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt