### PR TITLE
feat(sites): instant static hosting for claimed names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ GITHUB_CLIENT_ID=your-github-oauth-client-id
 GITHUB_CLIENT_SECRET=your-github-oauth-client-secret
 # 32 random bytes, hex-encoded (e.g. `openssl rand -hex 32`) — signs session cookies
 SESSION_SECRET=replace-with-32-random-bytes-hex
+# 32 random bytes, hex-encoded — signs deploy API tokens. Separate from
+# SESSION_SECRET so rotating one never invalidates the other.
+SITE_TOKEN_SECRET=replace-with-32-random-bytes-hex
+# Vercel Blob store token (https://vercel.com/storage/blob) — holds the bytes
+# of hosted sites. Deploy endpoints answer 503 without it.
+BLOB_READ_WRITE_TOKEN=your-vercel-blob-token
 # Public origin this app is served from, no trailing slash (e.g. https://runs-on.dev)
 APP_ORIGIN=http://localhost:3000
 # owner/repo of the registry data repo the app reads/writes records to

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,9 @@ on:
     # which costs one deploy instead of one per claim.
     # `.moderation/**` joins them for the same reason: the spam log is
     # evidence, not application code, and a burst of spam should not spend
-    # the deploy budget.
-    paths-ignore: ['domains/**', 'owners/**', 'data/**', 'docs/**', '.moderation/**', '*.md']
+    # the deploy budget. `sites/**` is registry data too (hosted-site
+    # pointers, written per deploy), so it never triggers a build either.
+    paths-ignore: ['domains/**', 'owners/**', 'data/**', 'docs/**', '.moderation/**', 'sites/**', '*.md']
   schedule:
     # Daily at 04:00 UTC, off the top of the hour so it doesn't co-fire with
     # the health check. Rebuilds /stats from the current state of domains/.

--- a/app/api/sites/deploy/route.js
+++ b/app/api/sites/deploy/route.js
@@ -1,0 +1,120 @@
+import { authorizeBearer, resolveSiteName } from '../../../../lib/site-access.js';
+import { createRateLimiter } from '../../../../lib/throttle.js';
+import { readZip, MAX_ZIP_BYTES } from '../../../../lib/zip.js';
+import { getSite, putSite, applyDeployment, newDeployment } from '../../../../lib/sites.js';
+import { storeConfigured, putDeployment, deletePrefixes } from '../../../../lib/store.js';
+
+// A deploy spends real storage and a registry commit, so it gets the same
+// order of allowance a record edit does rather than a read's.
+const DEPLOY_WINDOW_MS = 10 * 60 * 1000;
+const DEPLOY_MAX = 6;
+const takeDeploy = createRateLimiter({ windowMs: DEPLOY_WINDOW_MS, max: DEPLOY_MAX });
+
+const TOKEN = () => process.env.REGISTRY_TOKEN;
+
+export const runtime = 'nodejs';
+
+// POST a zip, get a live deployment. Body: multipart/form-data with `site`
+// (the zip, required) and `name` (optional while accounts hold one name).
+//
+// The write order is deliberate: upload the files first, then move the
+// pointer. If the pointer write fails or loses a race, the freshly uploaded
+// prefix is reclaimed right there — a crash between the two is the only path
+// that can still orphan storage, and only a future cleanup workflow can see
+// that, because to every reader the orphan has never been referenced.
+export async function POST(request) {
+  if (!storeConfigured()) {
+    return Response.json({ error: 'storage_not_configured' }, { status: 503 });
+  }
+
+  // Refuse on the declared size before anything parses. The envelope adds a
+  // little overhead to the zip itself, so the hard check stays on file.size.
+  const declared = Number(request.headers.get('content-length') ?? 0);
+  if (declared > MAX_ZIP_BYTES + 64 * 1024) {
+    return Response.json({ error: 'too_big' }, { status: 413 });
+  }
+
+  // Credential and budget before the body: an unauthenticated caller must
+  // not be able to make the server parse anything, only spend its own
+  // (now-consumed) allowance.
+  const auth = authorizeBearer(request, takeDeploy);
+  if (auth.response) return auth.response;
+
+  const form = await request.formData().catch(() => null);
+  if (!form) {
+    return Response.json({ error: 'invalid_request' }, { status: 400 });
+  }
+  const file = form.get('site');
+  if (!(file instanceof File)) {
+    return Response.json({ error: 'missing_file' }, { status: 400 });
+  }
+  if (file.size > MAX_ZIP_BYTES) {
+    return Response.json({ error: 'too_big' }, { status: 413 });
+  }
+
+  const name = await resolveSiteName(auth, form.get('name'));
+  if (name.response) return name.response;
+
+  const zip = readZip(Buffer.from(await file.arrayBuffer()));
+  if (!zip.ok) {
+    return Response.json({ error: 'invalid_zip', reason: zip.reason }, { status: 400 });
+  }
+  if (!zip.entries.some((e) => e.name === 'index.html')) {
+    return Response.json({ error: 'no_index_html' }, { status: 400 });
+  }
+
+  let existing;
+  try {
+    existing = await getSite(name.name, { token: TOKEN() });
+  } catch {
+    return Response.json({ error: 'busy' }, { status: 503, headers: { 'Retry-After': '4' } });
+  }
+
+  const deployment = newDeployment({ files: zip.entries.length, bytes: zip.totalBytes });
+  const prefix = `sites/${name.name}/${deployment.id}/`;
+  const stored = await putDeployment(prefix, zip.entries);
+  if (!stored.ok) {
+    return Response.json({ error: 'storage_error' }, { status: 503 });
+  }
+
+  const { record, pruned } = applyDeployment(existing?.data, {
+    name: name.name,
+    owner: auth.login,
+    deployment,
+  });
+  const result = await putSite(record, {
+    token: TOKEN(),
+    sha: existing?.sha,
+    editor: auth.login,
+  });
+  if (!result.ok) {
+    // This deployment never entered history, so no future prune can see the
+    // prefix. Reclaim it now, best-effort — a failed delete is leftover
+    // storage, and it must never mask the failure that caused it.
+    await deletePrefixes([prefix]);
+    if (result.reason === 'stale' || result.reason === 'exists') {
+      // Another deploy of this name landed mid-flight (a lost race on the
+      // first deploy reports `exists`); the caller re-reads and decides,
+      // exactly as a stale record edit does.
+      return Response.json({ error: 'stale' }, { status: 409 });
+    }
+    if (result.reason === 'ratelimited') {
+      return Response.json({ error: 'busy' }, { status: 503, headers: { 'Retry-After': '4' } });
+    }
+    return Response.json({ error: 'server_error' }, { status: 500 });
+  }
+
+  // Sweep what fell out of history. Best-effort by design: the pointer has
+  // moved, and leftover bytes are a storage cost, not a correctness problem.
+  if (pruned.length > 0) {
+    await deletePrefixes(pruned.map((d) => `sites/${name.name}/${d.id}/`));
+  }
+
+  return Response.json({
+    url: `https://${name.name}.runs-on.dev/`,
+    deploymentId: deployment.id,
+    files: deployment.files,
+    bytes: deployment.bytes,
+    commit: result.commit ?? null,
+  });
+}

--- a/app/api/sites/deployments/route.js
+++ b/app/api/sites/deployments/route.js
@@ -1,0 +1,39 @@
+import { authorizeSiteAction } from '../../../../lib/site-access.js';
+import { createRateLimiter } from '../../../../lib/throttle.js';
+import { getSite } from '../../../../lib/sites.js';
+
+const TOKEN = () => process.env.REGISTRY_TOKEN;
+
+// Reads cost the registry two GitHub requests (owner index, site file), so
+// they are capped too — looser than deploys, since listing is what an agent
+// does to orient itself before deciding anything.
+const READ_WINDOW_MS = 10 * 60 * 1000;
+const READ_MAX = 30;
+const takeRead = createRateLimiter({ windowMs: READ_WINDOW_MS, max: READ_MAX });
+
+export async function GET(request) {
+  const url = new URL(request.url);
+  const auth = await authorizeSiteAction(request, {
+    explicitName: url.searchParams.get('name'),
+    takeBudget: takeRead,
+  });
+  if (auth.response) return auth.response;
+
+  let site;
+  try {
+    site = await getSite(auth.name, { token: TOKEN() });
+  } catch {
+    return Response.json({ error: 'busy' }, { status: 503, headers: { 'Retry-After': '4' } });
+  }
+
+  if (!site) {
+    return Response.json({ name: auth.name, active: null, deployments: [] });
+  }
+
+  return Response.json({
+    name: site.data.name,
+    active: site.data.active,
+    deployments: site.data.deployments,
+    updatedAt: site.data.updatedAt,
+  });
+}

--- a/app/api/sites/rollback/route.js
+++ b/app/api/sites/rollback/route.js
@@ -1,0 +1,62 @@
+import { authorizeBearer, resolveSiteName } from '../../../../lib/site-access.js';
+import { createRateLimiter } from '../../../../lib/throttle.js';
+import { getSite, putSite, rollbackTo } from '../../../../lib/sites.js';
+
+const TOKEN = () => process.env.REGISTRY_TOKEN;
+
+// A pointer swap, not a re-upload — but it is still a registry write with a
+// visitor-visible effect, so it gets a deploy-shaped allowance.
+const ROLLBACK_WINDOW_MS = 10 * 60 * 1000;
+const ROLLBACK_MAX = 6;
+const takeRollback = createRateLimiter({ windowMs: ROLLBACK_WINDOW_MS, max: ROLLBACK_MAX });
+
+// POST { deploymentId, name? } — re-points the live site at a deployment
+// still in history. There is nothing to roll back to once history has pruned
+// it: the bytes are gone, and saying so beats serving a stranger's 404.
+export async function POST(request) {
+  // Credential and budget before the body, for the same reason as the deploy
+  // route: an unauthenticated caller gets neither parsing nor a registry read.
+  const auth = authorizeBearer(request, takeRollback);
+  if (auth.response) return auth.response;
+
+  const body = await request.json().catch(() => ({}));
+  const deploymentId = typeof body.deploymentId === 'string' ? body.deploymentId.trim() : '';
+  if (!/^[0-9a-f]{8}$/.test(deploymentId)) {
+    return Response.json({ error: 'invalid_deployment_id' }, { status: 400 });
+  }
+
+  const name = await resolveSiteName(auth, body.name);
+  if (name.response) return name.response;
+
+  let site;
+  try {
+    site = await getSite(name.name, { token: TOKEN() });
+  } catch {
+    return Response.json({ error: 'busy' }, { status: 503, headers: { 'Retry-After': '4' } });
+  }
+  if (!site) {
+    return Response.json({ error: 'no_site' }, { status: 404 });
+  }
+
+  const record = rollbackTo(site.data, deploymentId);
+  if (!record) {
+    return Response.json({ error: 'unknown_deployment' }, { status: 404 });
+  }
+
+  const result = await putSite(record, {
+    token: TOKEN(),
+    sha: site.sha,
+    editor: auth.login,
+  });
+  if (!result.ok) {
+    if (result.reason === 'stale') {
+      return Response.json({ error: 'stale' }, { status: 409 });
+    }
+    if (result.reason === 'ratelimited') {
+      return Response.json({ error: 'busy' }, { status: 503, headers: { 'Retry-After': '4' } });
+    }
+    return Response.json({ error: 'server_error' }, { status: 500 });
+  }
+
+  return Response.json({ name: name.name, active: record.active, updatedAt: record.updatedAt });
+}

--- a/app/api/tokens/route.js
+++ b/app/api/tokens/route.js
@@ -1,0 +1,51 @@
+import { signSiteToken, SITE_TOKEN_SCOPE, SITE_TOKEN_TTL_MS } from '../../../lib/tokens.js';
+import { sessionFromRequest } from '../../../lib/session.js';
+import { createRateLimiter } from '../../../lib/throttle.js';
+
+// Minting is a no-op on the registry (the token is stateless), but it should
+// still not be free: a leaned-on button or a stuck loop minting thousands of
+// valid 30-day credentials is its own kind of incident. Tight enough that a
+// human generating, copying, and pasting never trips it.
+const MINT_WINDOW_MS = 10 * 60 * 1000;
+const MINT_MAX = 5;
+const takeMint = createRateLimiter({ windowMs: MINT_WINDOW_MS, max: MINT_MAX });
+
+// The only way a deploy token comes into existence: the browser session says
+// who the login is, the server signs it, the response shows it once. There is
+// deliberately no GET: stateless tokens cannot be listed, and a "does one
+// exist" oracle would only ever return yes after the first mint anyway.
+export async function POST(request) {
+  const session = sessionFromRequest(request, process.env.SESSION_SECRET);
+  if (!session?.login) {
+    return Response.json({ error: 'signin_required' }, { status: 401 });
+  }
+
+  const budget = takeMint(session.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return Response.json(
+      { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(seconds) } },
+    );
+  }
+
+  const secret = process.env.SITE_TOKEN_SECRET;
+  if (!secret) {
+    // Fail closed rather than sign with nothing: an empty secret would make
+    // every token forgeable by anyone who guesses the failure mode.
+    return Response.json({ error: 'not_configured' }, { status: 503 });
+  }
+
+  const now = Date.now();
+  const token = signSiteToken(
+    { login: session.login, scope: SITE_TOKEN_SCOPE },
+    secret,
+    { now },
+  );
+
+  return Response.json({
+    token,
+    scope: SITE_TOKEN_SCOPE,
+    expiresAt: new Date(now + SITE_TOKEN_TTL_MS).toISOString(),
+  });
+}

--- a/app/manage/page.jsx
+++ b/app/manage/page.jsx
@@ -3,6 +3,7 @@ import { readSession } from '../../lib/session.js';
 import { getOwnerIndex } from '../../lib/owners.js';
 import { getRecord } from '../../lib/registry.js';
 import RecordForm from './record-form.jsx';
+import TokenZone from './token-zone.jsx';
 
 export const metadata = {
   title: 'Manage your name — runs-on.dev',
@@ -65,6 +66,9 @@ export default async function Manage() {
           </p>
         ),
       )}
+      {/* Account-scoped, so it renders once after the per-name forms rather
+          than inside them: the token speaks for @login, not for one name. */}
+      <TokenZone login={session.login} />
     </Shell>
   );
 }

--- a/app/manage/token-zone.jsx
+++ b/app/manage/token-zone.jsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useState } from 'react';
+
+// The whole deploy workflow as a paste-and-go prompt for a coding agent. The
+// token rides inside it (or a placeholder before one exists), because the
+// one thing an agent cannot do for itself is mint a browser-session
+// credential — everything after that is three curl-able endpoints.
+function agentPrompt(token, expiresNote) {
+  return `You are deploying a static site to runs-on.dev for me.
+
+AUTH
+Bearer token (publishes only to my claimed runs-on.dev name, ${expiresNote}):
+${token}
+Send it as an Authorization: Bearer header on every request below. Never
+commit it to git, log it, or send it anywhere except runs-on.dev.
+
+BASE URL: https://runs-on.dev
+
+1) DEPLOY
+- Build the site first. The upload is the BUILT static output (HTML, CSS,
+  JS, assets), never the source project.
+- Zip the output so index.html sits at the ROOT of the zip, not inside a
+  dist/ or public/ folder:
+    cd <output-directory> && zip -r site.zip .
+- Upload:
+    curl -X POST https://runs-on.dev/api/sites/deploy \\
+      -H "Authorization: Bearer ${token}" \\
+      -F "site=@site.zip"
+- Success is 200 with { url, deploymentId, files, bytes }. Tell me the url
+  and the deploymentId.
+
+ZIP RULES (enforced server-side; a bad zip is rejected with a reason)
+- index.html is required at the zip root
+- zip at most 10 MB, uncompressed total at most 100 MB, at most 500 entries
+- relative paths only: no leading /, no .., no drive letters, no backslashes
+- no encrypted entries, standard stored/deflate compression only, no
+  duplicate file names
+
+2) LIST DEPLOYMENTS
+    curl -H "Authorization: Bearer ${token}" \\
+      https://runs-on.dev/api/sites/deployments
+Returns { active, deployments: [{ id, at, files, bytes }] }, newest last.
+
+3) ROLL BACK (instant, no re-upload)
+    curl -X POST https://runs-on.dev/api/sites/rollback \\
+      -H "Authorization: Bearer ${token}" \\
+      -H "Content-Type: application/json" \\
+      -d '{"deploymentId":"<8-hex id from the list>"}'
+
+ERRORS: fix per code, never blind-retry
+- 400 no_index_html: re-zip with index.html at the root
+- 400 invalid_zip plus a reason: fix the zip per the reason
+- 413 too_big: shrink assets, then redeploy
+- 409 stale: a newer deploy landed mid-flight. List deployments, decide,
+  then redeploy
+- 429 rate_limited: wait the Retry-After seconds, retry once
+- 503: runs-on.dev is busy or its storage is not configured. Tell me and
+  stop retrying
+
+NOTES
+- The last 5 deployments are kept; older ones are deleted and cannot be
+  rolled back to.
+- If the url still shows a profile card, serving is not enabled on
+  runs-on.dev yet; the deployment itself succeeded.
+- Deploying never touches DNS records or the profile card settings.`;
+}
+
+// The deploy-token card. Account-scoped, unlike the record forms above it,
+// which are per-name: one login mints one kind of credential, and the
+// deployment it unlocks is always that account's own name.
+export default function TokenZone({ login }) {
+  const [state, setState] = useState('idle'); // idle | minting | minted | error
+  const [token, setToken] = useState('');
+  const [expiresAt, setExpiresAt] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [copiedPrompt, setCopiedPrompt] = useState(false);
+
+  async function mint() {
+    setState('minting');
+    setCopied(false);
+    try {
+      const res = await fetch('/api/tokens', { method: 'POST' });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok && body.token) {
+        setToken(body.token);
+        setExpiresAt(body.expiresAt);
+        setState('minted');
+      } else {
+        setState('error');
+      }
+    } catch {
+      setState('error');
+    }
+  }
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
+  }
+
+  async function copyPrompt(text) {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedPrompt(true);
+      setTimeout(() => setCopiedPrompt(false), 2000);
+    } catch {}
+  }
+
+  return (
+    <section className="border border-(--color-rule) bg-(--color-card)">
+      <div className="border-b border-(--color-rule) px-6 py-5 sm:px-8">
+        <p className="font-(family-name:--font-mono) text-xs text-(--color-muted)">@{login}</p>
+        <h2 className="mt-1 font-(family-name:--font-display) text-xl font-medium tracking-tight text-(--color-ink) sm:text-2xl">
+          Deploy token
+        </h2>
+      </div>
+
+      <div className="px-6 py-5 sm:px-8">
+        <p className="text-sm leading-relaxed text-(--color-muted)">
+          Publish a static site to your name from a terminal or a coding agent, no browser
+          needed. Generate a token, then:
+        </p>
+        <pre className="mt-3 overflow-x-auto border border-(--color-rule) px-3 py-2 font-(family-name:--font-mono) text-xs leading-relaxed text-(--color-ink)">
+{`curl -X POST https://runs-on.dev/api/sites/deploy \\
+  -H "Authorization: Bearer <token>" \\
+  -F "site=@dist.zip"`}
+        </pre>
+
+        {state !== 'minted' && (
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={mint}
+              disabled={state === 'minting'}
+              className="border px-4 py-2 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-90 disabled:opacity-50"
+              style={{ borderColor: 'var(--color-signal)', background: 'var(--color-signal)', color: 'var(--color-paper)' }}
+            >
+              {state === 'minting' ? 'Generating…' : 'Generate token'}
+            </button>
+            {state === 'error' && (
+              <span className="font-(family-name:--font-mono) text-xs text-(--color-signal)">
+                could not generate just now, try again
+              </span>
+            )}
+          </div>
+        )}
+
+        {state === 'minted' && (
+          <div className="mt-4 space-y-3">
+            {/* Shown exactly once: the server stores nothing, so there is no
+                list to come back to and no way to show it again later. */}
+            <div className="border border-(--color-signal) px-3 py-2">
+              <p className="font-(family-name:--font-mono) text-xs text-(--color-signal)">
+                shown once — copy it now
+              </p>
+              <div className="mt-2 flex items-start gap-2">
+                <code className="min-w-0 flex-1 break-all font-(family-name:--font-mono) text-xs text-(--color-ink)">
+                  {token}
+                </code>
+                <button type="button" onClick={copy} className="shrink-0 border border-(--color-rule) px-2 py-1 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">
+                  {copied ? 'copied' : 'copy'}
+                </button>
+              </div>
+            </div>
+            <p className="text-xs leading-relaxed text-(--color-muted)">
+              Expires {expiresAt ? new Date(expiresAt).toLocaleDateString() : 'in 30 days'}.
+              Treat it like a password: it can publish to your name and nothing else.
+              Generating another does not revoke this one — old tokens simply expire.
+            </p>
+            <button type="button" onClick={mint} className="border border-(--color-rule) px-3 py-1.5 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">
+              generate another
+            </button>
+          </div>
+        )}
+
+        {/* The paste-and-go agent prompt. Embeds the real token only while
+            this render has one (the mint response is shown once); after a
+            reload it falls back to the placeholder, because stateless tokens
+            cannot be listed or shown again. */}
+        {(() => {
+          const live = state === 'minted';
+          const expiresNote = live
+            ? `expires ${expiresAt ? new Date(expiresAt).toLocaleDateString() : 'in 30 days'}`
+            : 'expires 30 days after you generate it';
+          const text = agentPrompt(
+            live ? token : 'rod1.YOUR_TOKEN (generate one above first)',
+            expiresNote,
+          );
+          return (
+            <details className="mt-6 border border-(--color-rule)" open={live}>
+              <summary className="cursor-pointer px-4 py-3 font-(family-name:--font-mono) text-xs text-(--color-ink)">
+                {'// '}hand this to your AI agent
+              </summary>
+              <div className="border-t border-(--color-rule) px-4 py-3">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs leading-relaxed text-(--color-muted)">
+                    A complete deploy-runbook prompt. {live
+                      ? 'Your token is already embedded.'
+                      : 'Generate a token first and it will embed itself.'}
+                  </p>
+                  <button type="button" onClick={() => copyPrompt(text)} className="shrink-0 border border-(--color-rule) px-2 py-1 font-(family-name:--font-mono) text-xs transition-opacity hover:opacity-80">
+                    {copiedPrompt ? 'copied' : 'copy prompt'}
+                  </button>
+                </div>
+                <pre className="mt-3 max-h-96 overflow-auto border border-(--color-rule) bg-(--color-paper) px-3 py-2 font-(family-name:--font-mono) text-xs leading-relaxed text-(--color-ink) whitespace-pre-wrap">
+{text}
+                </pre>
+              </div>
+            </details>
+          );
+        })()}
+      </div>
+    </section>
+  );
+}

--- a/lib/site-access.js
+++ b/lib/site-access.js
@@ -1,0 +1,78 @@
+import { siteTokenFromRequest, SITE_TOKEN_SCOPE } from './tokens.js';
+import { getOwnerIndex } from './owners.js';
+import { validateName } from './name.js';
+
+const TOKEN = () => process.env.REGISTRY_TOKEN;
+
+// The credential half of the front door: verify the bearer token and spend
+// the route's throttle budget. Split out from the name resolution so routes
+// whose parameters arrive in a request body (deploy's zip, rollback's JSON)
+// can authenticate BEFORE parsing anything — an unauthenticated caller must
+// not be able to spend server memory on a body, only its own rate budget.
+//
+// Returns { login } to proceed with, or { response } to return as-is.
+export function authorizeBearer(request, takeBudget) {
+  const payload = siteTokenFromRequest(request, process.env.SITE_TOKEN_SECRET);
+  if (!payload?.login || payload.scope !== SITE_TOKEN_SCOPE) {
+    return { response: Response.json({ error: 'invalid_token' }, { status: 401 }) };
+  }
+
+  const budget = takeBudget(payload.login.toLowerCase());
+  if (!budget.ok) {
+    const seconds = Math.ceil(budget.retryAfterMs / 1000);
+    return {
+      response: Response.json(
+        { error: 'rate_limited', retryInMs: budget.retryAfterMs },
+        { status: 429, headers: { 'Retry-After': String(seconds) } },
+      ),
+    };
+  }
+
+  return { login: payload.login };
+}
+
+// The name half: read the owner index and settle on the one name the action
+// targets. Split for the same reason as authorizeBearer — this spends a
+// registry read, so it runs after the body has proven itself worth one.
+//
+// Returns { name } to proceed with, or { response } to return as-is.
+export async function resolveSiteName({ login }, explicitName) {
+  // Fail closed, like /api/records: an index that could not be read must not
+  // read as "this account owns nothing" (which would be a 403 for a person
+  // who owns a name) nor as permission to act.
+  let index;
+  try {
+    index = await getOwnerIndex(login, { token: TOKEN() });
+  } catch {
+    return { response: Response.json({ error: 'busy' }, { status: 503, headers: { 'Retry-After': '4' } }) };
+  }
+  if (!index || !Array.isArray(index.names) || index.names.length === 0) {
+    return { response: Response.json({ error: 'no_claimed_name' }, { status: 403 }) };
+  }
+
+  // v1 accounts hold exactly one name, so it can be implied. The explicit
+  // form exists so the day MAX_NAMES_PER_ACCOUNT changes, callers that send a
+  // name keep working and the ambiguity is surfaced rather than guessed away.
+  let name;
+  if (explicitName !== null && explicitName !== undefined && explicitName !== '') {
+    name = String(explicitName).trim().toLowerCase();
+    if (!validateName(name).ok || !index.names.includes(name)) {
+      return { response: Response.json({ error: 'not_your_name' }, { status: 403 }) };
+    }
+  } else if (index.names.length === 1) {
+    name = index.names[0];
+  } else {
+    return { response: Response.json({ error: 'name_required' }, { status: 400 }) };
+  }
+
+  return { name };
+}
+
+// The whole front door in one call, for routes whose parameters ride in the
+// query string and parse for free (the deployments list). Body-carrying
+// routes use the two halves in order: authorizeBearer, parse, resolveSiteName.
+export async function authorizeSiteAction(request, { explicitName, takeBudget }) {
+  const auth = authorizeBearer(request, takeBudget);
+  if (auth.response) return auth;
+  return resolveSiteName(auth, explicitName);
+}

--- a/lib/sites.js
+++ b/lib/sites.js
@@ -1,0 +1,87 @@
+import { randomBytes } from 'node:crypto';
+import { API, REPO, headers, getContentsMeta } from './registry.js';
+import { validateName } from './name.js';
+
+// Hosted-site bookkeeping in the registry repo, parallel to domains/. A site
+// file never holds content — the bytes live in Blob under sites/<name>/<id>/
+// — it holds the pointer: which deployment is live and which older ones are
+// kept around for rollback.
+//
+// Deliberately a separate directory from domains/: sync-dns triggers on
+// domains/** pushes only, so site deploys can never fire a DNS sync, and the
+// DNS-bearing record stays the single authority on where a name resolves.
+
+export const MAX_DEPLOYMENTS_KEPT = 5;
+
+function pathFor(name) {
+  // Same guard shape as lib/owners.js: routes validate the name first, and
+  // this second check is what keeps a hostile string out of the API path even
+  // if a future caller forgets.
+  if (!validateName(name).ok) {
+    throw new Error(`invalid site name: ${name}`);
+  }
+  return `sites/${name}.json`;
+}
+
+export async function getSite(name, opts = {}) {
+  const meta = await getContentsMeta(pathFor(name), opts);
+  if (!meta) return null;
+  return { data: meta.data, sha: meta.sha };
+}
+
+export function newDeployment({ files, bytes, now = new Date() }) {
+  return {
+    id: randomBytes(4).toString('hex'),
+    at: now.toISOString(),
+    files,
+    bytes,
+  };
+}
+
+// Appends a deployment as the active one and prunes the history to the last
+// MAX_DEPLOYMENTS_KEPT. Returns the record to commit plus the deployments
+// that fell out of it, whose Blob prefixes the caller may then delete
+// (best-effort: a failed delete must never fail the deploy).
+export function applyDeployment(existing, { name, owner, deployment }) {
+  const history = [...(existing?.deployments ?? []).filter((d) => d.id !== deployment.id), deployment];
+  const kept = history.slice(-MAX_DEPLOYMENTS_KEPT);
+  const pruned = history.slice(0, -MAX_DEPLOYMENTS_KEPT);
+
+  const record = existing
+    ? { ...existing, active: deployment.id, deployments: kept, updatedAt: deployment.at }
+    : { name, owner, active: deployment.id, deployments: kept, updatedAt: deployment.at };
+
+  return { record, pruned };
+}
+
+// Swaps the active pointer to a deployment already in the history. Rollback
+// re-points rather than re-uploads, which is why pruned deployments are gone
+// for good: there is nothing left on the storage side to point at.
+export function rollbackTo(existing, deploymentId, { now = new Date() } = {}) {
+  if (!existing) return null;
+  const target = existing.deployments.find((d) => d.id === deploymentId);
+  if (!target) return null;
+  return { ...existing, active: target.id, updatedAt: now.toISOString() };
+}
+
+export async function putSite(record, { token, sha, editor, fetchImpl = fetch } = {}) {
+  const res = await fetchImpl(`${API}/repos/${REPO}/contents/${pathFor(record.name)}`, {
+    method: 'PUT',
+    headers: { ...headers(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: `site: ${record.name} by @${editor}`,
+      content: Buffer.from(`${JSON.stringify(record, null, 2)}\n`).toString('base64'),
+      ...(sha ? { sha } : {}),
+    }),
+  });
+
+  if (res.status === 403 || res.status === 429) return { ok: false, reason: 'ratelimited' };
+  // Same contract as putRecordUpdate: with a sha this is a stale write; without
+  // one the path already exists, which the first deploy treats as a race lost
+  // to another deploy of the same name, not a server error.
+  if (res.status === 409 || res.status === 422) return { ok: false, reason: sha ? 'stale' : 'exists' };
+  if (!res.ok) return { ok: false, reason: 'error' };
+
+  const written = await res.json().catch(() => null);
+  return { ok: true, commit: written?.commit?.sha ?? null };
+}

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,0 +1,65 @@
+import { put, list, del } from '@vercel/blob';
+
+// The one module that knows where hosted-site bytes live. Everything above it
+// speaks in `sites/<name>/<deploymentId>/...` pathnames; if the storage
+// backend ever moves (R2, S3, anything), it moves here and only here.
+
+export function storeConfigured() {
+  return Boolean(process.env.BLOB_READ_WRITE_TOKEN);
+}
+
+// Uploads a deployment's files in bounded batches rather than one request per
+// file (500 round-trips) or all at once (a 500-request fan-out). 10 keeps a
+// deploy of a realistic site a handful of round-trips without a burst the
+// store would rather not see.
+const BATCH = 10;
+
+export async function putDeployment(prefix, entries) {
+  for (let i = 0; i < entries.length; i += BATCH) {
+    const batch = entries.slice(i, i + BATCH);
+    // allSettled, not all: Promise.all abandons its siblings on the first
+    // rejection while they are still in flight, and those stray successes
+    // would outlive the failure report that never mentions them.
+    const settled = await Promise.allSettled(batch.map((entry) => put(
+      // The trailing path is the entry name verbatim; lib/zip.js already
+      // guaranteed it is a plain relative path, so it cannot escape the
+      // deployment prefix.
+      `${prefix}${entry.name}`,
+      entry.data,
+      // Hosted sites are public by definition; the deploy endpoint is the
+      // gate, not the store.
+      { access: 'public' },
+    )));
+    if (settled.some((r) => r.status === 'rejected')) {
+      // A failed batch makes this deployment undeployable, so the whole
+      // prefix goes — earlier batches included. Half an upload must never
+      // sit publicly at a path nothing will ever reference.
+      await deletePrefixes([prefix]);
+      return { ok: false, uploaded: i };
+    }
+  }
+  return { ok: true, uploaded: entries.length };
+}
+
+// Best-effort prefix delete for pruned deployments. The caller treats a
+// failure as leftover storage, never as a failed deploy: the pointer already
+// moved, and an orphaned prefix is reclaimable by the cleanup workflow.
+export async function deletePrefixes(prefixes) {
+  let deleted = 0;
+  for (const prefix of prefixes) {
+    try {
+      let cursor;
+      do {
+        const page = await list({ prefix, cursor });
+        if (page.blobs.length > 0) {
+          await del(page.blobs.map((b) => b.url));
+          deleted += page.blobs.length;
+        }
+        cursor = page.cursor;
+      } while (cursor);
+    } catch {
+      // Swallow on purpose, and report what did delete.
+    }
+  }
+  return { ok: true, deleted };
+}

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,0 +1,63 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+function sign(body, secret) {
+  return createHmac('sha256', secret).update(body).digest('base64url');
+}
+
+// Deploy tokens outlive any browser session (an agent or CI posts a zip weeks
+// after its owner clicked "generate"), so 30 days rather than the session's
+// 24 hours. One source of truth for the lifetime, like SESSION_TTL_MS.
+export const SITE_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+// The prefix makes a deploy token visually unmistakable from a session cookie
+// in logs and bug reports, and the version digit means a future format change
+// can ship as rod2 without rod1 tokens becoming ambiguous garbage.
+const PREFIX = 'rod1';
+export const SITE_TOKEN_SCOPE = 'sites';
+
+export function signSiteToken(payload, secret, { now = Date.now() } = {}) {
+  const body = Buffer.from(
+    JSON.stringify({ ...payload, exp: now + SITE_TOKEN_TTL_MS }),
+  ).toString('base64url');
+  return `${PREFIX}.${body}.${sign(body, secret)}`;
+}
+
+// The token counterpart of readSession, with the same fail-closed rules: a
+// valid signature only proves we minted the string, never that it is still
+// current or of this version. Stateless by design -- the server stores
+// nothing, so minting a new token cannot revoke an old one; rotation is the
+// revocation path, and the manage UI says so in plain words.
+export function readSiteToken(raw, secret, { now = Date.now() } = {}) {
+  if (typeof raw !== 'string' || !secret) return null;
+
+  const parts = raw.split('.');
+  if (parts.length !== 3 || parts[0] !== PREFIX) return null;
+
+  const [prefix, body, provided] = parts;
+  const expected = sign(body, secret);
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+
+  if (!payload || typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) return null;
+  if (now >= payload.exp) return null;
+
+  return payload;
+}
+
+// Deploy endpoints authenticate with `Authorization: Bearer rod1.…` instead of
+// the session cookie, because the whole point is publishing from a terminal or
+// an agent. Kept beside the session helper so neither route grows its own idea
+// of how to find a credential.
+export function siteTokenFromRequest(request, secret) {
+  const header = request.headers.get('authorization') ?? '';
+  const raw = header.match(/^Bearer\s+(rod1\.\S+)$/i)?.[1];
+  return raw ? readSiteToken(raw, secret) : null;
+}

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -1,0 +1,183 @@
+import { inflateRawSync, crc32 } from 'node:zlib';
+
+// A minimal, strict ZIP reader for untrusted uploads. No dependency, because
+// everything hostile about a zip is size-shaped and checkable before a single
+// byte is decompressed: the caps below are enforced against the central
+// directory (entry count, per-entry sizes, total uncompressed budget) and the
+// inflate call carries maxOutputLength so a central directory that lies about
+// a size cannot allocate its way past the budget either.
+//
+// Supported: methods 0 (stored) and 8 (deflate) — what every zip tool emits.
+// Rejected: encryption, other compression methods, ZIP64 (a 10 MB upload has
+// no legitimate need for it), duplicate names, and any entry name that is not
+// a plain relative path.
+
+export const MAX_ZIP_BYTES = 10 * 1024 * 1024;
+export const MAX_ENTRIES = 500;
+export const MAX_TOTAL_UNCOMPRESSED = 100 * 1024 * 1024;
+
+const EOCD_SIG = 0x06054b50;
+const CD_SIG = 0x02014b50;
+const LFH_SIG = 0x04034b50;
+// EOCD is 22 bytes; the only variable part after it is a comment capped at
+// 65535, so the signature can hide no further back than this.
+const EOCD_WINDOW = 22 + 65535;
+
+function findEOCD(buffer) {
+  const floor = Math.max(0, buffer.length - EOCD_WINDOW);
+  for (let i = buffer.length - 22; i >= floor; i--) {
+    if (buffer.readUInt32LE(i) !== EOCD_SIG) continue;
+    // The trailing comment length must account for every byte after the EOCD.
+    // Without that check a signature-looking byte sequence inside a comment
+    // or a deflated body could pose as the directory locator.
+    if (buffer.readUInt16LE(i + 20) === buffer.length - i - 22) return i;
+  }
+  return -1;
+}
+
+// Entry names become storage paths, so the rule is: a plain relative path,
+// nothing else. No absolute paths, no drive letters, no backslashes (the zip
+// spec says `/`, a `\` is either a hostile name or a broken writer), no `..`
+// or `.` or empty segments, no NULs. Directory entries (trailing `/`) are
+// skipped by the caller before this runs.
+export function isSafeEntryName(name) {
+  if (typeof name !== 'string' || name.length === 0 || name.length > 255) return false;
+  if (name.includes('\0') || name.includes('\\') || name.includes(':')) return false;
+  if (name.startsWith('/')) return false;
+  if (/^[a-zA-Z]/.test(name) && name[1] === ':') return false;
+  const segments = name.split('/');
+  if (segments.some((s) => s === '' || s === '.' || s === '..')) return false;
+  return true;
+}
+
+export function readZip(buffer, {
+  maxEntries = MAX_ENTRIES,
+  maxTotalUncompressed = MAX_TOTAL_UNCOMPRESSED,
+} = {}) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 22) return fail('empty');
+  if (buffer.length > MAX_ZIP_BYTES) return fail('too_big');
+
+  const eocd = findEOCD(buffer);
+  if (eocd < 0) return fail('no_directory');
+
+  const entries = buffer.readUInt16LE(eocd + 10);
+  const cdSize = buffer.readUInt32LE(eocd + 12);
+  const cdOffset = buffer.readUInt32LE(eocd + 16);
+
+  // ZIP64 escape hatches. An upload under MAX_ZIP_BYTES has no use for them,
+  // and the 0xFFFFFFFF sentinels mean "look elsewhere for the real number",
+  // which this reader deliberately does not do.
+  if (entries === 0xffff || cdSize === 0xffffffff || cdOffset === 0xffffffff) {
+    return fail('zip64');
+  }
+  if (entries === 0) return fail('empty');
+  if (entries > maxEntries) return fail('too_many_entries');
+  if (cdOffset + cdSize > eocd) return fail('corrupt');
+
+  const files = [];
+  const seen = new Set();
+  let totalUncompressed = 0;
+
+  // Every record — header, name, extra, comment — must fit inside the
+  // directory the EOCD declared, and the walk must land exactly on its end.
+  // An unbounded extraLen or commentLen on the final record would otherwise
+  // stride past the directory (or past the buffer) reading "metadata" that
+  // was never there.
+  const cdEnd = cdOffset + cdSize;
+
+  let pos = cdOffset;
+  for (let i = 0; i < entries; i++) {
+    if (pos + 46 > cdEnd || buffer.readUInt32LE(pos) !== CD_SIG) return fail('corrupt');
+
+    const flags = buffer.readUInt16LE(pos + 8);
+    const method = buffer.readUInt16LE(pos + 10);
+    const crc = buffer.readUInt32LE(pos + 16);
+    const compSize = buffer.readUInt32LE(pos + 20);
+    const uncompSize = buffer.readUInt32LE(pos + 24);
+    const nameLen = buffer.readUInt16LE(pos + 28);
+    const extraLen = buffer.readUInt16LE(pos + 30);
+    const commentLen = buffer.readUInt16LE(pos + 32);
+    const localOffset = buffer.readUInt32LE(pos + 42);
+
+    if (pos + 46 + nameLen + extraLen + commentLen > cdEnd) return fail('corrupt');
+    const name = buffer.toString('utf8', pos + 46, pos + 46 + nameLen);
+    pos += 46 + nameLen + extraLen + commentLen;
+
+    // Directory entries are structural, not files; skip them rather than
+    // reject, since every mainstream zip tool emits them.
+    if (name.endsWith('/')) continue;
+
+    if (flags & 0x1) return fail('encrypted');
+    if (method !== 0 && method !== 8) return fail('method');
+    if (!isSafeEntryName(name)) return fail('name');
+    if (seen.has(name)) return fail('duplicate');
+    seen.add(name);
+
+    // Stored entries carry their bytes verbatim, so the two sizes are the same
+    // number by definition; anything else is a corrupt writer.
+    if (method === 0 && compSize !== uncompSize) return fail('corrupt');
+
+    if (uncompSize > maxTotalUncompressed) return fail('too_big');
+    totalUncompressed += uncompSize;
+    if (totalUncompressed > maxTotalUncompressed) return fail('too_big');
+
+    files.push({ name, method, crc, compSize, uncompSize, localOffset });
+  }
+
+  // The declared directory must be consumed exactly: trailing slack inside it
+  // is a directory that lied about its own size.
+  if (pos !== cdEnd) return fail('corrupt');
+
+  // Extraction. `raw` subarrays share the zip buffer's memory rather than
+  // copying; entries collectively keep at most MAX_ZIP_BYTES alive, which is
+  // the same budget the upload already spent.
+  const out = [];
+  let budget = maxTotalUncompressed;
+  for (const file of files) {
+    const lfh = file.localOffset;
+    if (lfhOutOfBounds(buffer, lfh)) return fail('corrupt');
+    if (buffer.readUInt32LE(lfh) !== LFH_SIG) return fail('corrupt');
+
+    // The local header carries its own name/extra lengths, and the extra
+    // field length may legally differ from the central directory's copy — so
+    // the data offset comes from here, never from the central entry.
+    const lNameLen = buffer.readUInt16LE(lfh + 26);
+    const lExtraLen = buffer.readUInt16LE(lfh + 28);
+    const dataStart = lfh + 30 + lNameLen + lExtraLen;
+    const dataEnd = dataStart + file.compSize;
+    if (dataEnd > buffer.length) return fail('corrupt');
+
+    const raw = buffer.subarray(dataStart, dataEnd);
+    let data;
+    if (file.method === 0) {
+      data = raw;
+    } else {
+      try {
+        // maxOutputLength one past the remaining budget: a lying central
+        // directory that claims a small entry and inflates to gigabytes dies
+        // here instead of allocating them.
+        data = inflateRawSync(raw, { maxOutputLength: budget + 1 });
+      } catch {
+        return fail('corrupt');
+      }
+    }
+    if (data.length !== file.uncompSize) return fail('corrupt');
+    // Always verified: zero is the legitimate CRC of empty content, so a
+    // zero field is not a "nothing to check" marker an archive can claim to
+    // opt out of integrity — crc32 of the empty buffer is zero and passes.
+    if (crc32(data) !== file.crc) return fail('corrupt');
+    budget -= data.length;
+
+    out.push({ name: file.name, data });
+  }
+
+  return { ok: true, entries: out, totalBytes: maxTotalUncompressed - budget };
+}
+
+function lfhOutOfBounds(buffer, offset) {
+  return offset < 0 || offset + 30 > buffer.length;
+}
+
+function fail(reason) {
+  return { ok: false, reason };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "runs-on-dev",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@vercel/blob": "^2.8.0",
         "next": "^16.3.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -1079,6 +1080,68 @@
         "tailwindcss": "4.3.3"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.8.0.tgz",
+      "integrity": "sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.6.tgz",
+      "integrity": "sha512-2AsKCf6gE/Eniq09ARm1RK9rQMV5pcAHU7BFcR9MISO+4/RsjjkaYbQN6G85/xi9pYZ5CJNXvYn4TI6p1jKBcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.1.tgz",
+      "integrity": "sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.7.tgz",
+      "integrity": "sha512-fRu59npOu+1vsV570tiLKskfuRyOJ1MqceAkXbTIfWPnM+c9ve1tSK81oj4umKKirymlGUss3V60Lm5I38rKDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.6",
+        "@vercel/cli-exec": "1.0.1",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.20",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
@@ -1117,6 +1180,20 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1141,11 +1218,102 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/jiti": {
@@ -1156,6 +1324,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/lightningcss": {
@@ -1441,6 +1618,21 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -1540,6 +1732,51 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1594,6 +1831,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/scheduler": {
@@ -1665,6 +1911,33 @@
         }
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1672,6 +1945,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/styled-jsx": {
@@ -1718,11 +2000,81 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "AGPL-3.0-only",
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.2.0"
   },
   "scripts": {
     "dev": "next dev",
@@ -13,6 +13,7 @@
     "test": "node --test \"test/**/*.test.mjs\""
   },
   "dependencies": {
+    "@vercel/blob": "^2.8.0",
     "next": "^16.3.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/test/sites.test.mjs
+++ b/test/sites.test.mjs
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyDeployment, rollbackTo, newDeployment,
+  MAX_DEPLOYMENTS_KEPT,
+} from '../lib/sites.js';
+
+const at = (i) => new Date(Date.UTC(2026, 0, 1 + i)).toISOString();
+
+function deployment(i) {
+  return { id: `d${i}`, at: at(i), files: 3, bytes: 1024 };
+}
+
+test('the first deploy creates the record with the deployment active', () => {
+  const d = deployment(1);
+  const { record, pruned } = applyDeployment(null, { name: 'foo', owner: 'hawkay002', deployment: d });
+  assert.deepEqual(record, {
+    name: 'foo',
+    owner: 'hawkay002',
+    active: 'd1',
+    deployments: [d],
+    updatedAt: d.at,
+  });
+  assert.deepEqual(pruned, []);
+});
+
+test('later deploys append, keep the original owner, and stay capped', () => {
+  const first = applyDeployment(null, { name: 'foo', owner: 'hawkay002', deployment: deployment(1) });
+  let record = first.record;
+  for (let i = 2; i <= MAX_DEPLOYMENTS_KEPT + 2; i++) {
+    record = applyDeployment(record, { name: 'foo', owner: 'whoever', deployment: deployment(i) }).record;
+  }
+
+  assert.equal(record.deployments.length, MAX_DEPLOYMENTS_KEPT);
+  assert.deepEqual(record.deployments.map((d) => d.id), ['d3', 'd4', 'd5', 'd6', 'd7']);
+  assert.equal(record.active, 'd7');
+  // The owner on record is who claimed it, not who last deployed — for a
+  // single-owner v1 they are the same login, but the record must not become
+  // re-ownable by deploying at it.
+  assert.equal(record.owner, 'hawkay002');
+});
+
+test('deploying reports the deployments that fell out of history', () => {
+  const first = applyDeployment(null, { name: 'foo', owner: 'a', deployment: deployment(1) });
+  let prunedTotal = [];
+  let record = first.record;
+  for (let i = 2; i <= 7; i++) {
+    const step = applyDeployment(record, { name: 'foo', owner: 'a', deployment: deployment(i) });
+    record = step.record;
+    prunedTotal = prunedTotal.concat(step.pruned);
+  }
+  assert.deepEqual(prunedTotal.map((d) => d.id), ['d1', 'd2']);
+});
+
+test('rollback points at a deployment still in history', () => {
+  const record = {
+    name: 'foo',
+    owner: 'a',
+    active: 'd3',
+    deployments: [deployment(1), deployment(2), deployment(3)],
+    updatedAt: at(3),
+  };
+  const rolled = rollbackTo(record, 'd1', { now: new Date(Date.UTC(2026, 0, 9)) });
+  assert.equal(rolled.active, 'd1');
+  assert.equal(rolled.deployments.length, 3);
+  assert.equal(rolled.updatedAt, new Date(Date.UTC(2026, 0, 9)).toISOString());
+});
+
+test('rollback refuses a deployment that is not in history', () => {
+  const record = { name: 'foo', owner: 'a', active: 'd1', deployments: [deployment(1)], updatedAt: at(1) };
+  assert.equal(rollbackTo(record, 'gone'), null);
+  assert.equal(rollbackTo(null, 'd1'), null);
+  // Rolling back to the already-active deployment is a harmless no-op write
+  // the caller can compare and skip.
+  assert.equal(rollbackTo(record, 'd1')?.active, 'd1');
+});
+
+test('newDeployment mints distinct ids and records shape', () => {
+  const a = newDeployment({ files: 2, bytes: 10 });
+  const b = newDeployment({ files: 2, bytes: 10 });
+  assert.notEqual(a.id, b.id);
+  assert.match(a.id, /^[0-9a-f]{8}$/);
+  assert.equal(a.files, 2);
+  assert.equal(a.bytes, 10);
+  assert.equal(typeof a.at, 'string');
+});

