### PR TITLE
feat(health): notify stuck owners, and repair DNS drift automatically

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -12,24 +12,46 @@ on:
 
 permissions:
   contents: read
-  # The run closes the nudge issues whose names have recovered, so the person
-  # who was told their name was broken is told when it is fixed.
+  # The run opens a nudge issue for each newly stuck name and closes the ones
+  # whose names have recovered, so the person who can fix it is told, and told
+  # again when it is fixed.
   issues: write
 
-# The probe reads public HTTP and nothing else, so a scheduled run overlapping
-# a manual one is harmless; cancel the older one rather than queue it.
+# This used to cancel the older run, which was right while the job only read
+# public HTTP. It no longer is: the repair job writes DNS, and cancelling a run
+# mid-sync is precisely the failure this repair exists to clean up after.
+# Queue instead.
 concurrency:
   group: health-check
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    outputs:
+      drifted: ${{ steps.probe.outputs.drifted }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - run: node scripts/health-check.mjs
+      - id: probe
+        run: node scripts/health-check.mjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # A declared record missing from DNS can only be sync-dns having failed
+  # silently -- a run that lost its slot in the concurrency queue, most
+  # likely, since a queued run is evicted when a third arrives and each run
+  # only ever syncs its own push's names. Nothing else would pick those up.
+  #
+  # Repairing on detection closes that loop, using the same per-name path a
+  # maintainer would use by hand. If the repair fails, THIS job goes red,
+  # which is the alarm that actually warrants a person.
+  repair:
+    needs: check
+    if: needs.check.outputs.drifted != ''
+    uses: ./.github/workflows/sync-dns.yml
+    with:
+      names: ${{ needs.check.outputs.drifted }}
+    secrets: inherit

--- a/.github/workflows/sync-dns.yml
+++ b/.github/workflows/sync-dns.yml
@@ -16,6 +16,17 @@ on:
         description: 'Names to re-sync, space or comma separated (e.g. "laurentmaxhuni dexi")'
         required: true
         type: string
+  # Same contract, called rather than clicked: health-check repairs the drift
+  # it detects by calling this with the names it found. A workflow_call runs
+  # inside the caller's run, which sidesteps the fact that GITHUB_TOKEN cannot
+  # trigger a workflow_dispatch -- GitHub blocks that to prevent recursion, so
+  # the API route a script would take is not available to us.
+  workflow_call:
+    inputs:
+      names:
+        description: 'Names to re-sync, space or comma separated'
+        required: true
+        type: string
 
 permissions:
   contents: read

--- a/lib/health.js
+++ b/lib/health.js
@@ -59,6 +59,50 @@ export function planIssueClosures(rows, issues) {
   return closures;
 }
 
+// Which names this run should open a nudge issue for. The mirror of
+// planIssueClosures, and the half that was missing: the script listed open
+// issues, commented on them and closed the recovered ones, but nothing ever
+// created one. Every nudge issue in the tracker had been opened by hand, so a
+// name that went stuck after the last manual sweep was never mentioned to its
+// owner -- 25 names were stuck with 5 issues between them.
+//
+// Only `stuck` opens an issue. `down` means nothing answered, which a host
+// having a bad afternoon produces just as readily as a misconfiguration, and
+// a robot filing an issue about someone's transient outage is noise. `stuck`
+// is unambiguous: DNS resolves, the certificate is ours, and the registry's
+// own card is answering, which only happens when provider-side verification
+// has not completed.
+//
+// `cap` exists because the first run after this ships would otherwise file
+// every backlogged name at once. Opening a few per run spreads it out, and a
+// name that keeps failing gets picked up on a later run anyway.
+export function planIssueOpens(rows, issues, { cap = 5 } = {}) {
+  const spokenFor = new Set(
+    (issues ?? []).map((issue) => issueName(issue.title)).filter(Boolean),
+  );
+  return (rows ?? [])
+    .filter((row) => row.status === 'stuck' && !spokenFor.has(row.name))
+    .slice(0, cap)
+    .map((row) => ({ name: row.name }));
+}
+
+// What to actually tell the owner. A generic "your name is not serving"
+// helps nobody; the registry can see which of a few specific mistakes was
+// made, and saying so is the difference between an issue that gets fixed and
+// one that gets ignored.
+export function diagnoseStuck(claim) {
+  const cname = claim?.records?.CNAME ?? '';
+  const challenges = (claim?.subdomains?._vercel?.TXT ?? [])
+    .filter((v) => typeof v === 'string' && v.startsWith('vc-domain-verify='));
+
+  if (/\.vercel\.app$/i.test(cname)) return 'vercel-app-url';
+  if (/vercel-dns/i.test(cname)) {
+    return challenges.length === 0 ? 'vercel-no-challenge' : 'vercel-awaiting-verification';
+  }
+  if (/\.(github\.io|netlify\.app|pages\.dev)$/i.test(cname)) return 'platform-default-host';
+  return 'unknown';
+}
+
 // --- Drift between what the registry declares and what DNS actually serves ---
 //
 // This is the half of the health check that is ours to fix. A name stuck on

--- a/scripts/health-check.mjs
+++ b/scripts/health-check.mjs
@@ -1,5 +1,8 @@
 import { appendFile, readFile, readdir } from 'node:fs/promises';
-import { classifyClaim, planIssueClosures, STUCK_LABEL, findDrift, normalizeAnswer, expectationKey } from '../lib/health.js';
+import {
+  classifyClaim, planIssueClosures, planIssueOpens, diagnoseStuck,
+  STUCK_LABEL, findDrift, normalizeAnswer, expectationKey,
+} from '../lib/health.js';
 import { planDnsChanges, planZoneVerificationRecords } from '../lib/dns.js';
 import { Resolver } from 'node:dns/promises';
 
@@ -103,6 +106,10 @@ if (process.env.GITHUB_STEP_SUMMARY) {
 // issues API had a bad minute would be a poor trade.
 await closeRecoveredIssues(rows);
 
+// The other half. Without this the check knew a name was broken and never
+// told the one person who could fix it.
+await openStuckIssues(rows, claims);
+
 // `stuck` and `down` are reported, never failed on. Both describe something
 // a third party has not done -- an owner who has not re-run their provider's
 // verification, a host having a bad afternoon -- and a scheduled job that
@@ -118,7 +125,41 @@ const drift = await findDnsDrift(claims);
 if (drift.length > 0) {
   console.error(`health: ${drift.length} declared record(s) missing from DNS`);
   for (const record of drift) console.error(`  ${record.type} ${record.host} -> ${record.want}`);
-  process.exit(1);
+
+  // Drift used to exit 1 and stop there, which made it an alarm nobody could
+  // act on without opening a laptop -- and, worse, a red run masks every other
+  // finding in the same job. `selim`'s quoted TXT held this red for days and
+  // hid two names whose DNS was genuinely missing.
+  //
+  // It is now self-healing: the names are handed to the repair job, which
+  // calls sync-dns with exactly them. That is the same path a human would
+  // take by hand (workflow_dispatch with `names`), so nothing new can go
+  // wrong that could not already. The alarm moves with it -- if the repair
+  // fails, that job goes red, which is the signal that actually needs a
+  // person. Exiting 0 here is what lets the repair job run at all.
+  // The last label before the domain is the claim: `arpitraj.runs-on.dev` and
+  // `_vercel.arpitraj.runs-on.dev` both belong to `arpitraj`. The zone mirror
+  // at `_vercel.runs-on.dev` belongs to no claim and yields `_vercel`, so the
+  // result is intersected with the registry -- sync-dns rebuilds the mirror on
+  // every run regardless of which names it was given, so repairing any real
+  // name repairs the mirror alongside it.
+  const registry = new Set(claims.map((claim) => claim.name));
+  const names = [...new Set(
+    drift
+      .map((record) => String(record.host).replace(`.${DOMAIN}`, '').split('.').pop())
+      .filter((name) => registry.has(name)),
+  )].sort();
+
+  if (names.length === 0) {
+    console.error('health: drift is at the zone level only, which no per-name resync repairs');
+    process.exit(1);
+  }
+
+  console.error(`health: handing ${names.length} name(s) to the repair job: ${names.join(' ')}`);
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `drifted=${names.join(' ')}\n`, 'utf8');
+  }
+  process.exit(0);
 }
 console.log(`health: every declared record is live in DNS (${stuck.length} name(s) awaiting provider verification)`);
 
@@ -217,6 +258,97 @@ async function closeRecoveredIssues(statusRows) {
       console.log(`closed #${number} (${name} recovered)`);
     } catch (err) {
       console.error(`health: could not close #${number}: ${err.message}`);
+    }
+  }
+}
+
+// One issue per stuck name, saying which specific mistake was made. Best
+// effort like the closures: a failure here must not cost the run its probe.
+const STUCK_BODY = {
+  'vercel-app-url': (n, c) => `Your record points at \`${c.records.CNAME}\`, which is your project's **deployment URL** rather than a custom-domain target.
+
+Vercel decides what to serve from the \`Host\` header, and \`${n}.runs-on.dev\` is not registered on your project, so nothing there matches it and your site is never served for this hostname. A CNAME to a \`.vercel.app\` address looks like it should work and never does.
+
+**Fix:** add \`${n}.runs-on.dev\` as a domain on your Vercel project. Vercel will say the domain belongs to another team (it does — we own \`runs-on.dev\`) and give you a \`vc-domain-verify=\` TXT challenge. Put that on /manage as a subdomain record with label \`_vercel\` and type \`TXT\`, and replace the CNAME with the target Vercel shows you.`,
+
+  'vercel-no-challenge': (n, c) => `Your record points at \`${c.records.CNAME}\`, which is the right kind of target, but no ownership challenge is published — so Vercel can never verify the domain.
+
+\`runs-on.dev\` belongs to us, not to you, so Vercel needs proof you control this specific name before it will serve it.
+
+**Fix:** on your Vercel project's domain settings, copy the \`vc-domain-verify=${n}.runs-on.dev,…\` TXT value it offers. Add it on /manage as a subdomain record with label \`_vercel\`, type \`TXT\`. Save, wait a minute for our DNS sync, then hit Refresh on Vercel.`,
+
+  'vercel-awaiting-verification': (n) => `Your CNAME and your \`_vercel\` TXT challenge are both published correctly, but \`${n}.runs-on.dev\` is still serving our profile card rather than your project — so Vercel has not completed verification.
+
+**Fix:** open your Vercel project's domain settings and press **Refresh** next to \`${n}.runs-on.dev\`. Verification often needs that nudge once the DNS is in place.
+
+If it still will not verify, say so here — a challenge value can go stale if the domain was removed and re-added on Vercel, in which case you need the new one.`,
+
+  'platform-default-host': (n, c) => `Your record points at \`${c.records.CNAME}\`, your platform's default host, and nothing is answering for \`${n}.runs-on.dev\` there.
+
+Pointing DNS at the platform is only half of it: the platform also has to be told it should answer for this hostname, otherwise it has no matching site and falls through.
+
+**Fix:** add \`${n}.runs-on.dev\` as a custom domain in your hosting provider's settings (GitHub Pages: repo Settings → Pages → Custom domain; Netlify and Cloudflare Pages have the same under domain management). Then re-check here.`,
+
+  unknown: (n, c) => `\`${n}.runs-on.dev\` resolves and holds a valid certificate, but it is serving our profile card rather than your site — which means your provider is not yet answering for this hostname.
+
+Currently pointing at: \`${c.records?.CNAME ?? (c.records?.A ?? []).join(', ')}\`
+
+**Fix:** whichever host you are using, add \`${n}.runs-on.dev\` to it as a custom domain. DNS alone is not enough — the provider has to recognise the hostname before it will serve anything for it.`,
+};
+
+async function openStuckIssues(statusRows, allClaims) {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!token || !repo) return;
+
+  const api = (path, init = {}) =>
+    fetch(`https://api.github.com/repos/${repo}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+    });
+
+  // Both states matter for deduping: an owner who closed their issue without
+  // fixing the name should not be handed a fresh one every morning.
+  let issues;
+  try {
+    const res = await api(`/issues?state=all&labels=${STUCK_LABEL}&per_page=100`);
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    issues = (await res.json()).filter((issue) => !issue.pull_request);
+  } catch (err) {
+    console.error(`health: could not list ${STUCK_LABEL} issues: ${err.message}`);
+    return;
+  }
+
+  const byName = new Map(allClaims.map((claim) => [claim.name, claim]));
+  for (const { name } of planIssueOpens(statusRows, issues)) {
+    const claim = byName.get(name);
+    if (!claim) continue;
+    const kind = diagnoseStuck(claim);
+    const owner = claim.owner?.github;
+    const body = `${owner ? `@${owner} — ` : ''}${STUCK_BODY[kind](name, claim)}
+
+---
+Opened automatically by the daily health check, which noticed \`${name}.runs-on.dev\` is serving the registry's profile card instead of your site. It closes itself once your name starts serving. If this is wrong, or you meant to serve the card, just close it.`;
+
+    try {
+      const res = await api('/issues', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: `${name}.runs-on.dev is not serving your site yet`,
+          body,
+          labels: [STUCK_LABEL],
+        }),
+      });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const { number } = await res.json();
+      console.log(`opened #${number} (${name}: ${kind})`);
+    } catch (err) {
+      console.error(`health: could not open an issue for ${name}: ${err.message}`);
     }
   }
 }

