### PR TITLE
feat: manage page redesign, self-service name release, name swap

### DIFF
--- a/app/api/release/route.js
+++ b/app/api/release/route.js
@@ -1,0 +1,92 @@
+import { sessionFromRequest } from '../../../lib/session.js';
+import { validateName } from '../../../lib/name.js';
+import { getContentsMeta } from '../../../lib/registry.js';
+import { createRateLimiter } from '../../../lib/throttle.js';
+
+// Releases a claimed name: deletes domains/<name>.json from the repo,
+// making the name available for anyone to claim again. The sync-dns
+// workflow cleans up DNS automatically when the file disappears.
+
+const RELEASE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const RELEASE_MAX = 2;
+const takeRelease = createRateLimiter({ windowMs: RELEASE_WINDOW_MS, max: RELEASE_MAX });
+
+export async function POST(request) {
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
+  if (!session?.login) {
+    return Response.json({ error: 'signin_required' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const name = typeof body.name === 'string' ? body.name.trim().toLowerCase() : '';
+  const confirm = typeof body.confirm === 'string' ? body.confirm.trim().toLowerCase() : '';
+  if (!validateName(name).ok) {
+    return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+
+  // The caller must type the exact name to confirm. This prevents accidental
+  // releases from a mis-click, the same double-step pattern GitHub uses
+  // for repository deletion.
+  if (confirm !== name) {
+    return Response.json({ error: 'confirm_mismatch', detail: 'type the name exactly to confirm' }, { status: 400 });
+  }
+
+  const budget = takeRelease(session.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
+  }
+
+  // Read the current file to verify ownership and get the SHA for deletion.
+  const uncachedFetch = (url, init) => fetch(url, init, { cache: 'no-store' });
+  const meta = await getContentsMeta(`domains/${name}.json`, {
+    token: process.env.REGISTRY_TOKEN,
+    fetchImpl: uncachedFetch,
+  }).catch(() => null);
+
+  if (!meta) {
+    return Response.json({ error: 'not_found' }, { status: 404 });
+  }
+  if (meta.data.owner?.github?.toLowerCase() !== session.login.toLowerCase()) {
+    return Response.json({ error: 'not_owner' }, { status: 403 });
+  }
+
+  // Delete the file via the GitHub contents API. The SHA proves we read
+  // the current version; if someone changed the file between our read
+  // and this delete, GitHub rejects with 409.
+  const res = await fetch(
+    `https://api.github.com/repos/${process.env.REGISTRY_REPO ?? 'zordhalo/runs-on.dev'}/contents/domains/${name}.json`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${process.env.REGISTRY_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: `release: ${name} by @${session.login}`,
+        sha: meta.sha,
+      }),
+    },
+  ).catch(() => null);
+
+  if (!res) {
+    return Response.json({ error: 'network_error' }, { status: 502 });
+  }
+  if (res.status === 409) {
+    return Response.json({ error: 'stale', detail: 'record changed elsewhere, try again' }, { status: 409 });
+  }
+  if (!res.ok) {
+    return Response.json({ error: 'delete_failed', detail: `GitHub returned ${res.status}` }, { status: 502 });
+  }
+
+  return Response.json({
+    ok: true,
+    name,
+    message: `${name}.runs-on.dev has been released and is now available to claim`,
+  });
+}

--- a/app/api/swap/route.js
+++ b/app/api/swap/route.js
@@ -1,0 +1,156 @@
+import { sessionFromRequest } from '../../../lib/session.js';
+import { validateName } from '../../../lib/name.js';
+import { isReserved } from '../../../lib/blocklist.js';
+import { getRecord, getContentsMeta, putRecord } from '../../../lib/registry.js';
+import { createRateLimiter } from '../../../lib/throttle.js';
+
+// Swaps the user's claimed name for a new one. Releases the old name
+// FIRST, then creates the new record with everything carried over
+// (CNAME, subdomains, profile). Vercel-specific records (_vercel TXT) are
+// stripped since the verification token is domain-specific and won't work
+// on the new name — the client triggers the Vercel setup flow for the new
+// domain immediately after the swap.
+//
+// Release-before-create is deliberate: if the run dies halfway, the user
+// briefly owns nothing (retryable, harmless) instead of silently owning
+// two names, which would break the one-name-per-account invariant the PR
+// path enforces.
+
+const SWAP_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const SWAP_MAX = 2;
+const takeSwap = createRateLimiter({ windowMs: SWAP_WINDOW_MS, max: SWAP_MAX });
+
+export async function POST(request) {
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
+  if (!session?.login) {
+    return Response.json({ error: 'signin_required' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const from = typeof body.from === 'string' ? body.from.trim().toLowerCase() : '';
+  const to = typeof body.to === 'string' ? body.to.trim().toLowerCase() : '';
+  const confirm = typeof body.confirm === 'string' ? body.confirm.trim().toLowerCase() : '';
+
+  if (!validateName(from).ok || !validateName(to).ok) {
+    return Response.json({ error: 'invalid_name' }, { status: 400 });
+  }
+  if (from === to) {
+    return Response.json({ error: 'same_name', detail: 'pick a different name to swap to' }, { status: 400 });
+  }
+  if (confirm !== to) {
+    return Response.json({ error: 'confirm_mismatch', detail: 'type the new name exactly to confirm' }, { status: 400 });
+  }
+
+  const budget = takeSwap(session.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
+  }
+
+  const uncachedFetch = (url, init) => fetch(url, init, { cache: 'no-store' });
+  const token = process.env.REGISTRY_TOKEN;
+
+  // Read the current record to verify ownership
+  const meta = await getContentsMeta(`domains/${from}.json`, {
+    token,
+    fetchImpl: uncachedFetch,
+  }).catch(() => null);
+
+  if (!meta) {
+    return Response.json({ error: 'not_found' }, { status: 404 });
+  }
+  if (meta.data.owner?.github?.toLowerCase() !== session.login.toLowerCase()) {
+    return Response.json({ error: 'not_owner' }, { status: 403 });
+  }
+
+  // Check the new name is available
+  const existing = await getRecord(to, { token, fetchImpl: uncachedFetch }).catch(() => null);
+  if (existing) {
+    return Response.json({ error: 'taken', detail: `${to}.runs-on.dev is already claimed` }, { status: 409 });
+  }
+
+  // Check the new name isn't reserved
+  const reserved = isReserved(to);
+  if (reserved.reserved) {
+    return Response.json({ error: 'reserved', detail: `${to} is reserved (${reserved.list})` }, { status: 403 });
+  }
+
+  // Build the new record: copy everything except name-specific fields
+  const newRecord = {
+    name: to,
+    owner: meta.data.owner,
+    claimedAt: new Date().toISOString(),
+    records: { ...(meta.data.records ?? {}) },
+  };
+
+  // Copy subdomains but strip the _vercel TXT — the verification token is
+  // bound to the old domain and won't work on the new one. The Vercel setup
+  // flow (triggered by the client after swap) adds a fresh one.
+  if (meta.data.subdomains) {
+    const subs = { ...meta.data.subdomains };
+    delete subs._vercel;
+    if (Object.keys(subs).length > 0) {
+      newRecord.subdomains = subs;
+    }
+  }
+
+  // Copy profile
+  if (meta.data.profile) {
+    newRecord.profile = meta.data.profile;
+  }
+
+  // Step 1: Release the old record first (SHA from our read, so if anything
+  // changed underneath us the delete fails safely and nothing is lost). If
+  // this fails, the swap has not happened at all and the user still owns
+  // their old name — report failure honestly.
+  const deleteRes = await fetch(
+    `https://api.github.com/repos/${process.env.REGISTRY_REPO ?? 'zordhalo/runs-on.dev'}/contents/domains/${from}.json`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: `swap: ${from} → ${to} by @${session.login}`,
+        sha: meta.sha,
+      }),
+    },
+  ).catch(() => null);
+
+  if (!deleteRes || !deleteRes.ok) {
+    return Response.json({
+      ok: false,
+      error: 'release_failed',
+      detail: `could not release ${from}.runs-on.dev; nothing was changed, try again`,
+    }, { status: 500 });
+  }
+
+  // Step 2: Create the new record. putRecord refuses to overwrite, so if
+  // someone claimed the new name in the seconds since our check, this fails
+  // cleanly. The old name is already released at this point; the user owns
+  // nothing for the moment, which a retry fixes.
+  const createResult = await putRecord(newRecord, { token, fetchImpl: uncachedFetch });
+  if (!createResult.ok) {
+    const taken = createResult.reason === 'exists';
+    return Response.json({
+      ok: false,
+      error: taken ? 'taken' : 'create_failed',
+      detail: taken
+        ? `${from}.runs-on.dev was released, but ${to} was just claimed by someone else. Claim a different name from the homepage.`
+        : `${from}.runs-on.dev was released, but the new record could not be created. Claim ${to} again from the homepage while it is still free.`,
+    }, { status: taken ? 409 : 500 });
+  }
+
+  return Response.json({
+    ok: true,
+    name: to,
+    oldName: from,
+    message: `swapped ${from}.runs-on.dev → ${to}.runs-on.dev`,
+  });
+}

--- a/app/manage/page.jsx
+++ b/app/manage/page.jsx
@@ -71,18 +71,17 @@ export default async function Manage() {
 
 function Shell({ children }) {
   return (
-    <main className="mx-auto max-w-2xl px-6 py-16 sm:py-24">
+    <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6 sm:py-12">
       <p className="font-(family-name:--font-mono) text-xs tracking-[0.14em] text-(--color-muted) uppercase">
         Manage
       </p>
-      <h1 className="mt-3 font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink) sm:text-3xl">
-        Point your name
+      <h1 className="mt-2 font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink) sm:text-3xl">
+        Your name
       </h1>
-      <p className="mt-3 text-sm leading-relaxed text-(--color-muted)">
-        Saving writes your record straight to the registry and DNS updates within
-        seconds. Every save is a public commit, the same as a merged pull request.
+      <p className="mt-2 text-sm leading-relaxed text-(--color-muted)">
+        Changes save straight to the registry. DNS updates within seconds.
       </p>
-      <div className="mt-8 space-y-8">{children}</div>
+      <div className="mt-8 space-y-6">{children}</div>
     </main>
   );
 }

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -11,11 +11,98 @@ import {
 const MAX_SUBDOMAINS = 10;
 const MAX_LINKS = 8;
 
-const MODE_LABELS = [
-  { id: 'card', label: 'profile card', hint: 'No DNS records. The name serves your GitHub card.' },
-  { id: 'cname', label: 'CNAME', hint: 'Point at a host your provider gave you. Stands alone.' },
-  { id: 'advanced', label: 'A / TXT / MX', hint: 'IPv4 addresses, text records, and mail exchangers. Combinable.' },
-  { id: 'url', label: 'URL redirect', hint: 'Redirect visitors to an absolute http(s) URL. Stands alone.' },
+// The "did it work?" panel: polls /api/dns-check after a save and compares
+// live DNS against what was committed.
+function VerifyPanel({ name, cname, url, hasDns, vercelTxt }) {
+  const [check, setCheck] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    const tick = async () => {
+      try {
+        const res = await fetch(`/api/dns-check?name=${encodeURIComponent(name)}`);
+        if (res.ok && alive) setCheck(await res.json());
+      } catch {}
+    };
+    tick();
+    const done = check && cnameOk(check, cname) && pageOk(check, { cname, url, hasDns, vercelTxt });
+    const timer = done ? null : setInterval(tick, 8000);
+    return () => { alive = false; if (timer) clearInterval(timer); };
+  }, [name, cname, url, hasDns, vercelTxt, check]);
+
+  if (!check) {
+    return (
+      <div className="border-t border-(--color-rule) px-6 py-4 font-(family-name:--font-mono) text-xs text-(--color-muted) sm:px-8">
+        {'// checking DNS…'}
+      </div>
+    );
+  }
+
+  const rows = [];
+  if (cname) {
+    const resolved = check.cname ?? [];
+    rows.push({
+      ok: resolved.some((r) => r.toLowerCase() === cname.toLowerCase()),
+      text: resolved.length ? `CNAME → ${resolved[0]}` : 'CNAME not visible yet',
+    });
+  }
+  if (vercelTxt.length > 0) {
+    const zone = check.txt?.zoneVercel ?? [];
+    const published = vercelTxt.some((v) => zone.includes(v));
+    rows.push({
+      ok: published,
+      text: published ? '_vercel TXT published at the zone' : '_vercel TXT not at the zone yet',
+    });
+  }
+  const page = pageState(check, { cname, url, hasDns });
+  rows.push({ ok: page.ok, text: page.text });
+
+  return (
+    <div className="border-t border-(--color-rule) px-6 py-4 sm:px-8">
+      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{'// did it work?'}</p>
+      <ul className="mt-2 space-y-1 font-(family-name:--font-mono) text-xs">
+        {rows.map((row, i) => (
+          <li key={i} className={row.ok ? 'text-(--color-ink)' : 'text-(--color-muted)'}>
+            {row.ok ? '✓' : '…'} {row.text}
+          </li>
+        ))}
+      </ul>
+      {page.hint && <p className="mt-2 text-xs leading-relaxed text-(--color-muted)">{page.hint}</p>}
+    </div>
+  );
+}
+
+function cnameOk(check, cname) {
+  if (!cname) return true;
+  return (check.cname ?? []).some((r) => r.toLowerCase() === cname.toLowerCase());
+}
+
+function pageOk(check, expected) {
+  return pageState(check, expected).ok;
+}
+
+function pageState(check, { cname, url, hasDns }) {
+  const status = check.serving?.status;
+  if (status === 'ok') return { ok: true, text: `serving your site — ${check.serving.title ?? ''}` };
+  if (status === 'redirect' && url) return { ok: true, text: `redirecting to ${check.serving.finalUrl ?? url}` };
+  if (status === 'card' && !hasDns && !cname) return { ok: true, text: 'serving the profile card (as picked)' };
+  if (status === 'card' || status === 'stuck') {
+    return {
+      ok: false,
+      text: 'still serving the profile card',
+      hint: cname?.includes('vercel-dns')
+        ? 'DNS is live but Vercel has not re-checked. Removing and re-adding the domain in your Vercel project settings forces a fresh check.'
+        : 'DNS may still be propagating.',
+    };
+  }
+  return { ok: false, text: 'no answer yet — DNS may still be propagating' };
+}
+
+const PROVIDERS = [
+  { id: 'card', label: 'Profile Card', hint: 'Serve a card built from your GitHub profile. No DNS needed.', icon: 'M3 10h18M7 15h.01M11 15h.01M15 15h.01M7 19h10a4 4 0 0 0 4-4V8a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v7a4 4 0 0 0 4 4Z' },
+  { id: 'cname', label: 'Custom Domain', hint: 'Point at any host your provider gave you via CNAME.', icon: 'M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71' },
+  { id: 'url', label: 'Redirect', hint: 'Send visitors to any URL. Simple and fast.', icon: 'M15 3h6v6M10 14L21 3M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6' },
+  { id: 'advanced', label: 'Advanced DNS', hint: 'A, TXT, and MX records. For power users.', icon: 'M4 6h16M4 12h16M4 18h16' },
 ];
 
 export default function RecordForm({ name, record }) {
@@ -32,38 +119,35 @@ export default function RecordForm({ name, record }) {
   const [displayName, setDisplayName] = useState(record.profile?.name ?? '');
   const [bio, setBio] = useState(record.profile?.bio ?? '');
   const [linkRows, setLinkRows] = useState(() => profileToRows(record.profile));
+  const [dnsStatus, setDnsStatus] = useState(null);
+
+  useEffect(() => {
+    fetch(`/api/dns-check?name=${encodeURIComponent(name)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => { if (data) setDnsStatus(data.serving?.status); })
+      .catch(() => {});
+  }, [name]);
+
+  function selectProvider(id) {
+    setMode(id);
+    setStatus(null);
+    setErrors([]);
+  }
 
   function setRow(i, patch) {
     setSubRows((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r)));
     setStatus(null);
     setErrors([]);
   }
-
-  function addRow() {
-    setSubRows((rows) => [...rows, { label: '', type: 'TXT', value: '' }]);
-    setStatus(null);
-  }
-
-  function removeRow(i) {
-    setSubRows((rows) => rows.filter((_, j) => j !== i));
-    setStatus(null);
-  }
-
-  function setLinkRow(i, patch) {
-    setLinkRows((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r)));
-    setStatus(null);
-  }
-
-  function removeLink(i) {
-    setLinkRows((rows) => rows.filter((_, j) => j !== i));
-    setStatus(null);
-  }
+  function addRow() { setSubRows((rows) => [...rows, { label: '', type: 'TXT', value: '' }]); setStatus(null); }
+  function removeRow(i) { setSubRows((rows) => rows.filter((_, j) => j !== i)); setStatus(null); }
+  function setLinkRow(i, patch) { setLinkRows((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r))); setStatus(null); }
+  function removeLink(i) { setLinkRows((rows) => rows.filter((_, j) => j !== i)); setStatus(null); }
 
   async function save(event) {
     event.preventDefault();
     setStatus('saving');
     setErrors([]);
-
     const res = await fetch('/api/records', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -71,463 +155,408 @@ export default function RecordForm({ name, record }) {
         name,
         records: buildRecords(mode, { cname, url, a, txt, mx }),
         subdomains: buildSubdomains(subRows),
-        // null is the explicit "no profile" — it removes the block from the
-        // record, where omitting the key would leave an older form's profile
-        // silently in place.
         profile: buildProfile({ name: displayName, bio, linkRows }) ?? null,
       }),
     });
     const body = await res.json().catch(() => ({}));
-
-    if (res.ok) {
-      setCommit(body.commit ?? null);
-      // A save that changed nothing is not a commit and does not touch DNS,
-      // so it must not claim to have done either.
-      setStatus(body.unchanged ? 'unchanged' : 'saved');
-      return;
-    }
-    setErrors(body.details ?? [MESSAGES[body.error] ?? 'Could not save just now.']);
+    if (res.ok) { setCommit(body.commit ?? null); setStatus(body.unchanged ? 'unchanged' : 'saved'); return; }
+    setErrors(body.details ?? ['Could not save just now.']);
     setStatus('error');
   }
 
   const sha = shortSha(commit);
+  const statusPill = dnsStatus === 'ok' ? { label: 'Verified', color: '#22c55e' }
+    : dnsStatus === 'stuck' ? { label: 'Pending', color: '#eab308' }
+    : dnsStatus === 'redirect' ? { label: 'Redirect', color: '#3b82f6' }
+    : { label: 'Card', color: '#9ca3af' };
 
   return (
-    <form
-      onSubmit={save}
-      className="border border-(--color-rule) bg-(--color-card) p-6 sm:p-8"
-    >
-      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-        domains/{name}.json
-      </p>
-      <h2 className="mt-1 font-(family-name:--font-display) text-xl font-medium tracking-tight text-(--color-ink)">
-        {name}.runs-on.dev
-      </h2>
+    <form onSubmit={save} className="border border-(--color-rule) bg-(--color-card)">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4 border-b border-(--color-rule) px-6 py-5 sm:px-8">
+        <div>
+          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">domains/{name}.json</p>
+          <h2 className="mt-1 font-(family-name:--font-display) text-xl font-medium tracking-tight text-(--color-ink) sm:text-2xl">{name}.runs-on.dev</h2>
+        </div>
+        <span className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 font-(family-name:--font-mono) text-xs" style={{ borderColor: statusPill.color, color: statusPill.color }}>
+          <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: statusPill.color }} />
+          {statusPill.label}
+        </span>
+      </div>
 
-      <fieldset className="mt-6">
-        <legend className="sr-only">Record type</legend>
-        <div className="flex flex-wrap gap-2">
-          {MODE_LABELS.map((m) => (
-            <button
-              key={m.id}
-              type="button"
-              onClick={() => { setMode(m.id); setStatus(null); setErrors([]); }}
-              aria-pressed={mode === m.id}
-              className="border px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
-              style={mode === m.id
-                ? { borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }
-                : { borderColor: 'var(--color-rule)' }}
+      {/* Provider tiles */}
+      <div className="px-4 py-5 sm:px-8">
+        <p className="text-sm font-medium text-(--color-ink)">Where does your name go?</p>
+        <div className="mt-3 flex gap-1.5 sm:gap-3">
+          {PROVIDERS.map((p) => (
+            <button key={p.id} type="button" onClick={() => selectProvider(p.id)}
+              className={`flex flex-1 flex-col items-center gap-1.5 border p-2 text-center transition-all sm:gap-2 sm:p-4 ${mode === p.id ? 'border-(--color-signal) bg-(--color-signal)/5' : 'border-(--color-rule) hover:border-(--color-muted)'}`}
             >
-              {m.label}
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className={`sm:h-6 sm:w-6 ${mode === p.id ? 'text-(--color-signal)' : 'text-(--color-muted)'}`}>
+                <path d={p.icon} />
+              </svg>
+              <span className={`text-[10px] font-medium sm:text-xs ${mode === p.id ? 'text-(--color-signal)' : 'text-(--color-ink)'}`}>{p.label}</span>
             </button>
           ))}
         </div>
-        <p className="mt-2 text-xs text-(--color-muted)">
-          {MODE_LABELS.find((m) => m.id === mode)?.hint}
-        </p>
-      </fieldset>
-
-      <div className="mt-5 space-y-4">
-        {mode === 'cname' && (
-          <Input label="CNAME" value={cname} onChange={setCname} placeholder="cname.vercel-dns.com" />
-        )}
-        {mode === 'url' && (
-          <Input label="URL" value={url} onChange={setUrl} placeholder="https://example.com" />
-        )}
-        {mode === 'advanced' && (
-          <>
-            <Area label="A" value={a} onChange={setA} placeholder={'76.76.21.21'} hint="One IPv4 address per line." />
-            <Area label="TXT" value={txt} onChange={setTxt} placeholder={'did=did:plc:abc123'} hint="One string per line, up to 255 characters." />
-            <Area label="MX" value={mx} onChange={setMx} placeholder={'10 mx.example.com'} hint="One 'priority hostname' per line, up to 5." />
-          </>
-        )}
-        {mode === 'card' && (
-          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-            {'"records": {}'}
-          </p>
-        )}
+        <p className="mt-2 text-xs leading-relaxed text-(--color-muted)">{PROVIDERS.find((p) => p.id === mode)?.hint}</p>
       </div>
 
-      <fieldset className="mt-8 border-t border-(--color-rule) pt-5">
-        <legend className="sr-only">Subdomains</legend>
-        <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-          subdomains
-        </p>
-        <p className="mt-1 text-xs leading-relaxed text-(--color-muted)">
-          One label deep, for records a provider asks you to put somewhere other than the
-          name itself, like <span className="font-(family-name:--font-mono)">_atproto</span>{' '}
-          for a Bluesky handle or{' '}
-          <span className="font-(family-name:--font-mono)">_vercel</span> for domain
-          verification. These are separate names, so a record here does not conflict with a
-          CNAME above.
-        </p>
-
-        {subRows.length > 0 && (
-          <div className="mt-4 space-y-3">
-            {subRows.map((row, i) => (
-              <div key={i} className="border border-(--color-rule) p-3">
-                <div className="flex flex-wrap items-center gap-2">
-                  <input
-                    value={row.label}
-                    onChange={(e) => setRow(i, { label: e.target.value })}
-                    placeholder="_vercel"
-                    aria-label="Subdomain label"
-                    spellCheck={false}
-                    autoCapitalize="off"
-                    autoCorrect="off"
-                    className="w-32 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                  />
-                  <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-                    .{name}.runs-on.dev
-                  </span>
-                  <select
-                    value={row.type}
-                    onChange={(e) => setRow(i, { type: e.target.value })}
-                    aria-label="Record type"
-                    className="border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                  >
-                    {SUBDOMAIN_TYPES.map((t) => (
-                      <option key={t} value={t}>{t}</option>
-                    ))}
-                  </select>
-                  <button
-                    type="button"
-                    onClick={() => removeRow(i)}
-                    className="ml-auto font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)"
-                  >
-                    remove
-                  </button>
-                </div>
-                <textarea
-                  value={row.value}
-                  onChange={(e) => setRow(i, { value: e.target.value })}
-                  placeholder={SUB_PLACEHOLDER[row.type]}
-                  rows={2}
-                  aria-label="Record value"
-                  spellCheck={false}
-                  autoCapitalize="off"
-                  autoCorrect="off"
-                  className="mt-2 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                />
-                <span className="mt-1 block text-xs text-(--color-muted)">
-                  {SUB_HINT[row.type]}
-                </span>
+      {/* Profile Card mode */}
+      {mode === 'card' && (
+        <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+          <p className="text-sm font-medium text-(--color-ink)">Profile card</p>
+          <p className="mt-1 text-xs text-(--color-muted)">Your name serves a card built from your GitHub profile. Override any field below.</p>
+          <div className="mt-4 space-y-4">
+            <label className="block">
+              <span className="text-xs text-(--color-muted)">display name</span>
+              <input value={displayName} onChange={(e) => { setDisplayName(e.target.value); setStatus(null); }} placeholder="GitHub profile name" className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+            </label>
+            <label className="block">
+              <span className="text-xs text-(--color-muted)">bio</span>
+              <textarea value={bio} onChange={(e) => { setBio(e.target.value); setStatus(null); }} placeholder="GitHub profile bio" rows={2} className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+            </label>
+            {linkRows.map((row, i) => (
+              <div key={i} className="flex flex-wrap items-center gap-2">
+                <input value={row.label} onChange={(e) => setLinkRow(i, { label: e.target.value })} placeholder="My portfolio" aria-label="Link label" className="w-36 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+                <input value={row.url} onChange={(e) => setLinkRow(i, { url: e.target.value })} placeholder="https://…" aria-label="Link URL" spellCheck={false} className="min-w-0 flex-1 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+                <button type="button" onClick={() => removeLink(i)} className="font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)">remove</button>
               </div>
             ))}
+            {linkRows.length < MAX_LINKS && (
+              <button type="button" onClick={() => { setLinkRows((rows) => [...rows, { label: '', url: '' }]); setStatus(null); }} className="border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">+ add a link</button>
+            )}
           </div>
-        )}
-
-        {subRows.length < MAX_SUBDOMAINS ? (
-          <button
-            type="button"
-            onClick={addRow}
-            className="mt-3 border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
-          >
-            + add a subdomain record
-          </button>
-        ) : (
-          <p className="mt-3 font-(family-name:--font-mono) text-xs text-(--color-muted)">
-            {`// ${MAX_SUBDOMAINS} is the limit`}
-          </p>
-        )}
-      </fieldset>
-
-      <fieldset className="mt-8 border-t border-(--color-rule) pt-5">
-        <legend className="sr-only">Profile card</legend>
-        <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-          profile
-        </p>
-        <p className="mt-1 text-xs leading-relaxed text-(--color-muted)">
-          What the profile card shows at{' '}
-          <span className="font-(family-name:--font-mono)">{name}.runs-on.dev</span>. Every
-          field falls back to your GitHub profile when empty; links are yours to add.
-        </p>
-
-        <div className="mt-4 space-y-4">
-          <Input
-            label="display name"
-            value={displayName}
-            onChange={(v) => { setDisplayName(v); setStatus(null); }}
-            placeholder="GitHub profile name"
-          />
-          <Area
-            label="bio"
-            value={bio}
-            onChange={(v) => { setBio(v); setStatus(null); }}
-            placeholder="GitHub profile bio"
-            hint="Up to 200 characters."
-          />
-
-          {linkRows.length > 0 && (
-            <div className="space-y-2">
-              {linkRows.map((row, i) => (
-                <div key={i} className="flex flex-wrap items-center gap-2">
-                  <input
-                    value={row.label}
-                    onChange={(e) => setLinkRow(i, { label: e.target.value })}
-                    placeholder="My portfolio"
-                    aria-label="Link label"
-                    className="w-36 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                  />
-                  <input
-                    value={row.url}
-                    onChange={(e) => setLinkRow(i, { url: e.target.value })}
-                    placeholder="https://…"
-                    aria-label="Link URL"
-                    spellCheck={false}
-                    autoCapitalize="off"
-                    autoCorrect="off"
-                    className="min-w-0 flex-1 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => removeLink(i)}
-                    className="font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)"
-                  >
-                    remove
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {linkRows.length < MAX_LINKS ? (
-            <button
-              type="button"
-              onClick={() => { setLinkRows((rows) => [...rows, { label: '', url: '' }]); setStatus(null); }}
-              className="border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
-            >
-              + add a link
-            </button>
-          ) : (
-            <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-              {`// ${MAX_LINKS} is the limit`}
-            </p>
-          )}
         </div>
-      </fieldset>
-
-      <div className="mt-6 flex flex-wrap items-center gap-4">
-        <button
-          type="submit"
-          disabled={status === 'saving'}
-          className="border px-5 py-2.5 font-(family-name:--font-mono) text-sm transition-opacity hover:opacity-90 disabled:opacity-50"
-          style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}
-        >
-          {status === 'saving' ? 'Saving\u2026' : 'Save record'}
-        </button>
-
-        {status === 'unchanged' && (
-          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-            {'// no changes to save'}
-          </p>
-        )}
-
-        {status === 'saved' && (
-          <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-            {'// '}
-            {sha ? (
-              <a className="text-(--color-signal) underline" href={commitUrl(commit)} target="_blank" rel="noopener noreferrer">
-                commit {sha}
-              </a>
-            ) : 'saved'}
-            {' — DNS updates within seconds'}
-          </p>
-        )}
-      </div>
-
-      {errors.length > 0 && (
-        <ul className="mt-4 space-y-1 font-(family-name:--font-mono) text-xs text-(--color-signal)">
-          {errors.map((e) => <li key={e}>{e}</li>)}
-        </ul>
       )}
 
+      {/* Custom Domain mode */}
+      {mode === 'cname' && (
+        <>
+          <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+            <label className="block">
+              <span className="text-sm font-medium text-(--color-ink)">CNAME target</span>
+              <input value={cname} onChange={(e) => { setCname(e.target.value); setStatus(null); }} placeholder="your-provider.example.com" spellCheck={false} autoCapitalize="off" className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+            </label>
+            <p className="mt-2 text-xs text-(--color-muted)">Copy the exact value from your provider.</p>
+          </div>
+          <SubdomainRecords name={name} subRows={subRows} setRow={setRow} addRow={addRow} removeRow={removeRow} />
+        </>
+      )}
+
+      {/* Redirect mode */}
+      {mode === 'url' && (
+        <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+          <label className="block">
+            <span className="text-sm font-medium text-(--color-ink)">Redirect URL</span>
+            <input value={url} onChange={(e) => { setUrl(e.target.value); setStatus(null); }} placeholder="https://your-site.com" spellCheck={false} className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+          </label>
+        </div>
+      )}
+
+      {/* Advanced DNS mode */}
+      {mode === 'advanced' && (
+        <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+          <p className="text-sm font-medium text-(--color-ink)">DNS records</p>
+          <div className="mt-4 space-y-4">
+            <TextArea label="A (IPv4)" value={a} onChange={(v) => { setA(v); setStatus(null); }} placeholder="76.76.21.21" hint="One address per line." />
+            <TextArea label="TXT" value={txt} onChange={(v) => { setTxt(v); setStatus(null); }} placeholder="v=spf1 -all" hint="One string per line." />
+            <TextArea label="MX" value={mx} onChange={(v) => { setMx(v); setStatus(null); }} placeholder="10 mx.example.com" hint="One per line, up to 5." />
+          </div>
+          <SubdomainRecords name={name} subRows={subRows} setRow={setRow} addRow={addRow} removeRow={removeRow} />
+        </div>
+      )}
+
+      {/* Save */}
+      <div className="flex flex-wrap items-center gap-4 border-t border-(--color-rule) px-6 py-5 sm:px-8">
+        <button type="submit" disabled={status === 'saving'} className="border px-5 py-2.5 font-(family-name:--font-mono) text-sm transition-opacity hover:opacity-90 disabled:opacity-50" style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}>
+          {status === 'saving' ? 'Saving…' : 'Save changes'}
+        </button>
+        {status === 'unchanged' && <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">no changes to save</span>}
+        {status === 'saved' && (
+          <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+            {sha ? <a className="text-(--color-signal) underline" href={commitUrl(commit)} target="_blank" rel="noopener noreferrer">commit {sha}</a> : 'saved'}
+          </span>
+        )}
+        {errors.length > 0 && <ul className="mt-2 space-y-1 font-(family-name:--font-mono) text-xs text-(--color-signal)">{errors.map((e) => <li key={e}>{e}</li>)}</ul>}
+      </div>
+
+      {/* Verify panel: the "did it work?" feedback after a save, part of
+          the manage page since PR #57. */}
       {status === 'saved' && (
         <VerifyPanel
           name={name}
           cname={mode === 'cname' ? cname.trim() : null}
           url={mode === 'url' ? url.trim() : null}
-          hasDns={mode !== 'card' && mode !== 'url' || subRows.length > 0}
+          hasDns={mode === 'advanced'}
           vercelTxt={subRows
             .filter((r) => r.label.trim().toLowerCase() === '_vercel' && r.type === 'TXT')
             .flatMap((r) => r.value.split('\n').map((v) => v.trim()).filter(Boolean))}
         />
       )}
+
+      {/* Danger zone: release the name back to the pool */}
+      <SwapZone name={name} />
+      <ReleaseZone name={name} />
     </form>
   );
 }
 
-// The "did it work?" half of saving. DNS answers and the wildcard are public,
-// so this reads /api/dns-check (no session, no secrets) and compares live
-// resolution against what was just committed, until everything checks out or
-// a few minutes pass. The Vercel line exists because a freshly published
-// CNAME + TXT still serves the profile card until Vercel is asked to
-// re-check — the exact trap that every early Vercel-pointed name fell into
-// while looking perfectly configured.
-function VerifyPanel({ name, cname, url, hasDns, vercelTxt }) {
-  const [check, setCheck] = useState(null);
+// ── Swap zone (trade this name for a different one) ─────────
+function SwapZone({ name }) {
+  const [open, setOpen] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [confirmText, setConfirmText] = useState('');
+  const [swapping, setSwapping] = useState(false);
+  const [result, setResult] = useState(null);
 
-  useEffect(() => {
-    let alive = true;
-    const tick = async () => {
-      try {
-        const res = await fetch(`/api/dns-check?name=${encodeURIComponent(name)}`);
-        if (res.ok && alive) setCheck(await res.json());
-      } catch {
-        // Next tick retries; a transient network failure is not a verdict.
+  const validateNewName = (v) => {
+    const trimmed = v.trim().toLowerCase();
+    return /^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$/.test(trimmed) && trimmed.length >= 2 && trimmed !== name;
+  };
+
+  const canSwap = validateNewName(newName) && confirmText.trim().toLowerCase() === newName.trim().toLowerCase();
+
+  const swap = async () => {
+    if (!canSwap) return;
+    setSwapping(true);
+    setResult(null);
+    try {
+      const res = await fetch('/api/swap', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from: name,
+          to: newName.trim().toLowerCase(),
+          confirm: confirmText.trim().toLowerCase(),
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+
+      if (res.ok && body.ok) {
+        setResult({ ok: true, text: body.message });
+        setTimeout(() => { window.location.href = '/manage'; }, 2000);
+      } else {
+        setResult({ ok: false, text: body.detail ?? body.error ?? 'swap failed' });
       }
-    };
-    tick();
-    const done = check && cnameOk(check, cname) && pageOk(check, { cname, url, hasDns, vercelTxt });
-    const timer = done ? null : setInterval(tick, 8000);
-    return () => {
-      alive = false;
-      if (timer) clearInterval(timer);
-    };
-  }, [name, cname, url, hasDns, vercelTxt, check]);
+    } catch {
+      setResult({ ok: false, text: 'network error' });
+    }
+    setSwapping(false);
+  };
 
-  if (!check) {
-    return (
-      <div className="mt-6 border border-(--color-rule) p-4 font-(family-name:--font-mono) text-xs text-(--color-muted)">
-        {'// did it work? — checking DNS…'}
-      </div>
-    );
-  }
-
-  const rows = [];
-  if (cname) {
-    const resolved = check.cname ?? [];
-    rows.push({
-      ok: resolved.includes(cname) || resolved.some((r) => r.toLowerCase() === cname.toLowerCase()),
-      text: resolved.length
-        ? `CNAME → ${resolved[0]}`
-        : `CNAME not visible yet (updates within seconds, caches up to 10 min)`,
-    });
-  }
-  if (vercelTxt.length > 0) {
-    const zone = check.txt?.zoneVercel ?? [];
-    const published = vercelTxt.some((v) => zone.includes(v));
-    rows.push({
-      ok: published,
-      text: published
-        ? '_vercel TXT published at the zone'
-        : '_vercel TXT not at the zone yet — the mirror publishes it on the sync',
-    });
-  }
-
-  const page = pageState(check, { cname, url, hasDns });
-  rows.push({ ok: page.ok, text: page.text });
+  const nameAvailable = validateNewName(newName);
 
   return (
-    <div className="mt-6 border border-(--color-rule) p-4">
-      <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
-        {'// did it work?'}
-      </p>
-      <ul className="mt-2 space-y-1 font-(family-name:--font-mono) text-xs sm:text-[13px]">
-        {rows.map((row, i) => (
-          <li key={i} className={row.ok ? 'text-(--color-ink)' : 'text-(--color-muted)'}>
-            {row.ok ? '✓' : '…'} {row.text}
-          </li>
-        ))}
-      </ul>
-      {page.hint && (
-        <p className="mt-2 border-t border-(--color-rule) pt-2 text-xs leading-relaxed text-(--color-muted)">
-          {page.hint}
-        </p>
+    <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+      {!open ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="font-(family-name:--font-mono) text-xs text-(--color-signal) underline hover:opacity-80"
+        >
+          swap this name for a different one
+        </button>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-(--color-ink)">Swap {name}.runs-on.dev</p>
+          <p className="text-xs leading-relaxed text-(--color-muted)">
+            Trade this name for a new one. All your settings (CNAME, profile, subdomains)
+            carry over. The old name is released immediately and becomes available to anyone.
+          </p>
+
+          <div className="space-y-2">
+            <input
+              value={newName}
+              onChange={(e) => { setNewName(e.target.value); setResult(null); }}
+              placeholder="new-name"
+              aria-label="New name to swap to"
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+              className={`w-full border bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none ${nameAvailable || !newName ? 'border-(--color-rule) focus:border-(--color-signal)' : 'border-red-300'}`}
+            />
+            {newName && !nameAvailable && (
+              <p className="text-xs text-red-500">
+                {newName.trim().toLowerCase() === name ? "that's your current name" : 'invalid name (2-32 chars, a-z 0-9 hyphens)'}
+              </p>
+            )}
+            {nameAvailable && (
+              <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+                → {newName.trim().toLowerCase()}.runs-on.dev
+              </p>
+            )}
+          </div>
+
+          {nameAvailable && (
+            <div>
+              <input
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder={`type "${newName.trim().toLowerCase()}" to confirm`}
+                aria-label="Type the new name to confirm swap"
+                spellCheck={false}
+                autoCapitalize="off"
+                className="w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
+              />
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={swap}
+              disabled={swapping || !canSwap}
+              className="border px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{
+                borderColor: 'var(--color-signal)',
+                background: 'var(--color-signal)',
+                color: 'var(--color-paper)',
+              }}
+            >
+              {swapping ? 'Swapping…' : `Swap to ${newName.trim().toLowerCase() || '…'}`}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setOpen(false); setNewName(''); setConfirmText(''); setResult(null); }}
+              className="border border-(--color-rule) px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
+            >
+              Cancel
+            </button>
+          </div>
+
+          {result && (
+            <p className={`text-xs font-(family-name:--font-mono) ${result.ok ? 'text-green-600' : 'text-red-500'}`}>
+              {result.ok ? '✓ ' : '✗ '}{result.text}
+            </p>
+          )}
+        </div>
       )}
     </div>
   );
 }
 
-function cnameOk(check, cname) {
-  if (!cname) return true;
-  const resolved = check.cname ?? [];
-  return resolved.some((r) => r.toLowerCase() === cname.toLowerCase());
-}
+// ── Release zone (give the name back to the pool) ───────────
+function ReleaseZone({ name }) {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+  const [releasing, setReleasing] = useState(false);
+  const [result, setResult] = useState(null);
 
-function pageOk(check, expected) {
-  return pageState(check, expected).ok;
-}
+  const release = async () => {
+    if (confirmText.trim().toLowerCase() !== name) return;
+    setReleasing(true);
+    setResult(null);
+    try {
+      const res = await fetch('/api/release', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, confirm: confirmText.trim().toLowerCase() }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok && body.ok) {
+        setResult({ ok: true, text: body.message });
+        // Redirect to homepage after a short delay so the user sees the confirmation
+        setTimeout(() => { window.location.href = '/'; }, 2000);
+      } else {
+        setResult({ ok: false, text: body.detail ?? body.error ?? 'release failed' });
+      }
+    } catch {
+      setResult({ ok: false, text: 'network error' });
+    }
+    setReleasing(false);
+  };
 
-function pageState(check, { cname, url, hasDns }) {
-  const status = check.serving?.status;
-  const isVercel = typeof cname === 'string' && cname.includes('vercel-dns');
-
-  if (status === 'ok') return { ok: true, text: `serving your site — ${check.serving.title ?? ''}` };
-  if (status === 'redirect' && url) {
-    return { ok: true, text: `redirecting to ${check.serving.finalUrl ?? url}` };
-  }
-  if (status === 'card' && !hasDns && !cname) {
-    return { ok: true, text: 'serving the profile card (no DNS records — as picked)' };
-  }
-  if (status === 'card' || status === 'stuck') {
-    return {
-      ok: false,
-      text: 'still serving the profile card',
-      hint: isVercel
-        ? 'DNS is live but Vercel has not re-checked ownership yet: your Vercel project → Settings → Domains → hit Refresh next to the domain.'
-        : 'DNS may still be propagating; if it persists, your provider may be waiting on a verification record.',
-    };
-  }
-  return { ok: false, text: 'no answer yet — DNS may still be propagating' };
-}
-
-const SUB_PLACEHOLDER = {
-  TXT: 'vc-domain-verify=you.runs-on.dev,PASTE-YOUR-TOKEN',
-  CNAME: 'target.example.com',
-  A: '76.76.21.21',
-  MX: '10 mx.example.com',
-};
-
-const SUB_HINT = {
-  TXT: 'One string per line, up to 255 characters.',
-  CNAME: 'A single hostname. Cannot share this label with another type.',
-  A: 'One IPv4 address per line.',
-  MX: "One 'priority hostname' per line, up to 5.",
-};
-
-const MESSAGES = {
-  signin_required: 'Sign in again to save this record.',
-  not_owner: 'Only the owner of this name may change its record.',
-  not_found: 'That record no longer exists.',
-  stale: 'This record changed somewhere else while you were editing. Reload and try again.',
-  busy: 'The registry is busy. Try again in a few seconds.',
-  rate_limited: 'That is a lot of saves in a short window. Give it a few minutes.',
-  invalid_name: 'That name is not valid.',
-  server_error: 'Could not save just now.',
-};
-
-function Input({ label, value, onChange, placeholder }) {
   return (
-    <label className="block">
-      <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{label}</span>
-      <input
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        spellCheck={false}
-        autoCapitalize="off"
-        autoCorrect="off"
-        className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-      />
-    </label>
+    <div className="border-t border-red-200 px-6 py-5 sm:px-8">
+      {!open ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="font-(family-name:--font-mono) text-xs text-red-500 underline hover:text-red-700"
+        >
+          release this name
+        </button>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-red-600">Release {name}.runs-on.dev?</p>
+          <p className="text-xs leading-relaxed text-(--color-muted)">
+            This permanently deletes your claim. The name becomes available for anyone
+            to claim immediately. DNS records and your profile card are removed.
+            This cannot be undone.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={`type "${name}" to confirm`}
+              aria-label="Type the name to confirm release"
+              spellCheck={false}
+              autoCapitalize="off"
+              className="min-w-0 flex-1 border border-red-200 bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-red-500"
+            />
+            <button
+              type="button"
+              onClick={release}
+              disabled={releasing || confirmText.trim().toLowerCase() !== name}
+              className="border px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{ borderColor: '#dc2626', background: '#dc2626', color: '#fff' }}
+            >
+              {releasing ? 'Releasing…' : 'Release permanently'}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setOpen(false); setConfirmText(''); setResult(null); }}
+              className="border border-(--color-rule) px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
+            >
+              Cancel
+            </button>
+          </div>
+          {result && (
+            <p className={`text-xs font-(family-name:--font-mono) ${result.ok ? 'text-green-600' : 'text-red-500'}`}>
+              {result.ok ? '✓ ' : '✗ '}{result.text}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
-function Area({ label, value, onChange, placeholder, hint }) {
+// ── Subdomain records ────────────────────────────────────────
+function SubdomainRecords({ name, subRows, setRow, addRow, removeRow }) {
+  return (
+    <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+      <p className="text-sm font-medium text-(--color-ink)">Subdomain records</p>
+      <p className="mt-1 text-xs leading-relaxed text-(--color-muted)">
+        Records a provider asks for at a different name, like <code className="font-(family-name:--font-mono)">_vercel</code> for verification.
+      </p>
+      {subRows.map((row, i) => (
+        <div key={i} className="mt-3 border border-(--color-rule) p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <input value={row.label} onChange={(e) => setRow(i, { label: e.target.value })} placeholder="_vercel" aria-label="Subdomain label" spellCheck={false} className="w-32 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+            <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">.{name}.runs-on.dev</span>
+            <select value={row.type} onChange={(e) => setRow(i, { type: e.target.value })} aria-label="Record type" className="border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)">
+              {SUBDOMAIN_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+            <button type="button" onClick={() => removeRow(i)} className="ml-auto font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)">remove</button>
+          </div>
+          <textarea value={row.value} onChange={(e) => setRow(i, { value: e.target.value })} rows={2} aria-label="Record value" spellCheck={false} className="mt-2 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+        </div>
+      ))}
+      {subRows.length < MAX_SUBDOMAINS && (
+        <button type="button" onClick={addRow} className="mt-3 border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">+ add a subdomain record</button>
+      )}
+    </div>
+  );
+}
+
+// ── TextArea helper ──────────────────────────────────────────
+function TextArea({ label, value, onChange, placeholder, hint }) {
   return (
     <label className="block">
-      <span className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{label}</span>
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        rows={2}
-        spellCheck={false}
-        autoCapitalize="off"
-        autoCorrect="off"
-        className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
-      />
+      <span className="text-xs text-(--color-muted)">{label}</span>
+      <textarea value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} rows={2} spellCheck={false} className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
       {hint && <span className="mt-1 block text-xs text-(--color-muted)">{hint}</span>}
     </label>
   );


### PR DESCRIPTION
Split out from #107 per the review there: everything that does not depend on Vercel OAuth, so it can land on its own while the Vercel half is rebuilt against the Integrations API.

**Manage page redesign.** Provider tiles for the four registry-native modes (profile card, custom domain, redirect, advanced DNS), a live status pill in the header from `/api/dns-check`, and sections that show only what the picked mode uses. The `_vercel` subdomain TXT row still gets a zone-published check in the verify panel, since that reads the registry's own DNS, not any Vercel API.

**Self-service name release.** A type-to-confirm danger zone backed by `/api/release`: session and ownership checked, rate limited 2/hour, SHA compare-and-swap delete. DNS cleanup happens on the next sync when the record file disappears.

**Name swap.** Trade the current name for a new one; records, profile, and non-Vercel subdomains carry over (`_vercel` TXT is stripped, the token is domain-specific). Ordering per the review on #107: the old record is released first (SHA compare-and-swap), then the new one created. Every failure path returns `ok:false` with what actually happened; the worst intermediate state is owning nothing for a moment, which a retry fixes.

269/269 tests, build clean.

The Vercel integration (OAuth, one-click setup, force verify, project picker, in-verify TXT pruning) is parked on the `feat/vercel-integration` branch of Hawkay002/runs-on.dev and will be opened as its own PR once it targets the Vercel Integrations API with the scope names from the integration registration.
