### PR TITLE
Point lesley.runs-on.dev at GitHub Pages

### DIFF
--- a/domains/lesley.json
+++ b/domains/lesley.json
@@ -4,5 +4,7 @@
     "github": "Le-e-lab"
   },
   "claimedAt": "2026-09-09T19:52:42.954Z",
-  "records": {}
+  "records": {
+    "CNAME": "le-e-lab.github.io"
+  }
 }


### PR DESCRIPTION
Adding the CNAME record to serve my portfolio at **lesley.runs-on.dev**.

```json
{
  "name": "lesley",
  "owner": { "github": "Le-e-lab" },
  "claimedAt": "2026-09-09T19:52:42.954Z",
  "records": { "CNAME": "le-e-lab.github.io" }
}
```

- Owner: Le-e-lab (matches PR author)
- `claimedAt` unchanged from the existing claim
- CNAME points to my GitHub Pages host, where the portfolio lives (site served at the root of the custom domain)