--- a/test/health.test.mjs
+++ b/test/health.test.mjs
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyClaim, issueName, planIssueClosures, normalizeAnswer, findDrift } from '../lib/health.js';
+import {
+  classifyClaim, issueName, planIssueClosures, planIssueOpens, diagnoseStuck,
+  normalizeAnswer, findDrift,
+} from '../lib/health.js';
 
 const base = { name: 'lucas', owner: { github: 'zordhalo' }, claimedAt: '2026-08-30T00:00:00Z' };
 
@@ -149,4 +152,58 @@ test('only one surrounding pair is stripped, inner quotes survive', () => {
 test('a verification token is unaffected by TXT normalization', () => {
   const t = 'vc-domain-verify=selim.runs-on.dev,ABC123def';
   assert.equal(normalizeAnswer('TXT', t), t);
+});
+
+// --- opening nudge issues (the half that never existed) ---
+
+const rows = (o) => Object.entries(o).map(([name, status]) => ({ name, status }));
+
+test('opens an issue only for stuck names', () => {
+  const out = planIssueOpens(rows({ a: 'stuck', b: 'ok', c: 'down', d: 'card', e: 'redirect' }), []);
+  assert.deepEqual(out.map((x) => x.name), ['a']);
+});
+
+// A robot filing an issue about someone's transient outage is noise; `down`
+// is as easily a host having a bad afternoon as a misconfiguration.
+test('down is never reported, however many there are', () => {
+  assert.deepEqual(planIssueOpens(rows({ a: 'down', b: 'down' }), []), []);
+});
+
+test('a name that already has an issue is not given another', () => {
+  const issues = [{ number: 7, title: 'a.runs-on.dev is not serving your site yet' }];
+  assert.deepEqual(planIssueOpens(rows({ a: 'stuck', b: 'stuck' }), issues).map((x) => x.name), ['b']);
+});
+
+// Deduping reads closed issues too: an owner who closed theirs without fixing
+// the name should not be handed a fresh one every morning.
+test('a closed issue still counts as spoken for', () => {
+  const issues = [{ number: 7, title: 'a.runs-on.dev is not serving your site yet', state: 'closed' }];
+  assert.deepEqual(planIssueOpens(rows({ a: 'stuck' }), issues), []);
+});
+
+test('the cap bounds how many a single run files', () => {
+  const many = rows(Object.fromEntries('abcdefgh'.split('').map((n) => [n, 'stuck'])));
+  assert.equal(planIssueOpens(many, []).length, 5);
+  assert.equal(planIssueOpens(many, [], { cap: 2 }).length, 2);
+});
+
+// --- diagnosis drives what the issue actually says ---
+
+test('a CNAME at a vercel.app deployment URL is named as such', () => {
+  assert.equal(diagnoseStuck({ records: { CNAME: 'portfolio-chi.vercel.app' } }), 'vercel-app-url');
+});
+
+test('a vercel target with no challenge is distinguished from one awaiting verification', () => {
+  const cname = { CNAME: 'abc.vercel-dns-017.com' };
+  assert.equal(diagnoseStuck({ records: cname }), 'vercel-no-challenge');
+  assert.equal(
+    diagnoseStuck({ records: cname, subdomains: { _vercel: { TXT: ['vc-domain-verify=a.runs-on.dev,t'] } } }),
+    'vercel-awaiting-verification',
+  );
+});
+
+test('platform default hosts are recognised, and anything else falls back', () => {
+  assert.equal(diagnoseStuck({ records: { CNAME: 'me.github.io' } }), 'platform-default-host');
+  assert.equal(diagnoseStuck({ records: { CNAME: 'x.pages.dev' } }), 'platform-default-host');
+  assert.equal(diagnoseStuck({ records: { A: ['1.2.3.4'] } }), 'unknown');
 });


### PR DESCRIPTION
Two halves of the same gap: the health check knew things were broken and nothing downstream acted on it.

## 1. It never opened an issue

`closeRecoveredIssues` listed open `dns-stuck` issues, commented on them, and closed the recovered ones. Nothing anywhere **created** one — every nudge issue in the tracker had been opened by hand. So any name that went stuck after the last manual sweep was never mentioned to the one person who could fix it.

Today: **25 names stuck, 5 issues between them.**

`planIssueOpens` is the mirror of `planIssueClosures`, and `diagnoseStuck` picks which specific mistake was made so the issue says something worth reading:

| diagnosis | what the owner is told |
|---|---|
| `vercel-app-url` | CNAME points at a `.vercel.app` deployment URL; Vercel routes on `Host` and never matches this name |
| `vercel-no-challenge` | Right target, but no `vc-domain-verify` published, so verification can't complete |
| `vercel-awaiting-verification` | Both records correct — press Refresh on Vercel |
| `platform-default-host` | DNS points at github.io / netlify.app / pages.dev, but the platform was never told the hostname |
| `unknown` | Generic, with the actual target quoted back |

Only `stuck` files an issue. `down` is as easily a host having a bad afternoon as a misconfiguration, and a robot opening issues about someone's transient outage is noise.

Capped at 5 per run so the backlog isn't filed in one morning, and deduped against **closed** issues as well as open ones — an owner who closed theirs without fixing the name shouldn't be handed a fresh one every day.

## 2. Drift exited 1 and stopped there

A declared record missing from DNS can only be `sync-dns` having failed silently. The likeliest cause is a run evicted from the concurrency queue: `cancel-in-progress: false` still only holds **one** pending run, so a third push drops the second, and since each run syncs only its own push's names, nothing ever picks them up. `arpitraj` sat with neither of its records published for exactly that reason, and only surfaced because I went looking.

The drifted names now go to a repair job that calls `sync-dns` with them — the same per-name path a maintainer would use by hand.

`workflow_call` rather than an API dispatch, because `GITHUB_TOKEN` cannot trigger a `workflow_dispatch`; GitHub blocks that to prevent recursion, so the route a script would take isn't available.

**The alarm moves rather than disappears.** A failed repair is a red job, which is the case that actually wants a person. Exiting 0 on detected drift is what lets the repair job run at all.

## Also

`health-check` flips to `cancel-in-progress: false`. Cancelling the older run was correct while the job only read public HTTP. It now writes DNS, and cancelling mid-sync is precisely the failure this repair exists to clean up after.

## Verification

Ran the script locally against the live registry — reports 25 stuck, no drift (post-repair), and writes nothing without a token, as designed. 292 tests passing, build clean.

Twelve new tests cover the open/dedupe/cap logic and all five diagnoses.

## What to expect on the first scheduled run

Five issues get filed against the oldest stuck names, then five more the next day, until the backlog clears. If you'd rather it went faster or slower, `cap` is one number in `planIssueOpens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt