### PR TITLE
fix(check): rate limit the availability endpoint and use CARD_TOKEN

### DIFF
--- a/app/api/check/route.js
+++ b/app/api/check/route.js
@@ -1,6 +1,22 @@
 import { validateName } from '../../../lib/name.js';
 import { isReserved } from '../../../lib/blocklist.js';
 import { getRecord } from '../../../lib/registry.js';
+import { createRateLimiter } from '../../../lib/throttle.js';
+
+// A separate card-read token keeps availability checks off REGISTRY_TOKEN,
+// the same quota /api/claim depends on. Every other read-only route
+// (dns-check, sites/[name], claim-banner) already does this; /api/check was
+// the lone hold-out, so a loop here could starve claiming for everyone.
+const TOKEN = () => process.env.CARD_TOKEN ?? process.env.REGISTRY_TOKEN;
+
+// Keyed on the requested name, like dns-check. The availability check is
+// the form's debounce call, so a real visitor produces one request per typed
+// name, not a burst; an anonymous loop over random names is the thing this
+// has to cap. Anonymous by design (no session to key on), so the name is
+// the natural unit — poll one name, see one answer.
+const CHECK_WINDOW_MS = 60 * 1000;
+const CHECK_MAX = 10;
+const takeCheck = createRateLimiter({ windowMs: CHECK_WINDOW_MS, max: CHECK_MAX });
 
 export async function GET(request) {
   const name = (new URL(request.url).searchParams.get('name') ?? '').trim().toLowerCase();
@@ -9,9 +25,22 @@ export async function GET(request) {
   if (!grammar.ok) return Response.json({ available: false, code: `invalid_${grammar.reason}` });
   if (isReserved(name).reserved) return Response.json({ available: false, code: 'reserved' });
 
+  // Rate limit before the read: a request that costs no GitHub quota still
+  // costs a slot, and gating only the read would let a loop spend the
+  // limiter without ever being refused (every name 404s, every answer is
+  // 'available'). Same shape as the write routes.
+  const budget = takeCheck(name);
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
+  }
+
   let existing;
   try {
-    existing = await getRecord(name, { token: process.env.REGISTRY_TOKEN });
+    existing = await getRecord(name, { token: TOKEN() });
   } catch (err) {
     // Log before collapsing the failure into a code. Without this the only
     // trace a broken registry read leaves is "check_failed" on the visitor's


### PR DESCRIPTION
Part of #138 (finding 2).

## The problem

`/api/check` was the only unauthenticated endpoint spending GitHub quota with no rate limiter (claim: 12/10min, records: 12/10min, dns-check: 10/min, check: nothing), and it spent `REGISTRY_TOKEN` rather than the `CARD_TOKEN` fallback every other read-only route uses (dns-check, sites/[name], claim-banner). An anonymous loop over random valid names costs one authenticated read each against the same 5,000/hour budget `/api/claim`'s existence check draws on, which puts the claim path into its 503 busy state for everyone.

## The change

- per-name rate limit, 10/min, the same budget and key dns-check already uses: the form debounces at 300ms and caches the last result per exact name, so a human typing produces one request per name and never sees it; a loop hammering one name is the thing this caps
- gated before the read, so a 429 answer costs no GitHub quota at all
- `CARD_TOKEN ?? REGISTRY_TOKEN`, matching the sibling routes, keeping availability checks off the claim path's token

`claim-form.jsx` already had a `rate_limited` message mapped, so the 429 renders as "Too many attempts in a short window".

313/313 tests, build clean.