--- a/test/tokens.test.mjs
+++ b/test/tokens.test.mjs
@@ -1,0 +1,110 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import {
+  signSiteToken, readSiteToken, siteTokenFromRequest,
+  SITE_TOKEN_TTL_MS, SITE_TOKEN_SCOPE,
+} from '../lib/tokens.js';
+
+const secret = 'test-secret-value';
+
+test('round-trips a payload', () => {
+  const now = Date.now();
+  const token = signSiteToken({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE }, secret, { now });
+  assert.deepEqual(readSiteToken(token, secret, { now }), {
+    login: 'hawkay002',
+    scope: SITE_TOKEN_SCOPE,
+    exp: now + SITE_TOKEN_TTL_MS,
+  });
+});
+
+test('carries the rod1 prefix and three parts', () => {
+  const token = signSiteToken({ login: 'zordhalo', scope: SITE_TOKEN_SCOPE }, secret);
+  const parts = token.split('.');
+  assert.equal(parts.length, 3);
+  assert.equal(parts[0], 'rod1');
+});
+
+test('rejects a tampered payload', () => {
+  const token = signSiteToken({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE }, secret);
+  const [, sig] = token.split('.');
+  const body = Buffer.from(
+    JSON.stringify({ login: 'someone-else', scope: SITE_TOKEN_SCOPE }),
+  ).toString('base64url');
+  assert.equal(readSiteToken(`rod1.${body}.${sig}`, secret), null);
+});
+
+test('rejects a signature from a different secret', () => {
+  const token = signSiteToken({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE }, 'other-secret');
+  assert.equal(readSiteToken(token, secret), null);
+});
+
+test('rejects malformed input without throwing', () => {
+  for (const raw of ['', 'no-dot', 'a.b.c', 'rod1.only-two', 'rod2.a.b', 'rod1.a.b.c']) {
+    assert.equal(readSiteToken(raw, secret), null, raw);
+  }
+});
+
+// A token from any future rod2 scheme must not validate as rod1: version
+// confusion is how a retired format comes back from the dead.
+test('rejects a different version prefix even with a valid signature', () => {
+  const body = Buffer.from(
+    JSON.stringify({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE, exp: Date.now() + 1000 }),
+  ).toString('base64url');
+  const sig = createHmac('sha256', secret).update(body).digest('base64url');
+  assert.equal(readSiteToken(`rod2.${body}.${sig}`, secret), null);
+});
+
+test('rejects a token past its expiry, exactly at the boundary', () => {
+  const now = Date.now();
+  const token = signSiteToken({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE }, secret, { now });
+  assert.notEqual(readSiteToken(token, secret, { now: now + SITE_TOKEN_TTL_MS - 1 }), null);
+  assert.equal(readSiteToken(token, secret, { now: now + SITE_TOKEN_TTL_MS }), null);
+});
+
+test('fails closed on a missing or non-numeric expiry', () => {
+  for (const exp of [undefined, '9999999999999', null, NaN]) {
+    const body = Buffer.from(
+      JSON.stringify({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE, exp }),
+    ).toString('base64url');
+    const sig = createHmac('sha256', secret).update(body).digest('base64url');
+    assert.equal(readSiteToken(`rod1.${body}.${sig}`, secret), null, `exp ${JSON.stringify(exp)}`);
+  }
+});
+
+test('an extended expiry does not survive the signature check', () => {
+  const now = Date.now();
+  const token = signSiteToken({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE }, secret, { now });
+  const sig = token.split('.').pop();
+  const stretched = Buffer.from(
+    JSON.stringify({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE, exp: now + 10 * SITE_TOKEN_TTL_MS }),
+  ).toString('base64url');
+  assert.equal(readSiteToken(`rod1.${stretched}.${sig}`, secret), null);
+});
+
+// With no secret configured the helper must fail closed rather than treat the
+// absence as a universal-accept wildcard.
+test('readSiteToken returns null without a secret', () => {
+  const token = signSiteToken({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE }, secret);
+  assert.equal(readSiteToken(token, undefined), null);
+  assert.equal(readSiteToken(token, ''), null);
+});
+
+function requestWith(header) {
+  return { headers: new Map([['authorization', header]]) };
+}
+
+test('siteTokenFromRequest reads a Bearer token, case-insensitively', () => {
+  const token = signSiteToken({ login: 'hawkay002', scope: SITE_TOKEN_SCOPE }, secret);
+  const req = requestWith(`Bearer ${token}`);
+  assert.equal(siteTokenFromRequest(req, secret)?.login, 'hawkay002');
+  const lower = requestWith(`bearer ${token}`);
+  assert.equal(siteTokenFromRequest(lower, secret)?.login, 'hawkay002');
+});
+
+test('siteTokenFromRequest ignores anything that is not a rod1 bearer token', () => {
+  assert.equal(siteTokenFromRequest(requestWith(''), secret), null);
+  assert.equal(siteTokenFromRequest(requestWith('Bearer ghpx_someothertoken'), secret), null);
+  assert.equal(siteTokenFromRequest(requestWith('Basic rod1.abc.def'), secret), null);
+  assert.equal(siteTokenFromRequest({ headers: new Map() }, secret), null);
+});

--- a/test/zip.test.mjs
+++ b/test/zip.test.mjs
@@ -1,0 +1,247 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deflateRawSync, crc32 as crcOf } from 'node:zlib';
+import { readZip, isSafeEntryName, MAX_ZIP_BYTES, MAX_ENTRIES } from '../lib/zip.js';
+
+// Builds a spec-conforming zip in memory so the reader is tested against the
+// real byte layout, not a mock of it. `entries` is [{ name, data, method }] —
+// the builder writes local headers, a central directory, and an EOCD, exactly
+// the three structures a mainstream zip tool emits.
+function makeZip(entries, { comment = '' } = {}) {
+  const local = [];
+  const central = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBuf = Buffer.from(entry.name, 'utf8');
+    const method = entry.method ?? 8;
+    const data = entry.data ?? Buffer.alloc(0);
+    const packed = method === 0 ? data : deflateRawSync(data);
+    const crc = crcOf(data);
+
+    const lfh = Buffer.alloc(30);
+    lfh.writeUInt32LE(0x04034b50, 0);
+    lfh.writeUInt16LE(20, 4);          // version needed
+    lfh.writeUInt16LE(0, 6);           // flags
+    lfh.writeUInt16LE(method, 8);
+    lfh.writeUInt32LE(0, 10);          // mod time/date
+    lfh.writeUInt32LE(crc, 14);
+    lfh.writeUInt32LE(packed.length, 18);
+    lfh.writeUInt32LE(data.length, 22);
+    lfh.writeUInt16LE(nameBuf.length, 26);
+    lfh.writeUInt16LE(0, 28);          // local extra length
+    local.push(lfh, nameBuf, packed);
+
+    const cdh = Buffer.alloc(46);
+    cdh.writeUInt32LE(0x02014b50, 0);
+    cdh.writeUInt16LE(20, 4);          // version made by
+    cdh.writeUInt16LE(20, 6);          // version needed
+    cdh.writeUInt16LE(0, 8);           // flags
+    cdh.writeUInt16LE(method, 10);
+    cdh.writeUInt32LE(0, 12);          // mod time/date
+    cdh.writeUInt32LE(crc, 16);
+    cdh.writeUInt32LE(packed.length, 20);
+    cdh.writeUInt32LE(data.length, 24);
+    cdh.writeUInt16LE(nameBuf.length, 28);
+    cdh.writeUInt16LE(0, 30);          // extra length
+    cdh.writeUInt16LE(0, 32);          // comment length
+    cdh.writeUInt32LE(0, 34);          // disk start
+    cdh.writeUInt32LE(0, 36);          // internal attrs
+    cdh.writeUInt32LE(0, 38);          // external attrs
+    cdh.writeUInt32LE(offset, 42);     // local header offset
+    central.push(cdh, nameBuf);
+
+    offset += 30 + nameBuf.length + packed.length;
+  }
+
+  const cdOffset = offset;
+  const centralBuf = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(centralBuf.length, 12);
+  eocd.writeUInt32LE(cdOffset, 16);
+  eocd.writeUInt16LE(comment.length, 20);
+
+  return Buffer.concat([...local, centralBuf, eocd, Buffer.from(comment, 'utf8')]);
+}
+
+const page = Buffer.from('<html>hello</html>', 'utf8');
+const style = Buffer.from('body{margin:0}', 'utf8');
+
+test('reads a deflated zip with nested paths', () => {
+  const zip = makeZip([
+    { name: 'index.html', data: page },
+    { name: 'assets/app.css', data: style },
+  ]);
+  const out = readZip(zip);
+  assert.equal(out.ok, true);
+  assert.deepEqual(out.entries.map((e) => e.name), ['index.html', 'assets/app.css']);
+  assert.equal(out.entries[0].data.toString(), '<html>hello</html>');
+  assert.equal(out.entries[1].data.toString(), 'body{margin:0}');
+});
+
+test('reads stored (method 0) entries', () => {
+  const zip = makeZip([{ name: 'index.html', data: page, method: 0 }]);
+  const out = readZip(zip);
+  assert.equal(out.ok, true);
+  assert.equal(out.entries[0].data.toString(), '<html>hello</html>');
+});
+
+test('skips directory entries without counting them as files', () => {
+  const zip = makeZip([
+    { name: 'assets/', data: Buffer.alloc(0) },
+    { name: 'index.html', data: page },
+  ]);
+  const out = readZip(zip);
+  assert.equal(out.ok, true);
+  assert.equal(out.entries.length, 1);
+});
+
+test('reads a zip with a trailing comment', () => {
+  const zip = makeZip([{ name: 'index.html', data: page }], { comment: 'made by a test' });
+  assert.equal(readZip(zip).ok, true);
+});
+
+test('rejects an empty buffer and a non-zip buffer', () => {
+  assert.equal(readZip(Buffer.alloc(0)).reason, 'empty');
+  assert.equal(readZip(Buffer.from('not a zip at all, definitely not')).reason, 'no_directory');
+});
+
+test('rejects a corrupt CRC', () => {
+  const zip = makeZip([{ name: 'index.html', data: page }]);
+  // Flip the CRC in the central directory: the entry will inflate to the
+  // right size but fail integrity.
+  const eocdAt = zip.length - 22;
+  const cdSize = zip.readUInt32LE(eocdAt + 12);
+  const cdAt = eocdAt - cdSize;
+  zip.writeUInt32LE(0xdeadbeef, cdAt + 16);
+  assert.equal(readZip(zip).reason, 'corrupt');
+});
+
+// Zero is the real CRC of empty content, not an opt-out flag: a nonempty
+// entry claiming zero must fail integrity now that every entry is checked.
+test('rejects a nonempty entry with a zeroed CRC', () => {
+  const zip = makeZip([{ name: 'index.html', data: page }]);
+  const eocdAt = zip.length - 22;
+  const cdAt = eocdAt - zip.readUInt32LE(eocdAt + 12);
+  zip.writeUInt32LE(0, cdAt + 16);
+  assert.equal(readZip(zip).reason, 'corrupt');
+});
+
+test('accepts an empty file, whose CRC is genuinely zero', () => {
+  const zip = makeZip([
+    { name: 'index.html', data: page },
+    { name: 'empty.txt', data: Buffer.alloc(0) },
+  ]);
+  const out = readZip(zip);
+  assert.equal(out.ok, true);
+  assert.equal(out.entries[1].data.length, 0);
+});
+
+// The central directory walk must consume exactly cdOffset + cdSize bytes.
+// A final record whose extraLen overruns the declared directory is truncated
+// metadata wearing a valid-looking header.
+test('rejects a final central-directory record overrunning the directory', () => {
+  const zip = makeZip([
+    { name: 'index.html', data: page },
+    { name: 'a.txt', data: Buffer.from('x') },
+  ]);
+  const eocdAt = zip.length - 22;
+  const cdSize = zip.readUInt32LE(eocdAt + 12);
+  const cdAt = eocdAt - cdSize;
+  // Second record's header sits after the first record's 46 + nameLen bytes.
+  const secondAt = cdAt + 46 + 'index.html'.length;
+  zip.writeUInt16LE(100, secondAt + 30); // extraLen claims bytes that are not there
+  assert.equal(readZip(zip).reason, 'corrupt');
+});
+
+test('rejects a central directory that does not end where it declares', () => {
+  const zip = makeZip([{ name: 'index.html', data: page }]);
+  const eocdAt = zip.length - 22;
+  // Shrink the declared size by one byte: the records still parse, but the
+  // walk ends past the boundary it promised to consume exactly.
+  zip.writeUInt32LE(zip.readUInt32LE(eocdAt + 12) - 1, eocdAt + 12);
+  assert.equal(readZip(zip).reason, 'corrupt');
+});
+
+test('rejects a duplicate entry name', () => {
+  const zip = makeZip([
+    { name: 'index.html', data: page },
+    { name: 'index.html', data: page },
+  ]);
+  assert.equal(readZip(zip).reason, 'duplicate');
+});
+
+test('rejects encrypted entries', () => {
+  const zip = makeZip([{ name: 'index.html', data: page }]);
+  const eocdAt = zip.length - 22;
+  const cdAt = eocdAt - zip.readUInt32LE(eocdAt + 12);
+  const flags = zip.readUInt16LE(cdAt + 8);
+  zip.writeUInt16LE(flags | 0x1, cdAt + 8);
+  assert.equal(readZip(zip).reason, 'encrypted');
+});
+
+test('rejects an unsupported compression method', () => {
+  const zip = makeZip([{ name: 'index.html', data: page }]);
+  const eocdAt = zip.length - 22;
+  const cdAt = eocdAt - zip.readUInt32LE(eocdAt + 12);
+  zip.writeUInt16LE(12, cdAt + 10); // bzip2
+  assert.equal(readZip(zip).reason, 'method');
+});
+
+// The zip-bomb shape: a central directory that claims a small uncompressed
+// size for an entry that inflates far beyond the budget. maxOutputLength must
+// stop the inflate, not just the post-hoc size check.
+test('rejects an entry lying about its uncompressed size', () => {
+  const bomb = Buffer.alloc(4 * 1024 * 1024, 0x41); // 4 MB inflates from ~4 KB
+  const zip = makeZip([{ name: 'index.html', data: bomb }]);
+  // Claim 100 bytes in both headers, keep the real deflate stream.
+  const eocdAt = zip.length - 22;
+  const cdAt = eocdAt - zip.readUInt32LE(eocdAt + 12);
+  const lfhAt = zip.readUInt32LE(cdAt + 42);
+  zip.writeUInt32LE(100, cdAt + 24);
+  zip.writeUInt32LE(100, lfhAt + 22);
+  const out = readZip(zip, { maxTotalUncompressed: 1024 * 1024 });
+  assert.equal(out.ok, false);
+});
+
+test('enforces the entry-count cap', () => {
+  const many = Array.from({ length: 11 }, (_, i) => ({ name: `f${i}.txt`, data: Buffer.from('x') }));
+  const zip = makeZip(many);
+  assert.equal(readZip(zip, { maxEntries: 10 }).reason, 'too_many_entries');
+  assert.equal(readZip(zip).ok, true);
+  assert.ok(MAX_ENTRIES >= 10);
+});
+
+test('enforces the total uncompressed budget across entries', () => {
+  const chunk = Buffer.alloc(600 * 1024, 0x42);
+  const zip = makeZip([
+    { name: 'a.bin', data: chunk },
+    { name: 'b.bin', data: chunk },
+  ]);
+  assert.equal(readZip(zip, { maxTotalUncompressed: 1024 * 1024 }).reason, 'too_big');
+  assert.equal(readZip(zip, { maxTotalUncompressed: 2 * 1024 * 1024 }).ok, true);
+});
+
+test('rejects a buffer over MAX_ZIP_BYTES outright', () => {
+  assert.equal(readZip(Buffer.alloc(MAX_ZIP_BYTES + 1)).reason, 'too_big');
+});
+
+test('isSafeEntryName accepts plain relative paths', () => {
+  for (const good of ['index.html', 'assets/app.css', 'a/b/c.js', 'favicon.ico', 'x'.repeat(255)]) {
+    assert.equal(isSafeEntryName(good), true, good);
+  }
+});
+
+test('isSafeEntryName rejects traversal and absolute shapes', () => {
+  for (const bad of [
+    '', '/abs.html', '../up.js', 'a/../../b', 'a/./b', 'a//b', 'c:\\x', 'C:/x',
+    'a\\b.html', 'nul\0byte', '.hidden/..', 'a/../b.txt', 'x'.repeat(256), 'a/', 'C:x',
+  ]) {
+    assert.equal(isSafeEntryName(bad), false, JSON.stringify(bad));
+  }
+});


### PR DESCRIPTION
First slice of here.now-style instant hosting: a terminal or coding agent posts a zip of static files, the bytes land in Vercel Blob, and sites/<name>.json in the registry holds the pointer with the last 5 deployments kept for rollback. A user's recordless claimed name stops being only a profile card.

This PR is deliberately dark: nothing a name serves changes yet. It lands the upload pipeline (tokens, zip validation, storage, registry writes, rollback) so serving can be agreed separately and flipped on in its own PR.

What is in here:
- Deploy tokens (lib/tokens.js, /api/tokens, a /manage card): stateless rod1 tokens, HMAC-signed like the session cookie with their own secret and a 30 day TTL. Minted from the browser session, shown once, no listing (there is nothing stored to list).
- Strict zip reader (lib/zip.js): dependency-free, built for untrusted input. Entry count, per-entry and total uncompressed caps are enforced against the central directory, inflate carries maxOutputLength so a directory that lies about sizes cannot allocate past the budget, and traversal shapes, encryption, unusual methods, duplicate names and zip64 are rejected. CRC verified on every entry.
- Sites registry (lib/sites.js): sites/<name>.json parallel to domains/, never touching DNS sync. Deployments append, history caps at 5, rollback is a pointer swap.
- API routes (app/api/sites/{deploy,deployments,rollback}): upload first, pointer second, so a failure orphans reclaimable storage instead of serving 404s. Registry writes compare-and-swap on sha like record edits; lost races return 409. Failed or lost-race writes reclaim their prefix. Bearer auth and rate budget are verified before any body parsing or registry read, fail-closed throughout (lib/site-access.js).
- Storage seam (lib/store.js): one module wraps @vercel/blob (the only new dependency); allSettled batches and whole-prefix reclaim on a failed batch, so a half-upload never sits publicly.
- sites/** joins the deploy workflow paths-ignore (registry data, not app code); engines >=22.2.0 for zlib.crc32.

Open questions worth settling before or alongside the serving PR: Blob vs R2 as the backend (the seam exists so this is a one-module swap), and whether the token card copy matches how you want the feature explained.

Testing: node --test suite 350 passing (54 new). next build clean. Dev-server smoke of every endpoint gate (401/400/413/503 paths).