### PR TITLE
feat(manage): provider presets for CNAME mode

### DIFF
--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -178,7 +178,15 @@ const PRESETS = [
 export default function RecordForm({ name, record }) {
   const [mode, setMode] = useState(() => modeOf(record.records));
   const [cname, setCname] = useState(record.records?.CNAME ?? '');
-  const [selectedPreset, setSelectedPreset] = useState(null);
+  // Highlight the preset the loaded CNAME already matches (a Vercel user
+  // returning to their record sees the Vercel steps, not bare fields). Only
+  // derivable values match; anything hand-typed leaves no chip active.
+  const [selectedPreset, setSelectedPreset] = useState(() => {
+    const initial = record.records?.CNAME ?? '';
+    if (!initial) return null;
+    const ownerLogin = record.owner?.github;
+    return PRESETS.find((p) => p.prefillFor?.(ownerLogin) === initial)?.id ?? null;
+  });
   const [url, setUrl] = useState(record.records?.URL ?? '');
   const [a, setA] = useState((record.records?.A ?? []).join('\n'));
   const [txt, setTxt] = useState((record.records?.TXT ?? []).join('\n'));

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -346,6 +346,7 @@ export default function RecordForm({ name, record }) {
                 value={cname}
                 onChange={(e) => { setCname(e.target.value); setStatus(null); }}
                 placeholder={PRESETS.find((p) => p.id === selectedPreset)?.placeholder ?? 'your-provider.example.com'}
+                aria-label="CNAME target"
                 spellCheck={false}
                 autoCapitalize="off"
                 className="mt-3 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -215,13 +215,14 @@ export default function RecordForm({ name, record }) {
   // the field — but never over something the user typed themselves: only an
   // empty field or another preset's own prefill is replaced.
   function selectPreset(preset) {
-    setSelectedPreset((current) => (current === preset.id ? null : preset.id));
-    if (selectedPreset === preset.id) return;
+    const deselecting = selectedPreset === preset.id;
+    setSelectedPreset(deselecting ? null : preset.id);
+    setStatus(null);
+    if (deselecting) return;
     const prefill = preset.prefillFor?.(record.owner?.github);
     if (!prefill) return;
     const presetValues = PRESETS.map((p) => p.prefillFor?.(record.owner?.github)).filter(Boolean);
     if (!cname.trim() || presetValues.includes(cname.trim())) setCname(prefill);
-    setStatus(null);
   }
 
   function setRow(i, patch) {

--- a/app/manage/record-form.jsx
+++ b/app/manage/record-form.jsx
@@ -105,9 +105,80 @@ const PROVIDERS = [
   { id: 'advanced', label: 'Advanced DNS', hint: 'A, TXT, and MX records. For power users.', icon: 'M4 6h16M4 12h16M4 18h16' },
 ];
 
+// Provider presets for CNAME mode. Each one knows the target shape the
+// provider actually needs and the steps that provider requires beyond DNS —
+// which is exactly where the health check's stuck names come from: pointing
+// at a deployment URL instead of a custom-domain target, or attaching the
+// domain on the provider's side never happening at all. The preset fills the
+// half DNS can do and walks the user through the half it can't.
+const PRESETS = [
+  {
+    id: 'github-pages',
+    label: 'GitHub Pages',
+    placeholder: 'yourusername.github.io',
+    prefillFor: (login) => (login ? `${String(login).toLowerCase()}.github.io` : ''),
+    guide: null,
+    steps: (name, login) => [
+      `Target ${login ? `${String(login).toLowerCase()}.github.io` : 'yourusername.github.io'} (or <project>.github.io if the site lives in a project repo)`,
+      `In that repo: Settings → Pages → Custom domain, enter ${name}.runs-on.dev, save`,
+      "Save here. The zone publishes within a minute, HTTPS follows on GitHub's side",
+    ],
+  },
+  {
+    id: 'netlify',
+    label: 'Netlify',
+    placeholder: 'your-site.netlify.app',
+    prefillFor: null,
+    guide: null,
+    steps: (name) => [
+      "Target your site's netlify.app address (Domain settings shows it)",
+      `In Netlify: Domain settings → Add a domain → ${name}.runs-on.dev`,
+      'Save here, then let Netlify provision the certificate',
+    ],
+  },
+  {
+    id: 'cloudflare-pages',
+    label: 'Cloudflare Pages',
+    placeholder: 'your-project.pages.dev',
+    prefillFor: null,
+    guide: null,
+    steps: (name) => [
+      "Target your project's pages.dev address",
+      `In Cloudflare: your Pages project → Custom domains → Set up a custom domain → ${name}.runs-on.dev`,
+      'Save here. Cloudflare issues the certificate once the CNAME is live',
+    ],
+  },
+  {
+    id: 'vercel',
+    label: 'Vercel',
+    placeholder: 'cname.vercel-dns.com',
+    prefillFor: () => 'cname.vercel-dns.com',
+    guide: '/docs/guides/vercel',
+    steps: (name) => [
+      `In your Vercel project: Settings → Domains → Add, enter ${name}.runs-on.dev`,
+      'It will show a verification TXT starting with vc-domain-verify= — copy the whole value',
+      'Add it below as a subdomain record: label _vercel, type TXT',
+      'Save here. Vercel needs one re-check after the TXT is live, so give it a minute',
+    ],
+  },
+  {
+    id: 'render',
+    label: 'Render',
+    placeholder: 'your-service.onrender.com',
+    prefillFor: null,
+    guide: null,
+    steps: (name) => [
+      "Target your service's onrender.com address",
+      `In Render: your service → Settings → Custom Domains → Add ${name}.runs-on.dev`,
+      'Save here; Render validates the CNAME and issues the certificate',
+    ],
+  },
+];
+
 export default function RecordForm({ name, record }) {
   const [mode, setMode] = useState(() => modeOf(record.records));
   const [cname, setCname] = useState(record.records?.CNAME ?? '');
+  const [selectedPreset, setSelectedPreset] = useState(null);
   const [url, setUrl] = useState(record.records?.URL ?? '');
   const [a, setA] = useState((record.records?.A ?? []).join('\n'));
   const [txt, setTxt] = useState((record.records?.TXT ?? []).join('\n'));
@@ -137,6 +208,20 @@ export default function RecordForm({ name, record }) {
     setMode(id);
     setStatus(null);
     setErrors([]);
+  }
+
+  // Picking a preset swaps the placeholder and, when the preset can derive a
+  // target (GitHub Pages from the owner's login, Vercel's generic), prefills
+  // the field — but never over something the user typed themselves: only an
+  // empty field or another preset's own prefill is replaced.
+  function selectPreset(preset) {
+    setSelectedPreset((current) => (current === preset.id ? null : preset.id));
+    if (selectedPreset === preset.id) return;
+    const prefill = preset.prefillFor?.(record.owner?.github);
+    if (!prefill) return;
+    const presetValues = PRESETS.map((p) => p.prefillFor?.(record.owner?.github)).filter(Boolean);
+    if (!cname.trim() || presetValues.includes(cname.trim())) setCname(prefill);
+    setStatus(null);
   }
 
   function setRow(i, patch) {
@@ -232,11 +317,63 @@ export default function RecordForm({ name, record }) {
       {mode === 'cname' && (
         <>
           <div className="border-t border-(--color-rule) px-6 py-5 sm:px-8">
+            <span className="text-sm font-medium text-(--color-ink)">CNAME target</span>
+
+            {/* Provider presets: fill the target shape and walk the steps
+                that provider needs beyond DNS. Optional — a plain hostname
+                typed below works exactly as before. */}
+            <div className="mt-3 flex flex-wrap gap-2">
+              {PRESETS.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => selectPreset(p)}
+                  aria-pressed={selectedPreset === p.id}
+                  className={`border px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-colors ${
+                    selectedPreset === p.id
+                      ? 'border-(--color-signal) bg-(--color-signal)/10 text-(--color-signal)'
+                      : 'border-(--color-rule) text-(--color-muted) hover:border-(--color-muted) hover:text-(--color-ink)'
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+
             <label className="block">
-              <span className="text-sm font-medium text-(--color-ink)">CNAME target</span>
-              <input value={cname} onChange={(e) => { setCname(e.target.value); setStatus(null); }} placeholder="your-provider.example.com" spellCheck={false} autoCapitalize="off" className="mt-1 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)" />
+              <input
+                value={cname}
+                onChange={(e) => { setCname(e.target.value); setStatus(null); }}
+                placeholder={PRESETS.find((p) => p.id === selectedPreset)?.placeholder ?? 'your-provider.example.com'}
+                spellCheck={false}
+                autoCapitalize="off"
+                className="mt-3 w-full border border-(--color-rule) bg-transparent px-3 py-2 font-(family-name:--font-mono) text-sm text-(--color-ink) outline-none focus:border-(--color-signal)"
+              />
             </label>
             <p className="mt-2 text-xs text-(--color-muted)">Copy the exact value from your provider.</p>
+
+            {(() => {
+              const preset = PRESETS.find((p) => p.id === selectedPreset);
+              if (!preset) return null;
+              return (
+                <div className="mt-4 border border-(--color-rule) bg-(--color-card) px-4 py-3">
+                  <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{'// '}{preset.label} setup</p>
+                  <ol className="mt-2 space-y-1.5 text-xs leading-relaxed text-(--color-ink)">
+                    {preset.steps(name, record.owner?.github).map((step, i) => (
+                      <li key={i} className="flex gap-2">
+                        <span className="font-(family-name:--font-mono) text-(--color-muted)">{i + 1}.</span>
+                        <span>{step}</span>
+                      </li>
+                    ))}
+                  </ol>
+                  {preset.guide && (
+                    <a href={preset.guide} className="mt-3 inline-block font-(family-name:--font-mono) text-xs text-(--color-signal) underline">
+                      full guide →
+                    </a>
+                  )}
+                </div>
+              );
+            })()}
           </div>
           <SubdomainRecords name={name} subRows={subRows} setRow={setRow} addRow={addRow} removeRow={removeRow} />
         </>


### PR DESCRIPTION
## The problem this attacks

The health check's `diagnoseStuck` classes are a taxonomy of entry mistakes: `vercel-app-url` (pointed at a deployment URL), `platform-default-host` (DNS points at the platform but the custom domain was never attached there), `vercel-no-challenge`. Every one of those is a mistake made at the moment of filling in the CNAME, found days later by the daily probe.

## The change

Provider presets inside Custom Domain mode — GitHub Pages, Netlify, Cloudflare Pages, Vercel, Render — as optional chips above the CNAME input. A preset:

- swaps the input placeholder for the shape that provider actually needs
- prefills the target only when it can be derived (GitHub Pages from the owner's login, Vercel's generic), and never over a value the user typed themselves — only an empty field or another preset's own derivable value is replaced
- shows a numbered walkthrough naming the user's actual `<name>.runs-on.dev` throughout, covering the half DNS can't do (attach the custom domain on the provider, add the `_vercel` TXT as a subdomain record below)
- Vercel links the existing `/docs/guides/vercel` guide

A returning Vercel user (cname.vercel-dns.com on file) opens the mode with the Vercel chip already highlighted and its steps visible; hand-tuned targets match no chip. A plain hostname with no preset works exactly as before.

313/313 tests, build clean.
