### PR TITLE
style(nav): cutout dock, drop shadows removed

### DIFF
--- a/app/edge-picker.jsx
+++ b/app/edge-picker.jsx
@@ -486,7 +486,9 @@ export default function EdgePicker() {
   const visibleItemOffsets = [-2, -1, 1, 2];
 
   // Paper theme
-  const pillShadow = '0 0 0 1px rgba(255,255,255,0.15) inset, 0 4px 12px rgba(0,0,0,0.35)';
+  // Cutout look: the pill keeps only its inset hairline ring, no outer
+  // drop shadow, matching the flat bezel.
+  const pillShadow = '0 0 0 1px rgba(255,255,255,0.15) inset';
 
   return (
     <div
@@ -538,7 +540,7 @@ export default function EdgePicker() {
 
       {/* Curved SVG Dock Bezel: MAINTAINED in both expanded and compact states */}
       <svg
-        className="absolute right-0 top-0 h-full w-[56px] pointer-events-none drop-shadow-[-4px_0_14px_rgba(0,0,0,0.65)]"
+        className="absolute right-0 top-0 h-full w-[56px] pointer-events-none"
         viewBox="0 0 56 380"
         preserveAspectRatio="none"
       >


### PR DESCRIPTION
The bezel cast a 14px drop shadow off the right edge and the active pill carried an outer glow, both reading as a floating element sitting above the page. Removed both: the dock now sits flush with the viewport edge like a cutout.

The pill keeps its 1px inset hairline ring so it still reads against the near-black bezel with nothing else propping it up.

313/313 tests, build clean. Diff is the two shadow declarations, nothing else.
