### PR TITLE
fix(health): dedupe nudges on the hostname, not the label

### DIFF
--- a/scripts/health-check.mjs
+++ b/scripts/health-check.mjs
@@ -278,15 +278,26 @@ async function openStuckIssues(statusRows, allClaims) {
       },
     });
 
-  // Both states matter for deduping: an owner who closed their issue without
-  // fixing the name should not be handed a fresh one every morning.
+  // Two lists, because either alone lets a duplicate through.
+  //
+  // Labelled in every state: an owner who closed their nudge without fixing
+  // the name should not be handed a fresh one every morning.
+  //
+  // Open issues regardless of label: a nudge opened by hand carries no label,
+  // and the first real run filed a second issue at an owner who already had
+  // one open and a conversation running in it. Deduping on the hostname in
+  // the title rather than on the label is what stops that.
   let issues;
   try {
-    const res = await api(`/issues?state=all&labels=${STUCK_LABEL}&per_page=100`);
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-    issues = (await res.json()).filter((issue) => !issue.pull_request);
+    const [labelled, open] = await Promise.all([
+      api(`/issues?state=all&labels=${STUCK_LABEL}&per_page=100`),
+      api('/issues?state=open&per_page=100'),
+    ]);
+    if (!labelled.ok) throw new Error(`${labelled.status} ${labelled.statusText}`);
+    if (!open.ok) throw new Error(`${open.status} ${open.statusText}`);
+    issues = [...await labelled.json(), ...await open.json()].filter((issue) => !issue.pull_request);
   } catch (err) {
-    console.error(`health: could not list ${STUCK_LABEL} issues: ${err.message}`);
+    console.error(`health: could not list issues to dedupe against: ${err.message}`);
     return;
   }
 

--- a/test/health.test.mjs
+++ b/test/health.test.mjs
@@ -249,3 +249,17 @@ test('an A-record claim renders its addresses rather than undefined', () => {
   assert.ok(body.includes('1.2.3.4, 5.6.7.8'));
   assert.ok(!body.includes('undefined'));
 });
+
+// An issue opened by hand carries no dns-stuck label. Deduping on the label
+// alone filed a second issue at an owner who already had one open, with a
+// conversation running in it -- so the hostname in the title is what counts.
+test('an unlabelled issue naming the host still counts as spoken for', () => {
+  const issues = [{ number: 119, title: 'amanworks.runs-on.dev: CNAME restored after a manage-page bug removed it' }];
+  const out = planIssueOpens(rows({ amanworks: 'stuck', other: 'stuck' }), issues);
+  assert.deepEqual(out.map((x) => x.name), ['other']);
+});
+
+test('an issue whose title does not name a claim is ignored by the dedupe', () => {
+  const issues = [{ number: 1, title: 'Add a dark mode toggle' }];
+  assert.deepEqual(planIssueOpens(rows({ amanworks: 'stuck' }), issues).map((x) => x.name), ['amanworks']);
+});


### PR DESCRIPTION
The first successful run of the issue opener filed #127 at @89Aman, who already had **#119** open about the same name — with an active conversation in it where I was walking him through the fix.

## Cause

The dedupe listed issues carrying the `dns-stuck` label:

```js
api(`/issues?state=all&labels=${STUCK_LABEL}&per_page=100`)
```

#119 was opened by hand and carries no label, so it was invisible to the query and `amanworks` read as unspoken for. The effect generalises badly: anyone helped manually gets a second, worse thread the next morning, and the manual thread is exactly where the real help was happening.

## Fix

Two lists now feed the dedupe:

- **labelled, every state** — so a nudge an owner closed without fixing isn't refiled daily
- **every open issue, any label** — so a hand-written one counts

`planIssueOpens` already keys on the hostname parsed out of the title, so both fold in without changing its logic.

## Tests

Two added: an unlabelled issue naming the host suppresses the nudge, and an unrelated issue title (`"Add a dark mode toggle"`) doesn't accidentally suppress anything. Suite at 298.

#127 is already closed as a duplicate, with an explanation for @89Aman that it was our dedupe gap rather than anything on his end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaamJBGmuixRazaDcoVHt