### PR TITLE
fix(ci): let the maintenance workflows actually push to main

### DIFF
--- a/.github/workflows/prune-verification.yml
+++ b/.github/workflows/prune-verification.yml
@@ -43,7 +43,14 @@ jobs:
   prune:
     runs-on: ubuntu-latest
     steps:
+      # ssh-key, not the default token: main is protected by a ruleset whose
+      # only bypass this repo can express is DeployKey (Integration bypass is
+      # org-only, and this repo is user-owned). A push authenticated by the
+      # default GITHUB_TOKEN is rejected with GH006 even though the workflow
+      # has contents: write.
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.REGISTRY_DEPLOY_KEY }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'

--- a/.github/workflows/sync-owners.yml
+++ b/.github/workflows/sync-owners.yml
@@ -27,7 +27,13 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      # ssh-key, not the default token: see prune-verification.yml. Without it
+      # this job only ever "succeeded" because the index already matched and it
+      # short-circuited before pushing -- a claim landing by PR merge would have
+      # been rejected with GH006 under a green check.
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.REGISTRY_DEPLOY_KEY }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22'


### PR DESCRIPTION
`prune-verification` and `sync-owners` both commit to `main`, and both were being rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Required status check "test" is expected.
```

`prune-verification` failed loudly — it computed 36 correct record edits, committed them, then lost all three push attempts. `sync-owners` hid the same failure: `/api/claim` writes the owners index itself, so the job kept short-circuiting on *"owners/ already matches domains/, nothing to commit"* and exiting 0 without ever attempting a push. A claim landing by **PR merge** would have needed that push and been rejected — under a green check. A stale index reads as "owns nothing", which hands out a second name.

## Why not just exempt the bot

`github-actions[bot]` cannot be exempted on this repository. Both mechanisms are organization-only and this repo is user-owned:

- Ruleset `bypass_actors` with `actor_type: Integration` → `422: Actor GitHub Actions integration must be part of the ruleset source or owner organization`
- Classic `bypass_pull_request_allowances.apps` → silently ignored, `bypass_apps` stays empty

`DeployKey` is the one bypass actor a user-owned repo can express.

## What changed

`main` now carries a ruleset equivalent to the classic protection it replaces:

| Rule | Before (classic) | Now (ruleset) |
|---|---|---|
| PR required, 1 approval | yes | yes |
| Dismiss stale reviews | yes | yes |
| Require last push approval | yes | yes |
| Conversation resolution | yes | yes |
| Required check `test` | yes | yes |
| Block deletion | yes | yes |
| Block force-push | yes | yes |
| Bypass | repo admins (`enforce_admins: false`) | repo admins + deploy keys |

Both workflows now check out with `ssh-key: ${{ secrets.REGISTRY_DEPLOY_KEY }}`, an ed25519 write deploy key scoped to this repository alone — narrower than a PAT, which would carry the owner's identity across every repo they can reach.

## Honest note on the tradeoff

The ruleset's DeployKey bypass applies to **any** deploy key on the repo, not a named one — GitHub does not let you scope it further. There is exactly one deploy key here (`registry-maintenance`, id 162561950) and adding another requires admin access, but it is a real widening versus naming a single actor. Auditable via `gh api repos/zordhalo/runs-on.dev/keys`.

The previous classic protection is backed up and this is fully reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt