### PR TITLE
fix(health): treat a quoted TXT as equal to the value DNS holds

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -74,6 +74,20 @@ export function normalizeAnswer(type, value) {
   if (type === 'CNAME' || type === 'MX') {
     return String(value).toLowerCase().replace(/\.$/, '');
   }
+  // A TXT value is often written wrapped in double quotes, because that is how
+  // zone files present one and how most provider docs show it. The quotes are
+  // presentation, not content: the provider stores the inner string, so a
+  // record declaring `"Under Construction"` and DNS holding `Under
+  // Construction` are the same record. Comparing them raw reported permanent
+  // drift that no resync could ever clear, and failed health-check forever --
+  // which matters because that failure masks every other finding in the run.
+  //
+  // Only one fully-surrounding pair is stripped, so a value with quotes inside
+  // it keeps them.
+  if (type === 'TXT') {
+    const v = String(value);
+    return v.length >= 2 && v.startsWith('"') && v.endsWith('"') ? v.slice(1, -1) : v;
+  }
   return String(value);
 }
 

--- a/test/health.test.mjs
+++ b/test/health.test.mjs
@@ -130,3 +130,23 @@ test('findDrift compares MX on priority as well as host', () => {
   const right = new Map([['MX m.runs-on.dev', ['10 mx.example.com']]]);
   assert.deepEqual(findDrift(expected, right), []);
 });
+
+// A TXT wrapped in quotes is zone-file presentation, not content: the provider
+// stores the inner string, so comparing raw reported drift that no resync could
+// clear and failed health-check forever. selim.runs-on.dev sat in that state.
+test('a quoted TXT compares equal to the value DNS holds', () => {
+  assert.equal(
+    normalizeAnswer('TXT', '"Under Construction... SOON"'),
+    normalizeAnswer('TXT', 'Under Construction... SOON'),
+  );
+});
+
+test('only one surrounding pair is stripped, inner quotes survive', () => {
+  assert.equal(normalizeAnswer('TXT', '"say \\"hi\\""'), 'say \\"hi\\"');
+  assert.equal(normalizeAnswer('TXT', 'no quotes here'), 'no quotes here');
+});
+
+test('a verification token is unaffected by TXT normalization', () => {
+  const t = 'vc-domain-verify=selim.runs-on.dev,ABC123def';
+  assert.equal(normalizeAnswer('TXT', t), t);
+});


### PR DESCRIPTION
`health-check` has been failing since `selim` was claimed, and that failure was masking everything else the job found.

## The drift that could never clear

```
health: 3 declared record(s) missing from DNS
  TXT selim.runs-on.dev -> "Under Construction... SOON"
```

The record declares the value *with* surrounding double quotes:

```json
"TXT": ["\"Under Construction... SOON\""]
```

That's how zone files present a TXT and how most provider docs show one. Vercel stores the inner string, so DNS holds `Under Construction... SOON` and the raw string comparison never matches. No resync could fix it — the drift was permanent by construction, and `health-check` would have failed forever.

## Why it matters beyond one name

The drift check `process.exit(1)`s, so this one cosmetic mismatch failed the whole run — and that masked the genuinely broken names in the same output. Two claims had DNS missing entirely and nobody saw it, because the job had been red for days for an unrelated reason.

## Fix

`normalizeAnswer` strips one fully-surrounding quote pair for TXT before comparing. A value with quotes *inside* keeps them, and verification tokens (which carry no quotes) are unaffected — both pinned by tests.

Deliberately a comparison-side fix rather than rewriting anyone's record: the stored value still reflects what its owner typed, and TXT quoting is presentation rather than content.

Three tests added, suite at 284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt