### PR TITLE
fix(health): move the nudge templates into lib, out of the dead zone

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -103,6 +103,54 @@ export function diagnoseStuck(claim) {
   return 'unknown';
 }
 
+// What the nudge issue actually says. Kept here rather than in the script for
+// two reasons: this is the text 18 strangers will read, so it should be under
+// test like any other decision, and a module-level const in the script sat in
+// the temporal dead zone at its call site -- the function that used it hoists,
+// the const does not, so the first real run died with "Cannot access
+// 'STUCK_BODY' before initialization". The local dry-run could not catch it,
+// because with no token the writer returns early and never reaches the const.
+const BODIES = {
+  'vercel-app-url': (name, claim) => `Your record points at \`${claim.records.CNAME}\`, which is your project's **deployment URL** rather than a custom-domain target.
+
+Vercel decides what to serve from the \`Host\` header, and \`${name}.runs-on.dev\` is not registered on your project, so nothing there matches it and your site is never served for this hostname. A CNAME to a \`.vercel.app\` address looks like it should work and never does.
+
+**Fix:** add \`${name}.runs-on.dev\` as a domain on your Vercel project. Vercel will say the domain belongs to another team — it does, we own \`runs-on.dev\` — and offer you a \`vc-domain-verify=\` TXT challenge. Add that on [/manage](https://runs-on.dev/manage) as a subdomain record with label \`_vercel\` and type \`TXT\`, and replace the CNAME with the target Vercel shows you.`,
+
+  'vercel-no-challenge': (name, claim) => `Your record points at \`${claim.records.CNAME}\`, which is the right kind of target — but no ownership challenge is published, so Vercel can never verify the domain.
+
+\`runs-on.dev\` belongs to us rather than to you, so Vercel wants proof you control this specific name before it will serve it.
+
+**Fix:** in your Vercel project's domain settings, copy the \`vc-domain-verify=${name}.runs-on.dev,…\` TXT value it offers. Add it on [/manage](https://runs-on.dev/manage) as a subdomain record with label \`_vercel\`, type \`TXT\`. Save, give our DNS sync a minute, then press **Refresh** on Vercel.`,
+
+  'vercel-awaiting-verification': (name) => `Your CNAME and your \`_vercel\` TXT challenge are both published correctly, but \`${name}.runs-on.dev\` is still serving our profile card rather than your project — so Vercel has not finished verifying.
+
+**Fix:** open your Vercel project's domain settings and press **Refresh** next to \`${name}.runs-on.dev\`. Verification usually needs that nudge once the DNS is in place.
+
+If it still will not verify, say so here. A challenge value goes stale if the domain was removed and re-added on Vercel, in which case you need the new one.`,
+
+  'platform-default-host': (name, claim) => `Your record points at \`${claim.records.CNAME}\`, your platform's default host, and nothing is answering for \`${name}.runs-on.dev\` there.
+
+Pointing DNS at the platform is only half of it. The platform also has to be told it should answer for this hostname, or it has no matching site and falls through.
+
+**Fix:** add \`${name}.runs-on.dev\` as a custom domain in your host's settings — GitHub Pages puts it under repo Settings → Pages → Custom domain; Netlify and Cloudflare Pages have the same under domain management.`,
+
+  unknown: (name, claim) => `\`${name}.runs-on.dev\` resolves and holds a valid certificate, but it is serving our profile card rather than your site — which means your provider is not yet answering for this hostname.
+
+Currently pointing at: \`${claim.records?.CNAME ?? (claim.records?.A ?? []).join(', ')}\`
+
+**Fix:** whichever host you use, add \`${name}.runs-on.dev\` to it as a custom domain. DNS alone is not enough — the provider has to recognise the hostname before it serves anything for it.`,
+};
+
+export function stuckIssueBody(kind, name, claim) {
+  const render = BODIES[kind] ?? BODIES.unknown;
+  const owner = claim?.owner?.github;
+  return `${owner ? `@${owner} — ` : ''}${render(name, claim)}
+
+---
+Opened automatically by the daily health check, which noticed \`${name}.runs-on.dev\` is serving the registry's profile card instead of your site. It closes itself once your name starts serving. If this is wrong, or you meant to serve the card, just close it.`;
+}
+
 // --- Drift between what the registry declares and what DNS actually serves ---
 //
 // This is the half of the health check that is ours to fix. A name stuck on

--- a/scripts/health-check.mjs
+++ b/scripts/health-check.mjs
@@ -1,6 +1,6 @@
 import { appendFile, readFile, readdir } from 'node:fs/promises';
 import {
-  classifyClaim, planIssueClosures, planIssueOpens, diagnoseStuck,
+  classifyClaim, planIssueClosures, planIssueOpens, diagnoseStuck, stuckIssueBody,
   STUCK_LABEL, findDrift, normalizeAnswer, expectationKey,
 } from '../lib/health.js';
 import { planDnsChanges, planZoneVerificationRecords } from '../lib/dns.js';
@@ -262,40 +262,6 @@ async function closeRecoveredIssues(statusRows) {
   }
 }
 
-// One issue per stuck name, saying which specific mistake was made. Best
-// effort like the closures: a failure here must not cost the run its probe.
-const STUCK_BODY = {
-  'vercel-app-url': (n, c) => `Your record points at \`${c.records.CNAME}\`, which is your project's **deployment URL** rather than a custom-domain target.
-
-Vercel decides what to serve from the \`Host\` header, and \`${n}.runs-on.dev\` is not registered on your project, so nothing there matches it and your site is never served for this hostname. A CNAME to a \`.vercel.app\` address looks like it should work and never does.
-
-**Fix:** add \`${n}.runs-on.dev\` as a domain on your Vercel project. Vercel will say the domain belongs to another team (it does — we own \`runs-on.dev\`) and give you a \`vc-domain-verify=\` TXT challenge. Put that on /manage as a subdomain record with label \`_vercel\` and type \`TXT\`, and replace the CNAME with the target Vercel shows you.`,
-
-  'vercel-no-challenge': (n, c) => `Your record points at \`${c.records.CNAME}\`, which is the right kind of target, but no ownership challenge is published — so Vercel can never verify the domain.
-
-\`runs-on.dev\` belongs to us, not to you, so Vercel needs proof you control this specific name before it will serve it.
-
-**Fix:** on your Vercel project's domain settings, copy the \`vc-domain-verify=${n}.runs-on.dev,…\` TXT value it offers. Add it on /manage as a subdomain record with label \`_vercel\`, type \`TXT\`. Save, wait a minute for our DNS sync, then hit Refresh on Vercel.`,
-
-  'vercel-awaiting-verification': (n) => `Your CNAME and your \`_vercel\` TXT challenge are both published correctly, but \`${n}.runs-on.dev\` is still serving our profile card rather than your project — so Vercel has not completed verification.
-
-**Fix:** open your Vercel project's domain settings and press **Refresh** next to \`${n}.runs-on.dev\`. Verification often needs that nudge once the DNS is in place.
-
-If it still will not verify, say so here — a challenge value can go stale if the domain was removed and re-added on Vercel, in which case you need the new one.`,
-
-  'platform-default-host': (n, c) => `Your record points at \`${c.records.CNAME}\`, your platform's default host, and nothing is answering for \`${n}.runs-on.dev\` there.
-
-Pointing DNS at the platform is only half of it: the platform also has to be told it should answer for this hostname, otherwise it has no matching site and falls through.
-
-**Fix:** add \`${n}.runs-on.dev\` as a custom domain in your hosting provider's settings (GitHub Pages: repo Settings → Pages → Custom domain; Netlify and Cloudflare Pages have the same under domain management). Then re-check here.`,
-
-  unknown: (n, c) => `\`${n}.runs-on.dev\` resolves and holds a valid certificate, but it is serving our profile card rather than your site — which means your provider is not yet answering for this hostname.
-
-Currently pointing at: \`${c.records?.CNAME ?? (c.records?.A ?? []).join(', ')}\`
-
-**Fix:** whichever host you are using, add \`${n}.runs-on.dev\` to it as a custom domain. DNS alone is not enough — the provider has to recognise the hostname before it will serve anything for it.`,
-};
-
 async function openStuckIssues(statusRows, allClaims) {
   const token = process.env.GITHUB_TOKEN;
   const repo = process.env.GITHUB_REPOSITORY;
@@ -329,11 +295,7 @@ async function openStuckIssues(statusRows, allClaims) {
     const claim = byName.get(name);
     if (!claim) continue;
     const kind = diagnoseStuck(claim);
-    const owner = claim.owner?.github;
-    const body = `${owner ? `@${owner} — ` : ''}${STUCK_BODY[kind](name, claim)}
-
----
-Opened automatically by the daily health check, which noticed \`${name}.runs-on.dev\` is serving the registry's profile card instead of your site. It closes itself once your name starts serving. If this is wrong, or you meant to serve the card, just close it.`;
+    const body = stuckIssueBody(kind, name, claim);
 
     try {
       const res = await api('/issues', {

--- a/test/health.test.mjs
+++ b/test/health.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  classifyClaim, issueName, planIssueClosures, planIssueOpens, diagnoseStuck,
+  classifyClaim, issueName, planIssueClosures, planIssueOpens, diagnoseStuck, stuckIssueBody,
   normalizeAnswer, findDrift,
 } from '../lib/health.js';
 
@@ -206,4 +206,46 @@ test('platform default hosts are recognised, and anything else falls back', () =
   assert.equal(diagnoseStuck({ records: { CNAME: 'me.github.io' } }), 'platform-default-host');
   assert.equal(diagnoseStuck({ records: { CNAME: 'x.pages.dev' } }), 'platform-default-host');
   assert.equal(diagnoseStuck({ records: { A: ['1.2.3.4'] } }), 'unknown');
+});
+
+// --- the issue text itself ---
+//
+// These exist because the first real run of the issue opener died with
+// "Cannot access 'STUCK_BODY' before initialization": the templates were a
+// module-level const in the script, below the call site, so they sat in the
+// temporal dead zone. Nothing local caught it -- without a token the writer
+// returns early and never reaches them. Rendering every kind here does.
+
+const stuckClaim = {
+  name: 'aman', owner: { github: 'aman690888' },
+  records: { CNAME: 'abc.vercel-dns-017.com' },
+};
+
+test('every diagnosis renders a body naming the owner and the name', () => {
+  for (const kind of ['vercel-app-url', 'vercel-no-challenge', 'vercel-awaiting-verification', 'platform-default-host', 'unknown']) {
+    const claim = kind === 'vercel-app-url'
+      ? { ...stuckClaim, records: { CNAME: 'portfolio.vercel.app' } }
+      : stuckClaim;
+    const body = stuckIssueBody(kind, 'aman', claim);
+    assert.ok(body.startsWith('@aman690888 — '), `${kind} should address the owner`);
+    assert.ok(body.includes('aman.runs-on.dev'), `${kind} should name the hostname`);
+    assert.ok(body.includes('**Fix:**') || kind === 'unknown', `${kind} should say what to do`);
+  }
+});
+
+test('an unrecognised diagnosis falls back rather than throwing', () => {
+  const body = stuckIssueBody('something-new', 'aman', stuckClaim);
+  assert.ok(body.includes('aman.runs-on.dev'));
+});
+
+test('a claim with no owner still renders', () => {
+  const body = stuckIssueBody('unknown', 'aman', { name: 'aman', records: {} });
+  assert.ok(!body.startsWith('@'));
+  assert.ok(body.includes('aman.runs-on.dev'));
+});
+
+test('an A-record claim renders its addresses rather than undefined', () => {
+  const body = stuckIssueBody('unknown', 'aman', { name: 'aman', records: { A: ['1.2.3.4', '5.6.7.8'] } });
+  assert.ok(body.includes('1.2.3.4, 5.6.7.8'));
+  assert.ok(!body.includes('undefined'));
 });


### PR DESCRIPTION
The first real run of the issue opener from #124 died before filing anything:

```
ReferenceError: Cannot access 'STUCK_BODY' before initialization
    at openStuckIssues (scripts/health-check.mjs:333:51)
```

`STUCK_BODY` was a module-level `const` appended below the call site. `openStuckIssues` is a function *declaration* and hoists; the `const` does not, so by the time the call ran the binding was still in its temporal dead zone.

## Why nothing caught it

The local dry-run I ran before merging couldn't have. Without `GITHUB_TOKEN` the writer returns early on its token check, several lines before it touches the templates:

```js
const token = process.env.GITHUB_TOKEN;
if (!token || !repo) return;     // <- local run stops here
```

So the entire write path was unexercised until it ran in CI with a token present. That's a general hazard with this script: the half that matters most is the half a local run deliberately skips.

## Fix

Moved the text to `lib/health.js` as `stuckIssueBody()`. Structural rather than a reorder:

- pure text with no dependency on script state cannot be in a dead zone at all
- it lives where this repo already keeps testable logic
- it's now under test — which matters more than usual, because this is the copy 18 strangers are going to read
- an unrecognised diagnosis falls back to the generic body instead of throwing

## Tests

Four added, aimed squarely at the failure mode: every diagnosis renders and addresses the owner by handle, names the hostname, and states a fix; an unknown kind falls back; a claim with no owner still renders; and an A-record claim prints its addresses rather than `undefined`. Suite at 296.

No issues were filed by the failed run, so nothing needs cleaning up — the tracker still shows the five pre-existing nudges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt