### PR TITLE
feat(debug): public /debug/<name> diagnosis page

### DIFF
--- a/app/api/dns-check/route.js
+++ b/app/api/dns-check/route.js
@@ -2,6 +2,7 @@ import dns from 'node:dns/promises';
 import { validateName } from '../../../lib/name.js';
 import { getRecord } from '../../../lib/registry.js';
 import { classifyClaim } from '../../../lib/health.js';
+import { probe } from '../../../lib/dns-probe.js';
 import { createRateLimiter } from '../../../lib/throttle.js';
 
 // Node runtime for node:dns — edge has no resolver. Dynamic because the
@@ -11,7 +12,6 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 const ZONE = 'runs-on.dev';
-const PROBE_TIMEOUT_MS = 8000;
 
 // Same budget the write routes use: generous for a real owner polling after
 // a save, tight enough that a leaned-on loop can't spend the registry's DNS
@@ -20,34 +20,6 @@ const PROBE_TIMEOUT_MS = 8000;
 const CHECK_WINDOW_MS = 60 * 1000;
 const CHECK_MAX = 10;
 const takeCheck = createRateLimiter({ windowMs: CHECK_WINDOW_MS, max: CHECK_MAX });
-
-// SSRF guard: the record's A entries and any redirect target must not point
-// at a private network the server can reach. lib/schema.js accepts any valid
-// IPv4 including loopback, link-local, and RFC 1918 ranges — the schema
-// governs what DNS can express, not what this endpoint should fetch.
-const PRIVATE_RANGES = [
-  /^10\./,
-  /^127\./,
-  /^169\.254\./,
-  /^172\.(1[6-9]|2[0-9]|3[01])\./,
-  /^192\.168\./,
-  /^0\./,
-  /^::1$/,
-  /^f[cd][0-9a-f]{2}:/i,
-];
-
-// TOCTOU: this resolves the name once, then `fetch` below resolves it again
-// independently. A short-TTL record could answer public here and private on
-// the second lookup (DNS rebinding). Fixing properly means resolving once and
-// connecting to the pinned address, which is more machinery than this
-// endpoint warrants today: `redirect: 'manual'` means at most a `<title>`
-// comes back, from a host inside our own zone, and the schema only accepts
-// A records (no AAAA, so no `::1` bypass). The reasoning lives here so it
-// isn't rediscovered.
-async function resolveAndCheckPrivate(hostname) {
-  const addresses = await dns.resolve4(hostname).catch(() => []);
-  return addresses.some((addr) => PRIVATE_RANGES.some((pattern) => pattern.test(addr)));
-}
 
 // Everything this endpoint returns is already public: DNS answers and the
 // page a name serves. It accepts any grammar-valid name for that reason —
@@ -64,38 +36,6 @@ async function safe(fn, fallback) {
 
 function flattenTxt(records) {
   return (records ?? []).map((chunks) => chunks.join(''));
-}
-
-// No redirect following. The initial URL is always <name>.runs-on.dev
-// (grammar-validated), so the destination is constrained by DNS, not by
-// whoever set the record. A URL-redirect name will still be classified
-// correctly: the registry's own wildcard serves the 307 itself, and the
-// probe sees the registry's page, not the redirect target.
-async function probe(name) {
-  const host = `${name}.${ZONE}`;
-  try {
-    // SSRF: if the name's A records point at a private range, the fetch
-    // would reach inside the network. Resolve first, refuse before fetching.
-    if (await resolveAndCheckPrivate(host)) {
-      return { ok: true, refused: true, finalHost: host, title: '', finalUrl: `https://${host}/` };
-    }
-    const res = await fetch(`https://${host}/`, {
-      redirect: 'manual',
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-      headers: { 'user-agent': 'runs-on-dev-dns-check (github.com/zordhalo/runs-on.dev)' },
-    });
-    const location = res.headers.get('location');
-    // A 3xx without following the redirect: classify by the status, don't
-    // fetch wherever it points.
-    if (res.status >= 300 && res.status < 400 && location) {
-      return { ok: true, finalHost: host, title: '', finalUrl: location, redirected: true };
-    }
-    const body = await res.text();
-    const title = /<title[^>]*>([^<]*)<\/title>/i.exec(body)?.[1]?.trim() ?? '';
-    return { ok: true, finalHost: host, title, finalUrl: `https://${host}/` };
-  } catch {
-    return { ok: false };
-  }
 }
 
 export async function GET(request) {

--- a/app/debug/[name]/page.jsx
+++ b/app/debug/[name]/page.jsx
@@ -1,0 +1,194 @@
+import dns from 'node:dns/promises';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { validateName } from '../../../lib/name.js';
+import { getRecord } from '../../../lib/registry.js';
+import { classifyClaim, diagnoseStuck } from '../../../lib/health.js';
+import { probe } from '../../../lib/dns-probe.js';
+import { REPO_URL } from '../../../lib/repo.js';
+
+// A public, shareable diagnosis for one name: what the record declares, what
+// DNS actually answers, what the name serves, and — when it is stuck — which
+// specific step is missing. The point is self-serve triage: the answer to
+// "why is my name still the card" becomes a link instead of an issue.
+//
+// Live DNS, so dynamic and noindex: this is a debug tool, not a page anyone
+// should land on from a search engine.
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Debug',
+  robots: { index: false },
+};
+
+const ZONE = 'runs-on.dev';
+const TOKEN = () => process.env.CARD_TOKEN ?? process.env.REGISTRY_TOKEN;
+
+async function safe(fn, fallback) {
+  try {
+    return await fn();
+  } catch {
+    return fallback;
+  }
+}
+
+function flattenTxt(records) {
+  return (records ?? []).map((chunks) => chunks.join(''));
+}
+
+// What each stuck diagnosis should tell a person, in the same words the fix
+// takes. Kept page-side rather than in lib/health.js because the issue
+// bodies there are issue-shaped (markdown, @mentions); this is a page.
+const STUCK_ADVICE = {
+  'vercel-app-url': (name) => ({
+    title: 'The CNAME points at a deployment URL',
+    body: `Vercel decides what to serve from the hostname, and a .vercel.app address is not registered as serving ${name}.runs-on.dev. Add ${name}.runs-on.dev as a domain on your Vercel project, then use the custom-domain target it shows you instead of the deployment URL.`,
+  }),
+  'vercel-no-challenge': (name) => ({
+    title: 'The Vercel ownership challenge is missing',
+    body: `runs-on.dev belongs to the registry, not to you, so Vercel needs proof you control this specific name before it will serve it. In your project's domain settings, copy the vc-domain-verify TXT value it offers and add it on /manage as a subdomain record with label _vercel and type TXT.`,
+  }),
+  'vercel-awaiting-verification': (name) => ({
+    title: 'DNS is right, Vercel just has not re-checked',
+    body: `The CNAME and the _vercel TXT are both published, which means everything on this side is done. Vercel often needs one nudge: remove and re-add ${name}.runs-on.dev in your project's domain settings to force a fresh verification check.`,
+  }),
+  'platform-default-host': (name) => ({
+    title: 'The platform does not know about this hostname',
+    body: `DNS points at your platform, but nothing there is configured to answer for ${name}.runs-on.dev. Add it as a custom domain where your site is hosted — GitHub Pages puts it under repo Settings → Pages, Netlify and Cloudflare Pages under domain settings.`,
+  }),
+  unknown: (name) => ({
+    title: 'Your host is not answering for this name yet',
+    body: `The name resolves and holds a certificate, but the registry's own page is still what visitors get, which means the provider has not taken ownership of the hostname. Add ${name}.runs-on.dev as a custom domain wherever the site is hosted.`,
+  }),
+};
+
+const VERDICT = {
+  ok: { label: 'Serving your site', color: '#22c55e' },
+  redirect: { label: 'Redirecting', color: '#3b82f6' },
+  card: { label: 'Serving the profile card', color: '#9ca3af' },
+  stuck: { label: 'Stuck on the profile card', color: '#eab308' },
+  down: { label: 'No answer', color: '#ef4444' },
+};
+
+export default async function DebugPage({ params }) {
+  const { name } = await params;
+  if (!validateName(name).ok) notFound();
+
+  const record = await safe(
+    () => getRecord(name, { token: TOKEN(), fetchImpl: (u, i) => fetch(u, { ...i, next: { revalidate: 30 } }) }),
+    null,
+  );
+
+  if (!record) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <p className="font-(family-name:--font-mono) text-xs tracking-[0.14em] text-(--color-muted) uppercase">Debug</p>
+        <h1 className="mt-2 font-(family-name:--font-display) text-2xl font-medium text-(--color-ink)">{name}.runs-on.dev</h1>
+        <p className="mt-4 text-sm leading-relaxed text-(--color-muted)">
+          This name is not claimed, so there is no record to check: the wildcard serves a
+          claim page for it and DNS points nowhere in particular.
+        </p>
+        <Link href={`/?claim=${encodeURIComponent(name)}`} className="mt-4 inline-block font-(family-name:--font-mono) text-sm text-(--color-signal) underline">
+          claim {name}.runs-on.dev →
+        </Link>
+      </main>
+    );
+  }
+
+  const records = record.records ?? {};
+  const wantedCname = typeof records.CNAME === 'string' ? records.CNAME : null;
+  const wantedTxt = (record.subdomains?._vercel?.TXT ?? []).filter((v) => typeof v === 'string');
+
+  const [cname, a, txtVercelLabel, txtVercelZone, servingProbe] = await Promise.all([
+    safe(() => dns.resolveCname(`${name}.${ZONE}`), []),
+    safe(() => dns.resolve4(`${name}.${ZONE}`), []),
+    safe(() => dns.resolveTxt(`_vercel.${name}.${ZONE}`), []),
+    safe(() => dns.resolveTxt(`_vercel.${ZONE}`), []),
+    probe(name),
+  ]);
+
+  const status = classifyClaim(record, servingProbe);
+  const verdict = VERDICT[status] ?? VERDICT.unknown;
+  const advice = status === 'stuck' ? STUCK_ADVICE[diagnoseStuck(record)]?.(name) : null;
+
+  const rows = [];
+  if (wantedCname) {
+    const live = (cname ?? []).some((r) => r.toLowerCase() === wantedCname.toLowerCase());
+    rows.push({ ok: live, text: live ? `CNAME → ${cname[0]}` : `CNAME not visible yet (want ${wantedCname})` });
+  }
+  if (wantedTxt.length > 0) {
+    const zone = flattenTxt(txtVercelZone);
+    const published = wantedTxt.some((v) => zone.includes(v));
+    rows.push({ ok: published, text: published ? '_vercel TXT published at the zone' : '_vercel TXT not at the zone yet' });
+  }
+  if (status === 'ok' && servingProbe.title) {
+    rows.push({ ok: true, text: `serving: ${servingProbe.title}` });
+  }
+  if (status === 'redirect') {
+    rows.push({ ok: true, text: `redirecting to ${servingProbe.finalUrl}` });
+  }
+  if (status === 'card') {
+    rows.push({ ok: true, text: 'no DNS records, wildcard serves the profile card (as picked)' });
+  }
+  if (status === 'stuck') {
+    rows.push({ ok: false, text: `still serving the registry's own page (${servingProbe.title || 'profile card'})` });
+  }
+  if (status === 'down') {
+    rows.push({ ok: false, text: `nothing answered https://${name}.${ZONE}/ when probed` });
+  }
+
+  const recordTypes = Object.keys(records);
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-16">
+      <p className="font-(family-name:--font-mono) text-xs tracking-[0.14em] text-(--color-muted) uppercase">Debug</p>
+      <div className="mt-2 flex flex-wrap items-center gap-3">
+        <h1 className="font-(family-name:--font-display) text-2xl font-medium tracking-tight text-(--color-ink)">
+          {name}.runs-on.dev
+        </h1>
+        <span
+          className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 font-(family-name:--font-mono) text-xs"
+          style={{ borderColor: verdict.color, color: verdict.color }}
+        >
+          <span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: verdict.color }} />
+          {verdict.label}
+        </span>
+      </div>
+
+      <div className="mt-6 border border-(--color-rule) bg-(--color-card) px-5 py-4">
+        <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">{'// live check'}</p>
+        <ul className="mt-2 space-y-1 font-(family-name:--font-mono) text-xs">
+          {rows.length === 0 && <li className="text-(--color-muted)">nothing to check yet</li>}
+          {rows.map((row, i) => (
+            <li key={i} className={row.ok ? 'text-(--color-ink)' : 'text-(--color-muted)'}>
+              {row.ok ? '✓' : '…'} {row.text}
+            </li>
+          ))}
+        </ul>
+        <p className="mt-3 font-(family-name:--font-mono) text-xs text-(--color-muted)">
+          record on file: {recordTypes.length > 0 ? recordTypes.join(', ') : 'no records (card)'}
+          {(cname ?? []).length === 0 && (a ?? []).length === 0 ? ' · nothing resolves at the name yet' : ''}
+        </p>
+      </div>
+
+      {advice && (
+        <div className="mt-4 border border-(--color-signal)/50 bg-(--color-signal)/5 px-5 py-4">
+          <p className="font-(family-name:--font-mono) text-xs text-(--color-signal)">{'// what is missing'}</p>
+          <p className="mt-2 text-sm font-medium text-(--color-ink)">{advice.title}</p>
+          <p className="mt-1 text-sm leading-relaxed text-(--color-muted)">{advice.body}</p>
+        </div>
+      )}
+
+      <p className="mt-6 text-sm text-(--color-muted)">
+        Owner? Fix any of this on{' '}
+        <Link href="/manage" className="text-(--color-signal) underline">/manage</Link>
+        {'. '}The record itself is{' '}
+        <a href={`${REPO_URL}/blob/main/domains/${name}.json`} target="_blank" rel="noopener noreferrer" className="text-(--color-signal) underline">
+          domains/{name}.json
+        </a>
+        . DNS changes take up to a minute to publish after a save.
+      </p>
+    </main>
+  );
+}

--- a/app/debug/[name]/page.jsx
+++ b/app/debug/[name]/page.jsx
@@ -5,6 +5,7 @@ import { validateName } from '../../../lib/name.js';
 import { getRecord } from '../../../lib/registry.js';
 import { classifyClaim, diagnoseStuck } from '../../../lib/health.js';
 import { probe } from '../../../lib/dns-probe.js';
+import { createRateLimiter } from '../../../lib/throttle.js';
 import { REPO_URL } from '../../../lib/repo.js';
 
 // A public, shareable diagnosis for one name: what the record declares, what
@@ -24,6 +25,14 @@ export const metadata = {
 
 const ZONE = 'runs-on.dev';
 const TOKEN = () => process.env.CARD_TOKEN ?? process.env.REGISTRY_TOKEN;
+
+// Every load spends a registry read, five DNS lookups, and one outbound
+// probe, and random names defeat the record cache's 30-second revalidate —
+// the same shape that made /api/check worth throttling. Per-name budget,
+// same as dns-check: a human checking their name never sees it; a loop does.
+const DEBUG_WINDOW_MS = 60 * 1000;
+const DEBUG_MAX = 10;
+const takeDebug = createRateLimiter({ windowMs: DEBUG_WINDOW_MS, max: DEBUG_MAX });
 
 async function safe(fn, fallback) {
   try {
@@ -75,6 +84,23 @@ const VERDICT = {
 export default async function DebugPage({ params }) {
   const { name } = await params;
   if (!validateName(name).ok) notFound();
+
+  // Gate before any network work: an over-budget request must cost nothing
+  // beyond the render. A page cannot answer 429, so this renders a plain
+  // slow-down state instead.
+  const budget = takeDebug(name);
+  if (!budget.ok) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <p className="font-(family-name:--font-mono) text-xs tracking-[0.14em] text-(--color-muted) uppercase">Debug</p>
+        <h1 className="mt-2 font-(family-name:--font-display) text-2xl font-medium text-(--color-ink)">{name}.runs-on.dev</h1>
+        <p className="mt-4 text-sm leading-relaxed text-(--color-muted)">
+          Too many checks on this name in the last minute. Live DNS answers change on
+          the scale of minutes anyway — reload shortly.
+        </p>
+      </main>
+    );
+  }
 
   // Distinguish "no record" from "could not read": a registry hiccup must
   // not render a claimed name as unclaimed — this page's whole value is

--- a/app/debug/[name]/page.jsx
+++ b/app/debug/[name]/page.jsx
@@ -69,16 +69,41 @@ const VERDICT = {
   card: { label: 'Serving the profile card', color: '#9ca3af' },
   stuck: { label: 'Stuck on the profile card', color: '#eab308' },
   down: { label: 'No answer', color: '#ef4444' },
+  unknown: { label: 'Unclassified', color: '#9ca3af' },
 };
 
 export default async function DebugPage({ params }) {
   const { name } = await params;
   if (!validateName(name).ok) notFound();
 
-  const record = await safe(
-    () => getRecord(name, { token: TOKEN(), fetchImpl: (u, i) => fetch(u, { ...i, next: { revalidate: 30 } }) }),
-    null,
-  );
+  // Distinguish "no record" from "could not read": a registry hiccup must
+  // not render a claimed name as unclaimed — this page's whole value is
+  // being trusted, and getRecord returns null only for 404, throwing for
+  // everything else.
+  let record = null;
+  let readFailed = false;
+  try {
+    record = await getRecord(name, {
+      token: TOKEN(),
+      fetchImpl: (u, i) => fetch(u, { ...i, next: { revalidate: 30 } }),
+    });
+  } catch {
+    readFailed = true;
+  }
+
+  if (readFailed) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <p className="font-(family-name:--font-mono) text-xs tracking-[0.14em] text-(--color-muted) uppercase">Debug</p>
+        <h1 className="mt-2 font-(family-name:--font-display) text-2xl font-medium text-(--color-ink)">{name}.runs-on.dev</h1>
+        <p className="mt-4 text-sm leading-relaxed text-(--color-muted)">
+          The registry could not be read just now, so there is nothing trustworthy to
+          report. Reload in a moment — a claimed name is not "not claimed" because a
+          read failed.
+        </p>
+      </main>
+    );
+  }
 
   if (!record) {
     return (
@@ -118,6 +143,12 @@ export default async function DebugPage({ params }) {
     rows.push({ ok: live, text: live ? `CNAME → ${cname[0]}` : `CNAME not visible yet (want ${wantedCname})` });
   }
   if (wantedTxt.length > 0) {
+    // The challenge has to be live at the claim's own _vercel label before
+    // the zone mirror copies it up, so this row names which half is lagging
+    // when the zone row below is still red.
+    const atName = flattenTxt(txtVercelLabel);
+    const liveAtName = wantedTxt.some((v) => atName.includes(v));
+    rows.push({ ok: liveAtName, text: liveAtName ? '_vercel TXT live at the name' : `_vercel TXT not live at _vercel.${name} yet` });
     const zone = flattenTxt(txtVercelZone);
     const published = wantedTxt.some((v) => zone.includes(v));
     rows.push({ ok: published, text: published ? '_vercel TXT published at the zone' : '_vercel TXT not at the zone yet' });

--- a/lib/dns-probe.js
+++ b/lib/dns-probe.js
@@ -1,0 +1,68 @@
+import dns from 'node:dns/promises';
+
+// The "what is this name actually serving" probe, shared by /api/dns-check
+// (the manage page's verify loop) and the public /debug/<name> page. Kept in
+// lib so both answer with the same verdict for the same name at the same
+// moment; a debug page that disagreed with the panel it explains would be
+// worse than no page at all.
+
+const ZONE = 'runs-on.dev';
+const PROBE_TIMEOUT_MS = 8000;
+
+// SSRF guard: the record's A entries and any redirect target must not point
+// at a private network the server can reach. lib/schema.js accepts any valid
+// IPv4 including loopback, link-local, and RFC 1918 ranges — the schema
+// governs what DNS can express, not what an endpoint should fetch.
+const PRIVATE_RANGES = [
+  /^10\./,
+  /^127\./,
+  /^169\.254\./,
+  /^172\.(1[6-9]|2[0-9]|3[01])\./,
+  /^192\.168\./,
+  /^0\./,
+  /^::1$/,
+  /^f[cd][0-9a-f]{2}:/i,
+];
+
+// TOCTOU: this resolves the name once, then `fetch` below resolves it again
+// independently. A short-TTL record could answer public here and private on
+// the second lookup (DNS rebinding). Fixing properly means resolving once and
+// connecting to the pinned address, which is more machinery than this
+// warrants today: `redirect: 'manual'` means at most a `<title>` comes back,
+// from a host inside our own zone, and the schema only accepts A records
+// (no AAAA, so no `::1` bypass). The reasoning lives here so it isn't
+// rediscovered.
+async function resolveAndCheckPrivate(hostname) {
+  const addresses = await dns.resolve4(hostname).catch(() => []);
+  return addresses.some((addr) => PRIVATE_RANGES.some((pattern) => pattern.test(addr)));
+}
+
+// No redirect following. The initial URL is always <name>.runs-on.dev
+// (grammar-validated by every caller), so the destination is constrained by
+// DNS, not by whoever set the record. A URL-redirect name still classifies
+// correctly: the registry's own wildcard serves the 307 itself, and the probe
+// sees the registry's answer, not the redirect target.
+export async function probe(name) {
+  const host = `${name}.${ZONE}`;
+  try {
+    if (await resolveAndCheckPrivate(host)) {
+      return { ok: true, refused: true, finalHost: host, title: '', finalUrl: `https://${host}/` };
+    }
+    const res = await fetch(`https://${host}/`, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      headers: { 'user-agent': 'runs-on-dev-probe (github.com/zordhalo/runs-on.dev)' },
+    });
+    const location = res.headers.get('location');
+    // A 3xx without following the redirect: classify by the status, don't
+    // fetch wherever it points.
+    if (res.status >= 300 && res.status < 400 && location) {
+      return { ok: true, finalHost: host, title: '', finalUrl: location, redirected: true };
+    }
+    const body = await res.text();
+    const title = /<title[^>]*>([^<]*)<\/title>/i.exec(body)?.[1]?.trim() ?? '';
+    return { ok: true, finalHost: host, title, finalUrl: `https://${host}/` };
+  } catch {
+    return { ok: false };
+  }
+}


### PR DESCRIPTION
## The idea

"Why is my name still the profile card" arrives as an issue (and as confusion) because the answer lives in three places a user cannot see: the record, live DNS, and what the name actually serves. This puts all three on one shareable page — the answer becomes a link.

`/debug/<name>` shows what the record declares, what DNS answers right now (CNAME, the `_vercel` TXT at the name and at the zone), what the name serves, and — for stuck names — which specific step is missing, using the same `diagnoseStuck` kinds the health check files issues with, rendered as concrete advice. The Vercel guidance is the corrected one (remove and re-add the domain to force a re-check, not the nonexistent Refresh button).

## How it stays honest

- the probe and its SSRF guard moved verbatim from `/api/dns-check` into `lib/dns-probe.js`, shared by both, so the page and the manage panel can never disagree; the route's diff is one import line
- a registry read that throws renders "could not read just now", never "not claimed" — a claimed name is not unclaimed because GitHub hiccuped
- per-name rate limit (10/min, same budget as dns-check), gated before any network work: each load costs a registry read, five DNS lookups, and one outbound probe, and random names defeat the record cache
- unclaimed names get their own state with a claim link; invalid names 404; `noindex` throughout

## Verified live

- a healthy name: green "Serving your site", the live CNAME row, the site's title
- a genuinely stuck name (tahir): "Stuck on the profile card", both TXT rows green, advice "DNS is right, Vercel just has not re-checked" — the two-row TXT display distinguishes zone-mirror lag from a TXT that never published
- burst-tested the limiter: 10 pass, the 11th renders the slow-down state, other names unaffected

313/313 tests, build clean.
