### PR TITLE
feat(prune): free capped zone slots by dropping settled verification challenges

### DIFF
--- a/.github/workflows/prune-verification.yml
+++ b/.github/workflows/prune-verification.yml
@@ -1,0 +1,98 @@
+name: prune-verification
+
+# Vercel caps one TXT hostname at 50 values. Every claim mirroring a
+# `vc-domain-verify=` challenge holds one at `_vercel.runs-on.dev`, and past
+# the cap sync-dns cannot publish at all — the next claim's verification can
+# never complete (issues #104, #105).
+#
+# A challenge is only load-bearing while a domain is pending verification.
+# This drops the ones that have demonstrably finished, from the CLAIM rather
+# than from DNS: planZoneVerificationRecords re-derives the desired set from
+# the claim files every run, so deleting the record alone gets it recreated on
+# the next sync. Removing it at the source is what makes it stay gone.
+#
+# Manual-only on purpose. Deciding wrongly deletes a stranger's in-flight
+# verification, so the trigger is a person who has read the dry run. Once this
+# has been exercised a few times a schedule can be added -- but the durable fix
+# for NEW claims is pruning at the moment of successful verification, in the
+# app, not a periodic sweep.
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Write the changes. Leave false for a dry run.'
+        type: boolean
+        default: false
+      limit:
+        description: 'Prune at most this many records (blank = all eligible).'
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+# Rewriting domains/ while another run is doing the same would race to commit
+# the same files. Queue rather than cancel: a half-finished prune that gets
+# cancelled after writing but before committing leaves nothing behind, but
+# there is no reason to interrupt one that is mid-flight.
+concurrency:
+  group: prune-verification
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Always run the report first, whatever the inputs say, so the log of an
+      # apply run also contains the evidence the apply was based on.
+      - name: Report what would be pruned
+        run: node scripts/prune-verification.mjs
+        env:
+          LIMIT: ${{ inputs.limit }}
+
+      - name: Apply and commit
+        if: ${{ inputs.apply }}
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          node scripts/prune-verification.mjs
+
+          if [ -z "$(git status --porcelain domains/)" ]; then
+            echo 'no records changed, nothing to commit.'
+            exit 0
+          fi
+
+          git add domains/
+          git commit -m 'prune: drop verification challenges from verified claims'
+
+          # main can move under us between checkout and push. Unlike the owners
+          # index this is NOT a pure function of the tree -- it depends on a
+          # live probe -- so a retry re-probes rather than replaying a stale
+          # plan. Rebasing keeps the prune on top of whatever landed.
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            echo "::warning::push rejected on attempt $attempt; rebasing and re-running"
+            git fetch origin main
+            git reset --hard origin/main
+            node scripts/prune-verification.mjs
+            if [ -z "$(git status --porcelain domains/)" ]; then
+              echo 'nothing left to prune after refresh.'
+              exit 0
+            fi
+            git add domains/
+            git commit -m 'prune: drop verification challenges from verified claims'
+          done
+
+          echo '::error::could not push the prune after 3 attempts'
+          exit 1
+        env:
+          APPLY: 'true'
+          LIMIT: ${{ inputs.limit }}

--- a/lib/prune.js
+++ b/lib/prune.js
@@ -1,0 +1,100 @@
+import { ZONE_VERIFICATION_LABEL } from './dns.js';
+
+// Vercel caps a single TXT hostname at 50 values, and every claim that mirrors
+// a challenge contributes one to `_vercel.runs-on.dev` (issues #104, #105).
+// Past the cap sync-dns cannot publish, so the next claim's verification can
+// never complete — the registry stops accepting new Vercel-hosted names.
+//
+// The challenge is only needed WHILE a domain is pending verification. Once
+// the provider has verified, the value is dead weight holding a capped slot.
+// But `planZoneVerificationRecords` re-derives the desired set from the claim
+// files on every run, so deleting the DNS record alone is futile: the next
+// sync recreates it. Removing it from the claim is what makes it stay gone —
+// `desired` shrinks and the existing reconciler cleans up the record with no
+// new logic.
+const CHALLENGE_PREFIX = 'vc-domain-verify=';
+
+// Only `subdomains._vercel` is mirrored to the zone. A nested label like
+// `_vercel.recruitment` publishes to `_vercel.recruitment.<name>.runs-on.dev`,
+// which is a different host with its own 50-value budget, so it holds none of
+// the contended slots and must be left alone.
+export function zoneChallengeValues(claim) {
+  const values = claim?.subdomains?.[ZONE_VERIFICATION_LABEL]?.TXT ?? [];
+  return values.filter((v) => typeof v === 'string' && v.startsWith(CHALLENGE_PREFIX));
+}
+
+// Returns the record as it should be written once the challenge is dropped,
+// or null when there is nothing to drop. Everything else on the record is
+// carried through untouched: other subdomain labels, records, profile.
+//
+// An emptied `subdomains` object is removed rather than left as `{}`, because
+// the schema treats the key as optional and a bare `{}` is noise in a file
+// people read and hand-edit.
+export function withoutZoneChallenge(claim) {
+  if (zoneChallengeValues(claim).length === 0) return null;
+
+  const subdomains = { ...claim.subdomains };
+  const entry = { ...subdomains[ZONE_VERIFICATION_LABEL] };
+
+  // The label may carry values this prune does not own — anything that is not
+  // a `vc-domain-verify=` challenge stays, and the label survives with it.
+  const keep = (entry.TXT ?? []).filter(
+    (v) => !(typeof v === 'string' && v.startsWith(CHALLENGE_PREFIX)),
+  );
+  if (keep.length > 0) {
+    entry.TXT = keep;
+    subdomains[ZONE_VERIFICATION_LABEL] = entry;
+  } else {
+    delete entry.TXT;
+    if (Object.keys(entry).length > 0) subdomains[ZONE_VERIFICATION_LABEL] = entry;
+    else delete subdomains[ZONE_VERIFICATION_LABEL];
+  }
+
+  const next = { ...claim };
+  if (Object.keys(subdomains).length > 0) next.subdomains = subdomains;
+  else delete next.subdomains;
+  return next;
+}
+
+// `status` comes from classifyClaim in lib/health.js, which is already the
+// registry's answer to "is this name serving its owner's site, or still the
+// wildcard profile card?".
+//
+// Only 'ok' is pruned. It is the one status that is positive evidence the
+// provider finished verifying: something that is not the registry's own card
+// is answering on the owner's hostname, which cannot happen until the
+// provider has taken ownership. 'stuck' is the opposite — verification has
+// NOT completed and the challenge is still load-bearing. 'down', 'card' and
+// 'redirect' are all ambiguous (mid-setup, or provider outage), and the cost
+// of guessing wrong is breaking someone's verification, so they are left.
+const PRUNABLE = new Set(['ok']);
+
+export function planVerificationPrune(claims, statusOf, { limit = Infinity } = {}) {
+  const candidates = [];
+  const held = { total: 0, byStatus: {} };
+
+  for (const claim of claims) {
+    const values = zoneChallengeValues(claim);
+    if (values.length === 0) continue;
+
+    const status = statusOf(claim.name) ?? 'unknown';
+    held.total += values.length;
+    held.byStatus[status] = (held.byStatus[status] ?? 0) + values.length;
+
+    if (!PRUNABLE.has(status)) continue;
+    const next = withoutZoneChallenge(claim);
+    if (next) candidates.push({ name: claim.name, status, freed: values.length, next });
+  }
+
+  // Deterministic order so a dry run and the apply that follows it agree on
+  // which records a `limit` selects.
+  candidates.sort((a, b) => a.name.localeCompare(b.name));
+
+  const prune = candidates.slice(0, limit);
+  return {
+    prune,
+    skipped: candidates.slice(limit),
+    held,
+    freed: prune.reduce((n, c) => n + c.freed, 0),
+  };
+}

--- a/scripts/prune-verification.mjs
+++ b/scripts/prune-verification.mjs
@@ -1,0 +1,109 @@
+import { readFile, writeFile, readdir } from 'node:fs/promises';
+import { classifyClaim } from '../lib/health.js';
+import { planVerificationPrune } from '../lib/prune.js';
+
+// Frees slots at the capped `_vercel.runs-on.dev` TXT host by dropping the
+// verification challenge from claims that have demonstrably finished
+// verifying. See lib/prune.js for why this has to happen at the claim rather
+// than at the DNS record.
+//
+// Writes nothing unless APPLY=true. The default is a report, because the
+// failure mode of guessing wrong is breaking a stranger's domain verification.
+
+const TIMEOUT_MS = 10_000;
+const CONCURRENCY = 8;
+const APPLY = process.env.APPLY === 'true';
+const LIMIT = process.env.LIMIT ? Number(process.env.LIMIT) : Infinity;
+
+if (Number.isNaN(LIMIT) || LIMIT <= 0) {
+  console.error(`prune-verification: LIMIT must be a positive number, got ${process.env.LIMIT}`);
+  process.exit(1);
+}
+
+// Identical to the health-check probe, and deliberately so: this decides
+// whether to delete someone's verification challenge on the strength of that
+// classification, so it must be the same question, asked the same way.
+async function probe(name) {
+  try {
+    const res = await fetch(`https://${name}.runs-on.dev/`, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { 'user-agent': 'runs-on-dev-prune-verification (github.com/zordhalo/runs-on.dev)' },
+    });
+    const body = await res.text();
+    const title = /<title[^>]*>([^<]*)<\/title>/i.exec(body)?.[1]?.trim() ?? '';
+    return { ok: true, finalHost: new URL(res.url).hostname, title };
+  } catch {
+    return { ok: false };
+  }
+}
+
+const claims = [];
+for (const file of await readdir('domains')) {
+  if (!file.endsWith('.json')) continue;
+  try {
+    claims.push(JSON.parse(await readFile(`domains/${file}`, 'utf8')));
+  } catch (err) {
+    // A record this run cannot read is a record it must not rewrite. Skipping
+    // loudly is right: the prune is best-effort maintenance, not a gate.
+    console.error(`prune: skipping unreadable ${file}: ${err.message}`);
+  }
+}
+
+// Only names that actually hold a contended slot are worth a network round
+// trip; the rest cannot be pruned whatever the probe says.
+const { held } = planVerificationPrune(claims, () => 'unknown');
+const queue = claims
+  .filter((claim) => (claim.subdomains?._vercel?.TXT ?? []).some(
+    (v) => typeof v === 'string' && v.startsWith('vc-domain-verify='),
+  ))
+  .map((claim) => claim.name);
+
+console.log(`prune: ${queue.length} claim(s) hold ${held.total} value(s) at _vercel.runs-on.dev (cap 50)`);
+
+const probes = new Map();
+const pending = [...queue];
+async function worker() {
+  while (pending.length > 0) {
+    const name = pending.shift();
+    probes.set(name, await probe(name));
+  }
+}
+await Promise.all(Array.from({ length: Math.min(CONCURRENCY, pending.length) }, worker));
+
+const byName = new Map(claims.map((c) => [c.name, c]));
+const statusOf = (name) => classifyClaim(byName.get(name), probes.get(name));
+const plan = planVerificationPrune(claims, statusOf, { limit: LIMIT });
+
+console.log('\nheld by status:');
+for (const [status, n] of Object.entries(plan.held.byStatus).sort()) {
+  console.log(`  ${status.padEnd(9)} ${n}`);
+}
+
+if (plan.prune.length === 0) {
+  console.log('\nnothing to prune: no claim holding a challenge is serving its own site yet.');
+  process.exit(0);
+}
+
+console.log(`\n${APPLY ? 'pruning' : 'would prune'} ${plan.prune.length} claim(s), freeing ${plan.freed} slot(s):`);
+for (const { name, freed } of plan.prune) {
+  console.log(`  ${name} (-${freed})`);
+}
+if (plan.skipped.length > 0) {
+  console.log(`\n${plan.skipped.length} further candidate(s) held back by LIMIT=${LIMIT}.`);
+}
+
+const remaining = plan.held.total - plan.freed;
+console.log(`\n_vercel.runs-on.dev: ${plan.held.total} -> ${remaining} of 50`);
+
+if (!APPLY) {
+  console.log('\ndry run. re-run with APPLY=true to write these changes.');
+  process.exit(0);
+}
+
+for (const { name, next } of plan.prune) {
+  await writeFile(`domains/${name}.json`, `${JSON.stringify(next, null, 2)}\n`);
+  console.log(`pruned domains/${name}.json`);
+}
+
+console.log(`\nprune-verification: rewrote ${plan.prune.length} record(s), freed ${plan.freed} slot(s).`);

--- a/test/prune.test.mjs
+++ b/test/prune.test.mjs
@@ -1,0 +1,111 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { planVerificationPrune, withoutZoneChallenge, zoneChallengeValues } from '../lib/prune.js';
+
+const claim = (name, extra = {}) => ({
+  name,
+  owner: { github: 'someone' },
+  claimedAt: '2026-08-30T00:00:00Z',
+  records: { CNAME: 'cname.vercel-dns.com' },
+  ...extra,
+});
+
+const withChallenge = (name) =>
+  claim(name, {
+    subdomains: { _vercel: { TXT: [`vc-domain-verify=${name}.runs-on.dev,tok`] } },
+  });
+
+test('a claim with no challenge holds nothing', () => {
+  assert.deepEqual(zoneChallengeValues(claim('a')), []);
+  assert.equal(withoutZoneChallenge(claim('a')), null);
+});
+
+// _vercel.<sub> publishes to a different host with its own 50-value budget,
+// so it holds none of the contended slots and must survive the prune.
+test('a nested _vercel.<sub> label is not a zone challenge and is left alone', () => {
+  const rec = claim('a', {
+    subdomains: { '_vercel.blog': { TXT: ['vc-domain-verify=blog.a.runs-on.dev,tok'] } },
+  });
+  assert.deepEqual(zoneChallengeValues(rec), []);
+  assert.equal(withoutZoneChallenge(rec), null);
+});
+
+test('pruning drops the _vercel label and the empty subdomains key with it', () => {
+  const next = withoutZoneChallenge(withChallenge('a'));
+  assert.equal('subdomains' in next, false);
+  assert.deepEqual(next.records, { CNAME: 'cname.vercel-dns.com' });
+  assert.equal(next.name, 'a');
+  assert.equal(next.claimedAt, '2026-08-30T00:00:00Z');
+});
+
+test('pruning preserves sibling subdomain labels', () => {
+  const rec = claim('a', {
+    subdomains: {
+      _vercel: { TXT: ['vc-domain-verify=a.runs-on.dev,tok'] },
+      _atproto: { TXT: ['did=plc:xyz'] },
+    },
+  });
+  const next = withoutZoneChallenge(rec);
+  assert.deepEqual(next.subdomains, { _atproto: { TXT: ['did=plc:xyz'] } });
+});
+
+// The label is shared: a value this prune does not own has to survive, and
+// keep the label alive with it.
+test('a non-challenge TXT under _vercel keeps the label', () => {
+  const rec = claim('a', {
+    subdomains: { _vercel: { TXT: ['vc-domain-verify=a.runs-on.dev,tok', 'something-else'] } },
+  });
+  assert.deepEqual(withoutZoneChallenge(rec).subdomains, { _vercel: { TXT: ['something-else'] } });
+});
+
+test('the input record is never mutated', () => {
+  const rec = withChallenge('a');
+  const before = JSON.stringify(rec);
+  withoutZoneChallenge(rec);
+  assert.equal(JSON.stringify(rec), before);
+});
+
+// 'ok' is the only status that is positive evidence verification completed.
+// Pruning a 'stuck' name would delete a challenge that is still load-bearing.
+test('only names serving their own site are pruned', () => {
+  const claims = ['served', 'stuck', 'down', 'card'].map(withChallenge);
+  const statuses = { served: 'ok', stuck: 'stuck', down: 'down', card: 'card' };
+  const plan = planVerificationPrune(claims, (n) => statuses[n]);
+
+  assert.deepEqual(plan.prune.map((p) => p.name), ['served']);
+  assert.equal(plan.freed, 1);
+  assert.equal(plan.held.total, 4);
+  assert.deepEqual(plan.held.byStatus, { ok: 1, stuck: 1, down: 1, card: 1 });
+});
+
+test('an unknown status is never pruned', () => {
+  const plan = planVerificationPrune([withChallenge('a')], () => undefined);
+  assert.deepEqual(plan.prune, []);
+  assert.deepEqual(plan.held.byStatus, { unknown: 1 });
+});
+
+test('claims holding no challenge are not counted as held', () => {
+  const plan = planVerificationPrune([claim('plain')], () => 'ok');
+  assert.equal(plan.held.total, 0);
+  assert.deepEqual(plan.prune, []);
+});
+
+// A dry run and the apply that follows it must select the same records, so
+// the order a limit slices has to be stable rather than directory order.
+test('limit selects deterministically by name and reports the remainder', () => {
+  const claims = ['c', 'a', 'b'].map(withChallenge);
+  const plan = planVerificationPrune(claims, () => 'ok', { limit: 2 });
+
+  assert.deepEqual(plan.prune.map((p) => p.name), ['a', 'b']);
+  assert.deepEqual(plan.skipped.map((p) => p.name), ['c']);
+  assert.equal(plan.freed, 2);
+});
+
+test('a claim holding two challenge values frees both', () => {
+  const rec = claim('a', {
+    subdomains: { _vercel: { TXT: ['vc-domain-verify=a.runs-on.dev,one', 'vc-domain-verify=a.runs-on.dev,two'] } },
+  });
+  const plan = planVerificationPrune([rec], () => 'ok');
+  assert.equal(plan.freed, 2);
+  assert.equal('subdomains' in plan.prune[0].next, false);
+});


### PR DESCRIPTION
Backfill for #104 / #105. Adds a manually-triggered maintenance job; changes no records in this PR.

## The problem

Vercel caps one TXT hostname at 50 values. 63 claims currently hold a `vc-domain-verify=` challenge at `_vercel.runs-on.dev`, so `sync-dns` fails outright on `main` and no new claim can complete verification:

```
failed to create TXT _vercel: 400 You have reached the maximum number of DNS values (50)
for TXT "_vercel" on "runs-on.dev".
```

(That message is legible thanks to #109, which landed today — before it, this was a bare `400`.)

## Why it prunes the claim, not the record

`planZoneVerificationRecords` re-derives the desired set from the claim files on every run. Delete the DNS record alone and the next sync recreates it — that is why the TTL in #110 oscillates instead of converging. Removing the value from the claim shrinks `desired`, and the **existing** reconciler removes the record with no new logic and it stays gone.

## How it decides what is settled

`classifyClaim` from `lib/health.js` — the same probe `health-check` already runs. Only `ok` is pruned, because it is the one status that is positive evidence verification completed: something that is not the registry's own profile card is answering on the owner's hostname, which cannot happen until the provider has taken ownership.

| status | meaning | pruned |
|---|---|---|
| `ok` | serving the owner's own site — provider verified | **yes** |
| `stuck` | wildcard card still answering — verification pending, challenge still load-bearing | no |
| `down` | nothing answered | no |
| `card` / `redirect` | no provider records | no |

Dry run against the live registry right now:

```
prune: 63 claim(s) hold 63 value(s) at _vercel.runs-on.dev (cap 50)

held by status:
  card      10
  ok        36
  redirect  4
  stuck     13

would prune 36 claim(s), freeing 36 slot(s)

_vercel.runs-on.dev: 63 -> 27 of 50
```

27 of 50, with the 13 names that genuinely still need their challenge untouched.

## Safety

- **Dry run by default.** `apply` is a `workflow_dispatch` boolean defaulting to false. The report step runs unconditionally, so an apply run's log always contains the evidence it acted on.
- **`limit` input** to prune a handful first and watch what happens.
- Deterministic ordering by name, so a dry run and the apply that follows select the same records.
- Nested `_vercel.<sub>` labels are left alone — they publish to a different host with its own 50-value budget and hold none of the contended slots.
- Sibling subdomain labels and any non-challenge TXT under `_vercel` survive; only the challenge values go.
- Records are not mutated in place, and an emptied `subdomains` key is removed rather than left as `{}`.

Verified on a scratch copy that an apply produces a minimal diff and the result still passes `validateRecord`:

```diff
   "records": {
     "CNAME": "9b0e4a947152a144.vercel-dns-017.com"
-  },
-  "subdomains": {
-    "_vercel": { "TXT": ["vc-domain-verify=aaqib.runs-on.dev,..."] }
   }
```

## Tests

11 new tests in `test/prune.test.mjs` covering the nested-label carve-out, sibling preservation, shared-label partial removal, non-mutation, status gating, and deterministic limiting. Suite: 269 passing.

## Scope

This is the backfill for the 63 that have accumulated. The durable fix for *new* claims is dropping the challenge at the moment verification succeeds — `c4b5bfd` on #103 does exactly that. Both halves are wanted; this one stops the bleeding now.

Manual trigger only, deliberately. Deciding wrongly deletes a stranger's in-flight verification, so an apply should be a person who has read the report. A schedule is worth adding once it has been exercised a few times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt