### PR TITLE
fix(manage,nav): warn on every record-dropping mode switch, focus rings on the dock

### DIFF
--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -586,7 +586,7 @@ export default function EdgePicker() {
             background: 'var(--paper)',
             boxShadow: pillShadow,
           }}
-          className={`absolute right-[9px] w-[34px] rounded-full flex items-center justify-center z-20 pointer-events-auto transition-[height] duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${
+          className={`absolute right-[9px] w-[34px] rounded-full flex items-center justify-center z-20 pointer-events-auto transition-[height] duration-300 ease-[cubic-bezier(0.34,1.56,0.64,1)] outline-none focus-visible:ring-2 focus-visible:ring-(--color-signal) focus-visible:ring-offset-2 focus-visible:ring-offset-transparent ${
             isCompact ? 'pointer-events-none' : 'cursor-pointer active:scale-95'
           }`}
         >
@@ -659,7 +659,7 @@ export default function EdgePicker() {
                 pointerEvents: isCompact ? 'none' : 'auto',
                 transition: 'opacity 0.25s ease',
               }}
-              className="absolute right-[9px] w-[34px] h-8 flex items-center justify-center pointer-events-auto cursor-pointer group"
+              className="absolute right-[9px] w-[34px] h-8 flex items-center justify-center pointer-events-auto cursor-pointer group outline-none focus-visible:ring-2 focus-visible:ring-(--color-signal) focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-full"
             >
               <span className="w-6 h-6 rounded-full flex items-center justify-center group-hover:bg-white/10 group-hover:scale-125 transition-all text-neutral-400 hover:text-white">
                 <item.Icon size={ICON_SIZE} strokeWidth={2} />

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -122,9 +122,17 @@ export default function RecordForm({ name, record }) {
   const [dnsStatus, setDnsStatus] = useState(null);
 
   // What the record held when the page loaded, not what the form currently
-  // builds: the point is to warn that saving in card mode would drop records
-  // that exist on the saved record right now.
-  const hadRecords = Object.keys(record.records ?? {}).length > 0;
+  // builds: the point is to warn that saving in a mode that drops records the
+  // file already has — card wipes everything, redirect drops a CNAME, cname
+  // drops A/TXT/MX — before the user hits Save.
+  const existingTypes = Object.keys(record.records ?? {});
+  const MODE_LABEL = { card: 'Profile Card', cname: 'Custom Domain', url: 'Redirect', advanced: 'Advanced DNS' };
+  // buildRecords(mode) returns exactly the types that mode can express, so
+  // any record type the file holds that the mode cannot keep is one that
+  // save would remove.
+  const kept = new Set(Object.keys(buildRecords(mode, { cname, url, a, txt, mx })));
+  const dropped = existingTypes.filter((t) => !kept.has(t));
+  const willDropRecords = dropped.length > 0;
 
   useEffect(() => {
     fetch(`/api/dns-check?name=${encodeURIComponent(name)}`)
@@ -207,24 +215,32 @@ export default function RecordForm({ name, record }) {
         <p className="mt-2 text-xs leading-relaxed text-(--color-muted)">{PROVIDERS.find((p) => p.id === mode)?.hint}</p>
       </div>
 
-      {/* Profile Card mode: this mode means "no DNS records", so entering it
-          and saving clears them. The profile editor itself lives further down,
-          outside the mode switch, because `profile` and `records` are
-          independent keys -- gating the bio behind this mode meant anyone with
-          a CNAME who wanted to edit their bio silently lost their records. */}
+      {/* Mode-specific section. The profile editor lives outside this
+          switch (further down) because `profile` and `records` are
+          independent keys — gating the bio behind this mode meant anyone
+          with a CNAME who wanted to edit their bio silently lost their
+          records. */}
       {mode === 'card' && (
         <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
           <p className="text-sm font-medium text-(--color-ink)">Profile card</p>
           <p className="mt-1 text-xs text-(--color-muted)">
             Your name serves a card built from your GitHub profile. No DNS records are published.
           </p>
-          {hadRecords && (
-            <p className="mt-3 border border-(--color-signal) px-3 py-2 font-(family-name:--font-mono) text-xs text-(--color-signal)">
-              Saving in this mode removes the DNS records on this name. To edit your card
-              without changing where the name points, pick your current mode above and edit
-              the profile section below instead.
-            </p>
-          )}
+        </div>
+      )}
+
+      {/* Warn when a save in this mode would remove records the file
+          currently holds. The WYSIWYG model makes switching mode drop
+          anything the new mode can't express; the banner makes that
+          visible rather than silent, for every destructive transition
+          (card, redirect, and cname each drop whatever the record had). */}
+      {willDropRecords && (
+        <div className="border-t border-(--color-rule) px-6 py-3 sm:px-8">
+          <p className="border border-(--color-signal) px-3 py-2 font-(family-name:--font-mono) text-xs text-(--color-signal)">
+            Saving in {MODE_LABEL[mode]} mode removes the {dropped.join(', ')} record(s)
+            on this name. To edit your card or redirect without changing where the name points,
+            edit the profile section below or keep your current mode.
+          </p>
         </div>
       )}
 


### PR DESCRIPTION
Part of #138 (finding 4).

## The problems

**The destructive-save warning only covered card mode.** The banner added after the profile-wipe incident renders only in Profile Card mode, but switching Custom Domain to Redirect and saving drops the CNAME silently, and cname drops A/TXT/MX the same way. The WYSIWYG model makes every mode switch drop whatever the new mode cannot express; the warning should say so for all of them.

**The dock anchors had no focus indication.** The pill and neighbor icons are real anchors (tabbable and arrow-operable since #93), but nothing showed where keyboard focus was.

## The change

- the warning now triggers whenever saving would remove record types the file currently holds, computed from `buildRecords(mode)` against the loaded record, and names the exact types that would be removed. Stay in your own mode with your own fields: no warning. Clear the CNAME field, or switch modes: warning.
- the pill and neighbor anchors carry `focus-visible` rings in the signal color, so keyboard users see focus without changing anything about the pointer-driven aesthetic.

313/313 tests, build clean.
