### PR TITLE
fix: keep the owners index in step with swap and release

### DIFF
--- a/app/api/claim/route.js
+++ b/app/api/claim/route.js
@@ -76,10 +76,20 @@ export async function POST(request) {
     // machinery of an atomic two-file commit via the Git Data API for that.
     try {
       const names = [...(ownerIndex?.names ?? []), name];
-      const indexResult = await putOwnerIndex(session.login, names, {
+      // One retry: this write is what keeps the one-per-account limit honest
+      // on the next request, and its usual failure (403/429) is exactly the
+      // transient a second attempt survives. The claim itself is never failed
+      // over it; the sync-owners rebuild heals whatever both attempts miss.
+      let indexResult = await putOwnerIndex(session.login, names, {
         token: TOKEN(),
         sha: ownerIndex?.sha,
-      });
+      }).catch(() => ({ ok: false, reason: 'threw' }));
+      if (!indexResult.ok) {
+        indexResult = await putOwnerIndex(session.login, names, {
+          token: TOKEN(),
+          sha: ownerIndex?.sha,
+        }).catch(() => ({ ok: false, reason: 'threw' }));
+      }
       if (!indexResult.ok) {
         console.warn(`owner index write failed for ${session.login}: ${indexResult.reason}`);
       }

--- a/app/api/release/route.js
+++ b/app/api/release/route.js
@@ -1,6 +1,7 @@
 import { sessionFromRequest } from '../../../lib/session.js';
 import { validateName } from '../../../lib/name.js';
 import { getContentsMeta } from '../../../lib/registry.js';
+import { getOwnerIndex, putOwnerIndex } from '../../../lib/owners.js';
 import { createRateLimiter } from '../../../lib/throttle.js';
 
 // Releases a claimed name: deletes domains/<name>.json from the repo,
@@ -82,6 +83,31 @@ export async function POST(request) {
   }
   if (!res.ok) {
     return Response.json({ error: 'delete_failed', detail: `GitHub returned ${res.status}` }, { status: 502 });
+  }
+
+  // Drop the released name from the owners/ index now, not whenever the
+  // sync-owners rebuild lands: /api/claim counts from this index, so a stale
+  // entry would tell a user who just released their only name that they are
+  // still at the one-per-account limit. Best-effort; the release already
+  // succeeded.
+  try {
+    const index = await getOwnerIndex(session.login, {
+      token: process.env.REGISTRY_TOKEN,
+      fetchImpl: uncachedFetch,
+    }).catch(() => null);
+    if (index?.names?.includes(name)) {
+      const names = index.names.filter((n) => n !== name);
+      const indexResult = await putOwnerIndex(session.login, names, {
+        token: process.env.REGISTRY_TOKEN,
+        sha: index.sha,
+        fetchImpl: uncachedFetch,
+      });
+      if (!indexResult.ok) {
+        console.warn(`owner index update failed for ${session.login} after release: ${indexResult.reason}`);
+      }
+    }
+  } catch (err) {
+    console.warn(`owner index update threw for ${session.login} after release: ${err.message}`);
   }
 
   return Response.json({

--- a/app/api/swap/route.js
+++ b/app/api/swap/route.js
@@ -2,6 +2,7 @@ import { sessionFromRequest } from '../../../lib/session.js';
 import { validateName } from '../../../lib/name.js';
 import { isReserved } from '../../../lib/blocklist.js';
 import { getRecord, getContentsMeta, putRecord } from '../../../lib/registry.js';
+import { getOwnerIndex, putOwnerIndex } from '../../../lib/owners.js';
 import { createRateLimiter } from '../../../lib/throttle.js';
 
 // Swaps the user's claimed name for a new one. Releases the old name
@@ -145,6 +146,28 @@ export async function POST(request) {
         ? `${from}.runs-on.dev was released, but ${to} was just claimed by someone else. Claim a different name from the homepage.`
         : `${from}.runs-on.dev was released, but the new record could not be created. Claim ${to} again from the homepage while it is still free.`,
     }, { status: taken ? 409 : 500 });
+  }
+
+  // Keep the owners/ index in step with the swap. sync-owners rebuilds it on
+  // the next push, but /manage and the homepage read the index the moment
+  // this response returns (the client redirects within seconds), and a stale
+  // entry renders the swapped-away name as "could not be read" instead of
+  // the new one. Best-effort for the same reason as /api/claim's index
+  // write: the swap already succeeded, so never fail the request over it.
+  try {
+    const index = await getOwnerIndex(session.login, { token, fetchImpl: uncachedFetch }).catch(() => null);
+    const names = (index?.names ?? []).filter((n) => n !== from);
+    if (!names.includes(to)) names.push(to);
+    const indexResult = await putOwnerIndex(session.login, names, {
+      token,
+      sha: index?.sha,
+      fetchImpl: uncachedFetch,
+    });
+    if (!indexResult.ok) {
+      console.warn(`owner index update failed for ${session.login} after swap: ${indexResult.reason}`);
+    }
+  } catch (err) {
+    console.warn(`owner index update threw for ${session.login} after swap: ${err.message}`);
   }
 
   return Response.json({

--- a/app/manage/page.jsx
+++ b/app/manage/page.jsx
@@ -53,17 +53,24 @@ export default async function Manage() {
   const records = await Promise.all(
     names.map((name) => getRecord(name, { token: TOKEN() }).catch(() => null)),
   );
+  const unreadable = names.filter((_, i) => !records[i]);
 
   return (
     <Shell>
       {records.map((record, i) =>
         record ? (
           <RecordForm key={names[i]} name={names[i]} record={record} />
-        ) : (
-          <p key={names[i]} className="text-sm text-(--color-muted)">
-            Could not read domains/{names[i]}.json just now. Reload to try again.
-          </p>
-        ),
+        ) : null,
+      )}
+      {/* An indexed name whose file cannot be read is skipped rather than
+          replacing the whole page with an error: one unreadable record must
+          not hide the others, and "reload to try again" was a promise the
+          stale-index window after a swap could not keep. */}
+      {unreadable.length > 0 && (
+        <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">
+          {'// not shown just now: '}
+          {unreadable.map((name) => `domains/${name}.json`).join(', ')}
+        </p>
       )}
     </Shell>
   );

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -46,6 +46,10 @@ async function ownedName(session) {
   const name = index?.names?.[0];
   if (!name) return null;
   const record = await getRecord(name, { token }).catch(() => null);
+  // An index entry whose record cannot be read (a stale index after a swap,
+  // or a transient read failure) must not render as "your name is a bare
+  // card": fall back to the claim form, which answers with the truth.
+  if (!record) return null;
   return { name, record };
 }
 


### PR DESCRIPTION
Part of #138 (finding 1).

## The problem

`/api/claim` writes `owners/<login>.json`, but swap and release do not. Until the sync-owners rebuild lands one to three minutes later, every reader of the index is wrong:

- `/manage` shows the swapped-away name as "could not be read, reload", and the swap UI redirects there within seconds of a successful swap, so every swap lands inside the window
- the homepage renders the released name as "yours, isn't pointing anywhere yet" (indexed name, unreadable record)
- `/api/claim` tells a user who just released their only name that they are still at the one-per-account limit

## The change

- swap and release update the index in the same request, best-effort exactly like claim's own write: the operation has already succeeded by then, so a bookkeeping failure is logged and never fails the response
- claim retries its index write once, since a 403/429 is the usual and transient failure, and this write is what keeps the limit honest on the next request
- `/manage` skips unreadable indexed names with a quiet note instead of replacing the page with a reload prompt the stale window cannot satisfy
- the homepage falls back to the claim form when an indexed name's record cannot be read, rather than rendering a wrong bare-card state

sync-owners' rebuild stays the source of truth; these writes just keep the window closed, and the rebuild finds nothing to change once it runs.

313/313 tests, build clean.
