### PR TITLE
fix(manage): editing a profile no longer wipes DNS records

### DIFF
--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -121,6 +121,11 @@ export default function RecordForm({ name, record }) {
   const [linkRows, setLinkRows] = useState(() => profileToRows(record.profile));
   const [dnsStatus, setDnsStatus] = useState(null);
 
+  // What the record held when the page loaded, not what the form currently
+  // builds: the point is to warn that saving in card mode would drop records
+  // that exist on the saved record right now.
+  const hadRecords = Object.keys(record.records ?? {}).length > 0;
+
   useEffect(() => {
     fetch(`/api/dns-check?name=${encodeURIComponent(name)}`)
       .then((res) => (res.ok ? res.json() : null))
@@ -202,31 +207,24 @@ export default function RecordForm({ name, record }) {
         <p className="mt-2 text-xs leading-relaxed text-(--color-muted)">{PROVIDERS.find((p) => p.id === mode)?.hint}</p>
       </div>
 
-      {/* Profile Card mode */}
+      {/* Profile Card mode: this mode means "no DNS records", so entering it
+          and saving clears them. The profile editor itself lives further down,
+          outside the mode switch, because `profile` and `records` are
+          independent keys -- gating the bio behind this mode meant anyone with
+          a CNAME who wanted to edit their bio silently lost their records. */}
       {mode === 'card' && (
         <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
           <p className="text-sm font-medium text-(--color-ink)">Profile card</p>
-          <p className="mt-1 text-xs text-(--color-muted)">Your name serves a card built from your GitHub profile. Override any field below.</p>
-          <div className="mt-4 space-y-4">
-            <label className="block">
-              <span className="text-xs text-(--color-muted)">display name</span>
-              <input value={displayName} onChange={(e) => { setDisplayName(e.target.value); setStatus(null); }} placeholder="GitHub profile name" className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
-            </label>
-            <label className="block">
-              <span className="text-xs text-(--color-muted)">bio</span>
-              <textarea value={bio} onChange={(e) => { setBio(e.target.value); setStatus(null); }} placeholder="GitHub profile bio" rows={2} className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
-            </label>
-            {linkRows.map((row, i) => (
-              <div key={i} className="flex flex-wrap items-center gap-2">
-                <input value={row.label} onChange={(e) => setLinkRow(i, { label: e.target.value })} placeholder="My portfolio" aria-label="Link label" className="w-36 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
-                <input value={row.url} onChange={(e) => setLinkRow(i, { url: e.target.value })} placeholder="https://…" aria-label="Link URL" spellCheck={false} className="min-w-0 flex-1 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
-                <button type="button" onClick={() => removeLink(i)} className="font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)">remove</button>
-              </div>
-            ))}
-            {linkRows.length < MAX_LINKS && (
-              <button type="button" onClick={() => { setLinkRows((rows) => [...rows, { label: '', url: '' }]); setStatus(null); }} className="border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">+ add a link</button>
-            )}
-          </div>
+          <p className="mt-1 text-xs text-(--color-muted)">
+            Your name serves a card built from your GitHub profile. No DNS records are published.
+          </p>
+          {hadRecords && (
+            <p className="mt-3 border border-(--color-signal) px-3 py-2 font-(family-name:--font-mono) text-xs text-(--color-signal)">
+              Saving in this mode removes the DNS records on this name. To edit your card
+              without changing where the name points, pick your current mode above and edit
+              the profile section below instead.
+            </p>
+          )}
         </div>
       )}
 
@@ -266,6 +264,38 @@ export default function RecordForm({ name, record }) {
           <SubdomainRecords name={name} subRows={subRows} setRow={setRow} addRow={addRow} removeRow={removeRow} />
         </div>
       )}
+
+      {/* Profile card fields. Always available, whatever the records mode:
+          `profile` is its own key on the record and is served by the card, so
+          editing a bio must never require touching where the name points. */}
+      <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+        <p className="text-sm font-medium text-(--color-ink)">Profile card details</p>
+        <p className="mt-1 text-xs text-(--color-muted)">
+          {mode === 'card'
+            ? 'Override any field below. Blank falls back to your GitHub profile.'
+            : 'Saved with your name and shown if you ever switch to the profile card. Editing these does not change your DNS.'}
+        </p>
+        <div className="mt-4 space-y-4">
+          <label className="block">
+            <span className="text-xs text-(--color-muted)">display name</span>
+            <input value={displayName} onChange={(e) => { setDisplayName(e.target.value); setStatus(null); }} placeholder="GitHub profile name" className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+          </label>
+          <label className="block">
+            <span className="text-xs text-(--color-muted)">bio</span>
+            <textarea value={bio} onChange={(e) => { setBio(e.target.value); setStatus(null); }} placeholder="GitHub profile bio" rows={2} className="mt-1 w-full resize-y border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+          </label>
+          {linkRows.map((row, i) => (
+            <div key={i} className="flex flex-wrap items-center gap-2">
+              <input value={row.label} onChange={(e) => setLinkRow(i, { label: e.target.value })} placeholder="My portfolio" aria-label="Link label" className="w-36 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+              <input value={row.url} onChange={(e) => setLinkRow(i, { url: e.target.value })} placeholder="https://…" aria-label="Link URL" spellCheck={false} className="min-w-0 flex-1 border border-(--color-rule) bg-transparent px-2 py-1.5 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+              <button type="button" onClick={() => removeLink(i)} className="font-(family-name:--font-mono) text-xs text-(--color-muted) underline hover:text-(--color-ink)">remove</button>
+            </div>
+          ))}
+          {linkRows.length < MAX_LINKS && (
+            <button type="button" onClick={() => { setLinkRows((rows) => [...rows, { label: '', url: '' }]); setStatus(null); }} className="border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">+ add a link</button>
+          )}
+        </div>
+      </div>
 
       {/* Save */}
       <div className="flex flex-wrap items-center gap-4 border-t border-(--color-rule) px-6 py-5 sm:px-8">
@@ -485,7 +515,11 @@ function ReleaseZone({ name }) {
             to claim immediately. DNS records and your profile card are removed.
             This cannot be undone.
           </p>
-          <div className="flex flex-wrap items-center gap-2">
+          {/* Stacked on mobile: the confirm input is flex-1 in the same row as
+              two buttons, which squeezed it to a few characters on a phone --
+              exactly the field someone has to type a name into exactly. Inline
+              again from sm up, where there is room for all three. */}
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
             <input
               value={confirmText}
               onChange={(e) => setConfirmText(e.target.value)}
@@ -493,24 +527,26 @@ function ReleaseZone({ name }) {
               aria-label="Type the name to confirm release"
               spellCheck={false}
               autoCapitalize="off"
-              className="min-w-0 flex-1 border border-red-200 bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-red-500"
+              className="w-full min-w-0 border border-red-200 bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-red-500 sm:w-auto sm:flex-1"
             />
-            <button
-              type="button"
-              onClick={release}
-              disabled={releasing || confirmText.trim().toLowerCase() !== name}
-              className="border px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-90 disabled:opacity-50"
-              style={{ borderColor: '#dc2626', background: '#dc2626', color: '#fff' }}
-            >
-              {releasing ? 'Releasing…' : 'Release permanently'}
-            </button>
-            <button
-              type="button"
-              onClick={() => { setOpen(false); setConfirmText(''); setResult(null); }}
-              className="border border-(--color-rule) px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
-            >
-              Cancel
-            </button>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={release}
+                disabled={releasing || confirmText.trim().toLowerCase() !== name}
+                className="border px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-90 disabled:opacity-50"
+                style={{ borderColor: '#dc2626', background: '#dc2626', color: '#fff' }}
+              >
+                {releasing ? 'Releasing…' : 'Release permanently'}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setOpen(false); setConfirmText(''); setResult(null); }}
+                className="border border-(--color-rule) px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80"
+              >
+                Cancel
+              </button>
+            </div>
           </div>
           {result && (
             <p className={`text-xs font-(family-name:--font-mono) ${result.ok ? 'text-green-600' : 'text-red-500'}`}>

--- a/test/record-fields.test.mjs
+++ b/test/record-fields.test.mjs
@@ -179,3 +179,33 @@ test('profile links round-trip through rows', () => {
     profile,
   );
 });
+
+// The manage form's four provider modes select what goes in `records`, and
+// 'card' means "publish nothing". That is correct on its own -- but the profile
+// editor used to render only inside the card-mode branch, so the single path to
+// editing a bio was to switch modes, and saving then wrote records:{} and
+// silently dropped a live CNAME. The profile fields now sit outside the mode
+// switch. These pin the contract that made the coupling dangerous.
+test('card mode publishes no records', () => {
+  assert.deepEqual(buildRecords('card', { cname: 'example.vercel.app' }), {});
+});
+
+test('a records mode ignores the fields belonging to other modes', () => {
+  assert.deepEqual(
+    buildRecords('cname', { cname: 'example.vercel.app', url: 'https://elsewhere.test' }),
+    { CNAME: 'example.vercel.app' },
+  );
+});
+
+test('building a profile never produces records', () => {
+  // profile and records are independent keys; editing one must not touch the
+  // other, which is exactly what the manage form got wrong.
+  const profile = buildProfile({ name: 'Ada', bio: 'builds things', linkRows: [] });
+  assert.equal('records' in (profile ?? {}), false);
+  assert.equal(profile.bio, 'builds things');
+});
+
+test('modeOf reports cname for a record that has one, so the form opens there', () => {
+  assert.equal(modeOf({ CNAME: 'example.vercel.app' }), 'cname');
+  assert.equal(modeOf({}), 'card');
+});


### PR DESCRIPTION
Reported live on prod: open the manage page with a CNAME set, click **Profile Card** to edit your bio, save — and the CNAME is gone from the record. `sync-dns` then removes it from the zone and the name falls back to the card. DNS caching hides it for a while, which is why it reads as fine right up until it doesn't.

## Root cause

The four provider modes select what goes in `records`, and `card` means "publish nothing":

```js
export function buildRecords(mode, fields = {}) {
  if (mode === 'cname') { ... }
  ...
  return {};   // card
}
```

That's correct on its own. The bug was one level up: the profile editor rendered **only inside the card-mode branch** —

```jsx
{mode === 'card' && (
  <div>… display name … bio … links …</div>
)}
```

so the only route to the bio field was to switch modes, and the save handler then wrote `records: buildRecords('card', …)` → `{}`.

`profile` and `records` are independent keys on a record. Gating one behind a mode that clears the other made data loss the default path for a routine edit.

## Fix

- **Profile fields moved out of the mode switch.** Editable in every mode, with copy that changes to suit: in card mode "override any field below", otherwise "editing these does not change your DNS".
- **Card mode now warns** when the *saved* record has records: "Saving in this mode removes the DNS records on this name." Keyed off what the record held on load, not what the form currently builds, so it says something true.
- Card mode still does what it says — switching to it deliberately and saving still clears records. That's the intended way to go back to the card.

## Also in here

The release confirm row stacks on mobile. The input was `flex-1` sharing a row with **Release permanently** and **Cancel**, squeezing it to a few characters on a phone — the one field you have to type a name into exactly. `flex-col` below `sm`, inline above.

## Tests

Four added to `record-fields.test.mjs` pinning the contract that made the coupling dangerous: card mode publishes no records, a mode ignores other modes' fields, `buildProfile` never produces records, and `modeOf` opens the form on the right mode for a record that has a CNAME. Suite: 275 passing, build clean.

## Not fixed here: the light-mode bio report

I could not reproduce this and did not want to change colours on a guess. There are three surfaces that render a bio, and I checked each:

- **`/banner/<name>`** — renders the bio at `t.muted` = `#5E6668` on `#F4F5F3`. Pulled two live banners in light mode and the bio is plainly visible in both, including a long one that wraps to two lines.
- **`/sites/<name>` card page** — the bio `<p>` carries no colour class, so it inherits `body { color: var(--ink) }`, which is `#14181b` in light and `#efe7d9` in dark. Correct in both.
- The manage form input — a normal `text-(--color-ink)` textarea.

So which surface was it? A screenshot or a URL and I'll fix it properly. If it was `/banner/<name>`, worth a hard refresh first: that route sets `max-age=300, stale-while-revalidate=600`, so a banner generated before the bio was saved can persist for up to fifteen minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt