### PR TITLE
fix(proxy): send claimed-host subpaths to the apex instead of 404

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -38,5 +38,21 @@ export function proxy(request) {
     return new NextResponse('not found', { status: 404 });
   }
 
+  // A claimed host serves exactly one thing: that name's card, at "/". Every
+  // other path belongs to the registry, and the card page renders the site
+  // footer and the nav dock, whose links are relative -- so clicking "manage"
+  // on kl.runs-on.dev asked kl.runs-on.dev for /manage, which rewrote to
+  // /sites/kl/manage, which does not exist, and 404'd. Every link on a card
+  // was broken this way, and so was any path a visitor typed.
+  //
+  // Sending them to the apex is where they were always meant to go. 307 rather
+  // than a permanent redirect: this is a routing decision we might revisit if
+  // claims ever serve sub-paths of their own, and a cached 308 would outlive
+  // the change in browsers we cannot reach.
+  if (request.nextUrl.pathname !== '/') {
+    const target = new URL(`${request.nextUrl.pathname}${request.nextUrl.search}`, `https://${ROOT}`);
+    return NextResponse.redirect(target, 307);
+  }
+
   return NextResponse.rewrite(new URL(`/sites/${name}${request.nextUrl.pathname}`, request.url));
 }


### PR DESCRIPTION
Every link on a profile card is broken in production right now.

## Reproduction

`kl.runs-on.dev` is a card-mode claim, so our wildcard serves it. The card page renders the site footer and the nav dock, and both link relatively:

```
$ curl -s https://kl.runs-on.dev/ | grep -oE 'href="/[^"]*"' | sort -u
href="/"  href="/about"  href="/faq"  href="/manage"  href="/stats"
```

Those resolve against the claimed host, and the proxy rewrote them into `/sites/kl/<path>`, which doesn't exist:

| clicked on the card | apex equivalent |
|---|---|
| `kl.runs-on.dev/docs` → **404** | `runs-on.dev/docs` → 200 |
| `kl.runs-on.dev/manage` → **404** | `runs-on.dev/manage` → 200 |
| `kl.runs-on.dev/about` → **404** | `runs-on.dev/about` → 200 |
| `kl.runs-on.dev/stats` → **404** | `runs-on.dev/stats` → 200 |
| `kl.runs-on.dev/faq` → **404** | `runs-on.dev/faq` → 200 |

So a visitor landing on someone's card cannot reach any part of the registry — including `/manage`, which is exactly where an owner arriving at their own name would click.

The footer has linked this way for a while; #93 widened the blast radius by putting the nav dock in the root layout, which added five more broken links to every card.

## Fix

A claimed host serves exactly one thing — that name's card at `/` — so every other path on it belongs to the registry. The proxy now redirects instead of rewriting into a route that cannot exist. Typed URLs get the same treatment as clicked links.

`307` rather than `308` deliberately: if claims ever serve sub-paths of their own this is a decision worth revisiting, and a cached permanent redirect would outlive the change in browsers we can't reach.

Asset paths are untouched — the matcher already excludes `api`, `_next`, `favicon.ico` and `icon.svg`, so they keep loading from the claimed host.

## Worth considering separately

This makes the links work, but it's worth asking whether the full site nav belongs on someone else's profile card at all. Right now a visitor to `kl.runs-on.dev` gets a dock offering Home / Manage / Stats / Docs / FAQ / About — registry chrome on a page that reads as Kevin's. A single "claimed on runs-on.dev" link in the footer might serve both sides better. Happy to open an issue rather than fold a design change into a bug fix.

Build clean, 275 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt