### PR TITLE
fix(manage): normalize pasted hostnames instead of rejecting them

### DIFF
--- a/lib/record-fields.js
+++ b/lib/record-fields.js
@@ -28,7 +28,10 @@ export function linesToList(text) {
 export function parseMx(text) {
   return linesToList(text).map((line) => {
     const [priority, ...rest] = line.split(/\s+/);
-    return { priority: Number(priority), value: rest.join(' ') };
+    // The host half is validated against the same HOSTNAME pattern as CNAME,
+    // so it gets the same normalisation -- an MX pasted as
+    // "10 mx.example.com." is the ordinary way a zone file writes it.
+    return { priority: Number(priority), value: normalizeHostname(rest.join(' ')) };
   });
 }
 
@@ -42,9 +45,27 @@ export function mxToLines(mx = []) {
 // records that could not have coexisted with the new shape anyway, which is
 // the conservative reading: the record you can see on screen is exactly the
 // record that gets written, with nothing carried invisibly underneath it.
+// DNS consoles hand out hostnames in forms the schema's HOSTNAME pattern
+// rejects, and the resulting "CNAME must be a hostname" is a maddening thing
+// to read about a value that plainly is one:
+//
+//   - a trailing dot is the fully-qualified form (`example.com.`), valid
+//     notation that several providers display and copy verbatim
+//   - DNS is case-insensitive, so `Example.COM` names the same host, but the
+//     pattern only matches lowercase
+//
+// Normalising beats rejecting: the stored record stays canonical (which is
+// what sync-dns and the schema both want) and the person pasting from their
+// provider is not asked to notice a full stop. Deliberately NOT applied to
+// TXT values, which are opaque and case-sensitive -- lowercasing a
+// verification token would break it.
+export function normalizeHostname(value) {
+  return String(value ?? '').trim().replace(/\.+$/, '').toLowerCase();
+}
+
 export function buildRecords(mode, fields = {}) {
   if (mode === 'cname') {
-    const value = String(fields.cname ?? '').trim();
+    const value = normalizeHostname(fields.cname);
     return value ? { CNAME: value } : {};
   }
   if (mode === 'url') {
@@ -96,7 +117,7 @@ export function buildSubdomains(rows = []) {
 
 function parseValue(type, raw) {
   if (type === 'CNAME') {
-    const v = String(raw ?? '').trim();
+    const v = normalizeHostname(raw);
     return v ? v : null;
   }
   if (type === 'MX') {

--- a/test/record-fields.test.mjs
+++ b/test/record-fields.test.mjs
@@ -209,3 +209,46 @@ test('modeOf reports cname for a record that has one, so the form opens there', 
   assert.equal(modeOf({ CNAME: 'example.vercel.app' }), 'cname');
   assert.equal(modeOf({}), 'card');
 });
+
+// Providers hand out hostnames in shapes the schema's HOSTNAME pattern
+// rejects. Rejecting them produced "CNAME must be a hostname" about a value
+// that plainly was one -- reported by an owner who had pasted Vercel's target
+// with its trailing dot and had no way to see what was wrong.
+test('a trailing dot is stripped from a CNAME', () => {
+  assert.deepEqual(
+    buildRecords('cname', { cname: 'e6bcca57117d3d7e.vercel-dns-017.com.' }),
+    { CNAME: 'e6bcca57117d3d7e.vercel-dns-017.com' },
+  );
+});
+
+test('a CNAME is lowercased, because DNS is case-insensitive', () => {
+  assert.deepEqual(
+    buildRecords('cname', { cname: '  CNAME.Vercel-DNS.com.  ' }),
+    { CNAME: 'cname.vercel-dns.com' },
+  );
+});
+
+test('normalized CNAMEs pass the schema that used to reject them', () => {
+  const rec = {
+    name: 'aman', owner: { github: 'x' }, claimedAt: '2026-09-07T00:00:00Z',
+    records: buildRecords('cname', { cname: 'E6BCCA.vercel-dns-017.com.' }),
+  };
+  assert.deepEqual(validateRecord(rec), { ok: true, errors: [] });
+});
+
+test('a subdomain CNAME row is normalized the same way', () => {
+  assert.deepEqual(
+    buildSubdomains([{ label: 'www', type: 'CNAME', value: 'Target.Example.COM.' }]),
+    { www: { CNAME: 'target.example.com' } },
+  );
+});
+
+test('an MX host is normalized but its priority is untouched', () => {
+  assert.deepEqual(parseMx('10 MX.Example.com.'), [{ priority: 10, value: 'mx.example.com' }]);
+});
+
+// Verification tokens are opaque and case-sensitive; normalizing one breaks it.
+test('TXT values are never lowercased or stripped', () => {
+  const v = 'vc-domain-verify=amanworks.runs-on.dev,81E73fdea1b7f9058ffa';
+  assert.deepEqual(buildSubdomains([{ label: '_vercel', type: 'TXT', value: v }]), { _vercel: { TXT: [v] } });
+});


### PR DESCRIPTION
Reported in #119 with screenshots. An owner pasted Vercel's CNAME target exactly as Vercel gave it and was told it wasn't a hostname.

## What they saw

Vercel's domain page offered:

```
CNAME  amanworks  →  e6bcca57117d3d7e.vercel-dns-017.com
TXT    _vercel    →  vc-domain-verify=amanworks.runs-on.dev,81e73fdea1b7f9058ffa
```

They pasted both correctly. The manage page returned:

```
CNAME must be a hostname
```

The value in the field was `e6bcca57117d3d7e.vercel-dns-017.com.` — with a trailing dot, the fully-qualified form. Valid DNS notation, displayed and copied verbatim by plenty of consoles. `schema.js`'s pattern has no optional trailing dot:

```js
const HOSTNAME = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
```

The error message is the real damage. It asserts the value is not a hostname when it plainly is, and nothing on screen points at the full stop. Nobody proofreads a 35-character hash for punctuation.

The same pattern is lowercase-only, so `Example.COM` was rejected too — DNS is case-insensitive and that names the same host.

## Fix

`normalizeHostname()` — trim, strip trailing dots, lowercase — applied wherever a hostname is read from a form field:

| field | before | after |
|---|---|---|
| CNAME target | `Vercel-DNS.com.` → rejected | `vercel-dns.com` |
| subdomain CNAME row | same | normalized |
| MX host | `10 MX.Example.com.` → rejected | `{ priority: 10, value: 'mx.example.com' }` |

**The schema stays strict.** Input is normalized on the way in rather than the validator loosened, so stored records remain canonical — which is what `sync-dns` and the PR validator both want.

**Not applied to TXT.** Those values are opaque and case-sensitive; lowercasing a verification token would break it. There's a test pinning that.

## Tests

Six added: trailing dot stripped, lowercasing, a normalized CNAME now passing `validateRecord`, subdomain CNAME rows, MX hosts keeping their priority, and TXT left alone. Suite: 281 passing, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt